### PR TITLE
Fixed segmentation fault: pointer adress not passed by reference

### DIFF
--- a/examples/common/avb.c
+++ b/examples/common/avb.c
@@ -87,19 +87,19 @@ out:	pci_cleanup(pacc);
 	return 0;
 }
 
-int gptpinit(int *shm_fd, char *memory_offset_buffer)
+int gptpinit(int *shm_fd, char **memory_offset_buffer)
 {
 	*shm_fd = shm_open(SHM_NAME, O_RDWR, 0);
 	if (*shm_fd == -1) {
 		perror("shm_open()");
 		return false;
 	}
-	memory_offset_buffer =
+	*memory_offset_buffer =
 	    (char *)mmap(NULL, SHM_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED,
 			 *shm_fd, 0);
-	if (memory_offset_buffer == (char *)-1) {
+	if (*memory_offset_buffer == (char *)-1) {
 		perror("mmap()");
-		memory_offset_buffer = NULL;
+		*memory_offset_buffer = NULL;
 		shm_unlink(SHM_NAME);
 		return false;
 	}

--- a/examples/common/avb.h
+++ b/examples/common/avb.h
@@ -114,7 +114,7 @@ int gptpscaling(gPtpTimeData * td, char *memory_offset_buffer);
 
 void gptpdeinit(int shm_fd, char *memory_offset_buffer);
 
-int gptpinit(int *shm_fd, char *memory_offset_buffer);
+int gptpinit(int *shm_fd, char **memory_offset_buffer);
 
 void avb_set_1722_cd_indicator(seventeen22_header *h1722, uint64_t cd_indicator);
 uint64_t avb_get_1722_cd_indicator(seventeen22_header *h1722);


### PR DESCRIPTION
There is a critical segmentation fault which prevents that `simple_talker` and `jackd_talker` are working anymore.

`gptpinit()`: igb_mmap pointer is passed by value though its address is changed and should be updated in a global sense (not only within the function's scope).
Beside this problem, various minor warnings are fixed.

The corresponding issue is: #184 (though it's description is not adapted yet)