### PR TITLE
Cross compile support

### DIFF
--- a/daemons/maap/linux/Makefile
+++ b/daemons/maap/linux/Makefile
@@ -4,11 +4,12 @@ INCFLAGS=$(COMMON_DIR)/maap_protocol.c
 CFLAGS=$(OPT) -Wall
 EXTRA_FLAGS=-I$(COMMON_DIR) 
 FLAGS=-lpthread -lpcap
+CC?=gcc
 
 all: maap_daemon
 
 maap_daemon: maap_linux.c
-	gcc -o $(BUILD_DIR)/maap_daemon $(INCFLAGS) maap_linux.c $(CFLAGS) $(FLAGS) $(EXTRA_FLAGS)
+	$(CC) -o $(BUILD_DIR)/maap_daemon $(INCFLAGS) maap_linux.c $(CFLAGS) $(FLAGS) $(EXTRA_FLAGS)
 
 clean:
 	rm -rf $(BUILD_DIR)/maap_daemon

--- a/daemons/mrpd/Makefile
+++ b/daemons/mrpd/Makefile
@@ -3,9 +3,9 @@ OPT=-O2
 CFLAGS=$(OPT) -Wall -Wextra -Wno-parentheses -ggdb -D_GNU_SOURCE
 
 ifeq ($(ARCH),arm)
-CC=arm-none-linux-gnueabi-gcc
+CC?=arm-none-linux-gnueabi-gcc
 else
-CC=gcc
+CC?=gcc
 endif
 INCFLAGS=-I../common -I../../examples/mrp_client
 

--- a/examples/common/Makefile
+++ b/examples/common/Makefile
@@ -1,4 +1,4 @@
-CC = gcc
+CC ?= gcc
 OPT = -O2 -g
 CFLAGS = $(OPT) -Wall -Wextra -Wno-parentheses
 

--- a/examples/jackd-listener/Makefile
+++ b/examples/jackd-listener/Makefile
@@ -1,4 +1,4 @@
-CC = gcc
+CC ?= gcc
 OPT = -O2 -g
 CFLAGS = $(OPT) -Wall -Wextra -Wno-parentheses -std=gnu99
 INCFLAGS = -I../../daemons/mrpd -I../common -I../../daemons/common

--- a/examples/jackd-talker/Makefile
+++ b/examples/jackd-talker/Makefile
@@ -1,4 +1,4 @@
-CC = gcc
+CC ?= gcc
 OPT = -O2 -g
 CFLAGS = $(OPT) -Wall -Wextra -Wno-parentheses -std=gnu99
 INCFLAGS = -I../../lib/igb -I../../daemons/mrpd -I../common -I../../daemons/common
@@ -13,7 +13,7 @@ jack.o: jack.c jack.h defines.h
 	$(CC) $(CFLAGS) -c jack.c
 
 jackd_talker.o: jackd_talker.c defines.h jack.h
-	gcc -c $(INCFLAGS) -I../../daemons/mrpd $(CFLAGS) jackd_talker.c
+	$(CC) -c $(INCFLAGS) -I../../daemons/mrpd $(CFLAGS) jackd_talker.c
 
 ../common/talker_mrp_client.o:
 	make -C ../common/ talker_mrp_client.o

--- a/examples/live_stream/Makefile
+++ b/examples/live_stream/Makefile
@@ -1,4 +1,4 @@
-CC=gcc
+CC?=gcc
 OPT=-O2 -g
 CFLAGS=$(OPT) -Wall -Wextra -Wno-parentheses
 INCFLAGS=-I ../../lib/igb/ -I../../daemons/mrpd -I../common -I../../daemons/common

--- a/examples/mrp_client/Makefile
+++ b/examples/mrp_client/Makefile
@@ -2,9 +2,9 @@ OPT=-O2
 CFLAGS=$(OPT) -Wall -Wextra -Wno-parentheses -ggdb
 
 ifeq ($(ARCH),arm)
-CC=arm-none-linux-gnueabi-gcc
+CC?=arm-none-linux-gnueabi-gcc
 else
-CC=gcc
+CC?=gcc
 endif
 #INCFLAGS=-I../../lib/igb
 #LDLIBS=-ligb -lpci -lz -pthread

--- a/examples/simple_listener/Makefile
+++ b/examples/simple_listener/Makefile
@@ -1,4 +1,4 @@
-CC = gcc
+CC ?= gcc
 OPT = -O2 -g
 CFLAGS = $(OPT) -Wall -Wextra -Wno-parentheses
 INCFLAGS = -I../../daemons/mrpd -I../common -I../../daemons/common

--- a/examples/simple_talker/Makefile
+++ b/examples/simple_talker/Makefile
@@ -1,4 +1,4 @@
-CC=gcc
+CC?=gcc
 OPT=-O2 -g
 CFLAGS=$(OPT) -Wall -Wextra -Wno-parentheses
 INCFLAGS=-I../../lib/igb -I../../daemons/mrpd -I../common -I../../daemons/common


### PR DESCRIPTION
Allow overriding the compiler/CC variable by using weak assignment to $(CC) and removing harcoded gcc entries. The maap, mrpd and mrp_control patches are cross-compile tested using a yocto build targetting a PPC and all changes are compile tested using native compile.