### PR TITLE
bugfix issue 169: MRP regression: listener does not see talker

### DIFF
--- a/examples/common/listener_mrp_client.c
+++ b/examples/common/listener_mrp_client.c
@@ -62,7 +62,7 @@ int msg_process(char *buf, int buflen)
 	{
 		l = 6; /* skip "Sxx T:" */
 		while ((l < buflen) && ('S' != buf[l++]));
-		if (l = buflen)
+		if (l == buflen)
 			return -1;
 		l++;
 		for(j = 0; j < 8 ; l+=2, j++)


### PR DESCRIPTION
Fatal typo: '=' instead of '=='.