### PR TITLE
Fix bogus PHY latency values in gPTP Linux HAL

### DIFF
--- a/daemons/gptp/linux/src/linux_hal_generic.cpp
+++ b/daemons/gptp/linux/src/linux_hal_generic.cpp
@@ -48,12 +48,8 @@
 #include <syscall.h>
 #include <limits.h>
 
-#if 0
 #define TX_PHY_TIME 184
 #define RX_PHY_TIME 382
-#endif
-#define TX_PHY_TIME 8000
-#define RX_PHY_TIME 8000
 
 net_result LinuxNetworkInterface::nrecv
 ( LinkLayerAddress *addr, uint8_t *payload, size_t &length ) {


### PR DESCRIPTION
On 2014-12-18 commit 5668e632c2063510b7f35e8a326c1622eab86325 introduced
a problem for users of the generic Linux HAL--some extremely large PHY
latency values (probably to offset latency introduced by a net sniffer)
were accidentally (I assume) committed. These cause low link delay values
to become negative.

This commit removes the preprocessor directives that replaced the original
latency values with the large ones.