### PR TITLE
Update jackd_talker.c

### DIFF
--- a/examples/jackd-talker/jackd_talker.c
+++ b/examples/jackd-talker/jackd_talker.c
@@ -766,8 +766,13 @@ int pci_connect()
 		}
 		printf("attaching to %s\n", devpath);
 		err = igb_attach(devpath, &igb_dev);
-		if (err || igb_attach_tx( &igb_dev )) {
+		if (err) {
 			printf("attach failed! (%s)\n", strerror(errno));
+			continue;
+		}
+		err = igb_attach_tx(devpath, &igb_dev);
+		if (err) {
+			printf("igb_attach_tx failed! (%s)\n", strerror(errno));
 			continue;
 		}
 		goto out;

--- a/examples/jackd-talker/jackd_talker.c
+++ b/examples/jackd-talker/jackd_talker.c
@@ -766,7 +766,7 @@ int pci_connect()
 		}
 		printf("attaching to %s\n", devpath);
 		err = igb_attach(devpath, &igb_dev);
-		if (err) {
+		if (err || igb_attach_tx( &igb_dev )) {
 			printf("attach failed! (%s)\n", strerror(errno));
 			continue;
 		}


### PR DESCRIPTION
Without the above change, igb_xmit fails as no tx_queues are allocated/mapped.