### PR TITLE
daemons: maap: Makefile fix build error

### DIFF
--- a/daemons/maap/linux/Makefile
+++ b/daemons/maap/linux/Makefile
@@ -7,8 +7,9 @@ FLAGS=-lpthread -lpcap
 
 all: maap_daemon
 
-maap_daemon: maap_linux.c
+maap_daemon: clean
+	mkdir $(BUILD_DIR)
 	gcc -o $(BUILD_DIR)/maap_daemon $(INCFLAGS) maap_linux.c $(CFLAGS) $(FLAGS) $(EXTRA_FLAGS)
 
 clean:
-	rm -rf $(BUILD_DIR)/maap_daemon
+	rm -rf $(BUILD_DIR)/


### PR DESCRIPTION
The rule to build maap daemon tries to copy the executable
in the build directory, since there wasnt any build directory
the rule was failing to build the maap daemon.
This patch fixes it by creating a build directory, while building
the maap daemon, and removes it off on calling the clean rule.

Signed-off-by: Lad, Prabhakar <prabhakar.csengg@gmail.com>