### PR TITLE
Fixed AVnu certification test failure 6.1a and 6.3a

### DIFF
--- a/daemons/gptp/common/avbts_message.hpp
+++ b/daemons/gptp/common/avbts_message.hpp
@@ -269,6 +269,9 @@ class PathTraceTLV {
 			identityList.end();
 	}
 	int length() {
+		// Total length of TLV is length of type field (UINT16) + length of 'length' field (UINT16) + length of
+		// identities (each PTP_CLOCK_IDENTITY_LENGTH) in the path
+		// See IEEE 802.1AS doc table 10-8 for details
 		return 2*sizeof(uint16_t) + PTP_CLOCK_IDENTITY_LENGTH*identityList.size();
 	}
 };

--- a/daemons/gptp/common/avbts_message.hpp
+++ b/daemons/gptp/common/avbts_message.hpp
@@ -226,6 +226,9 @@ protected:
 
 #pragma pack(push,1)
 
+// Path Trace TLV
+// See IEEE 802.1AS doc table 10-8 for details
+
 #define PATH_TRACE_TLV_TYPE 0x8
 
 class PathTraceTLV {
@@ -252,9 +255,10 @@ class PathTraceTLV {
 	}
 	void toByteString(uint8_t * byte_str) {
 		IdentityList::iterator iter;
-		*((uint16_t *)byte_str) = tlvType;
+		*((uint16_t *)byte_str) = tlvType;  // tlvType already in network byte order
 		byte_str += sizeof(tlvType);
-		*((uint16_t *)byte_str) = PLAT_htons(identityList.size()*PTP_CLOCK_IDENTITY_LENGTH);
+		*((uint16_t *)byte_str) =
+			PLAT_htons(identityList.size()*PTP_CLOCK_IDENTITY_LENGTH);
 		byte_str += sizeof(uint16_t);
 		for
 			(iter = identityList.begin();
@@ -269,9 +273,9 @@ class PathTraceTLV {
 			identityList.end();
 	}
 	int length() {
-		// Total length of TLV is length of type field (UINT16) + length of 'length' field (UINT16) + length of
+		// Total length of TLV is length of type field (UINT16) + length of 'length'
+		// field (UINT16) + length of
 		// identities (each PTP_CLOCK_IDENTITY_LENGTH) in the path
-		// See IEEE 802.1AS doc table 10-8 for details
 		return 2*sizeof(uint16_t) + PTP_CLOCK_IDENTITY_LENGTH*identityList.size();
 	}
 };

--- a/daemons/gptp/common/ieee1588.hpp
+++ b/daemons/gptp/common/ieee1588.hpp
@@ -124,6 +124,11 @@ class ClockIdentity {
 		memcpy(this->id, id, PTP_CLOCK_IDENTITY_LENGTH);
 	}
 	void set(LinkLayerAddress * address);
+	void print(const char *str) {
+		XPTPD_INFO
+			( "Clock Identity(%s): %02hhx %02hhx %02hhx %02hhx %02hhx %02hhx %02hhx %02hhx\n",
+			  str, id[0], id[1], id[2], id[3], id[4], id[5], id[6], id[7] );
+	}
 };
 
 #define INVALID_TIMESTAMP_VERSION 0xFF


### PR DESCRIPTION
Rejects Announce message with sourcePortIdentity same as my own

AVnu certification test 6.3a - PASS
Rejects Path Trace TLV with ClockIdentity same as mine
Implemented PathTraceTLV Parsing
Implemented PathTraceTLV Append/Search Operations
Added debug (print method) to ClockIdentity class

Corrected misc output format (printf), indentation issues