### PR TITLE
Fix a jackd_talker error from last open-avb-next merge.

### DIFF
--- a/examples/jackd-talker/jackd_talker.c
+++ b/examples/jackd-talker/jackd_talker.c
@@ -241,7 +241,7 @@ int pci_connect()
 			printf("attach failed! (%s)\n", strerror(errno));
 			continue;
 		}
-		err = igb_attach_tx(devpath, &igb_dev);
+		err = igb_attach_tx(&glob_igb_dev);
 		if (err) {
 			printf("igb_attach_tx failed! (%s)\n", strerror(errno));
 			continue;


### PR DESCRIPTION
A pull request was made against master a while back for a fix that
was never applied to open-avb-next. There was some refactoring done
in open-avb-next, so when it was last merged with master, this fix
didn't have the refactor changes applied. Now it does.