### PR TITLE
Gptp enhancements

### DIFF
--- a/daemons/gptp/common/avbts_osnet.cpp
+++ b/daemons/gptp/common/avbts_osnet.cpp
@@ -1,31 +1,31 @@
 /******************************************************************************
 
-  Copyright (c) 2009-2012, Intel Corporation 
+  Copyright (c) 2009-2012, Intel Corporation
   All rights reserved.
-  
-  Redistribution and use in source and binary forms, with or without 
+
+  Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:
-  
-   1. Redistributions of source code must retain the above copyright notice, 
+
+   1. Redistributions of source code must retain the above copyright notice,
       this list of conditions and the following disclaimer.
-  
-   2. Redistributions in binary form must reproduce the above copyright 
-      notice, this list of conditions and the following disclaimer in the 
+
+   2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
       documentation and/or other materials provided with the distribution.
-  
-   3. Neither the name of the Intel Corporation nor the names of its 
-      contributors may be used to endorse or promote products derived from 
+
+   3. Neither the name of the Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived from
       this software without specific prior written permission.
-  
+
   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
-  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
   POSSIBILITY OF SUCH DAMAGE.
 

--- a/daemons/gptp/common/avbts_osnet.hpp
+++ b/daemons/gptp/common/avbts_osnet.hpp
@@ -296,7 +296,7 @@ class OSNetworkInterface {
 	  * @return net_result enumeration
 	  */
 	 virtual net_result nrecv
-		 (LinkLayerAddress * addr, uint8_t * payload, size_t & length) = 0;
+		 (LinkLayerAddress * addr, uint8_t * payload, size_t & length, struct phy_delay *delay) = 0;
 
 	 /**
 	  * @brief Get Link Layer address (mac address)

--- a/daemons/gptp/common/avbts_port.hpp
+++ b/daemons/gptp/common/avbts_port.hpp
@@ -426,7 +426,7 @@ class IEEE1588Port {
 	 * hardware timestamper and create OS locks conditions
 	 * @return FALSE if error during building the interface. TRUE if success
 	 */
-	bool init_port();
+	bool init_port(int delay[4]);
 
 	/**
 	 * @brief  Currently doesnt do anything. Just returns.
@@ -438,7 +438,7 @@ class IEEE1588Port {
 	 * @brief Receives messages from the network interface
 	 * @return Its an infinite loop. Returns NULL in case of error.
 	 */
-	void *openPort(void);
+	void *openPort(IEEE1588Port *port);
 
 	/**
 	 * @brief Get the payload offset inside a packet
@@ -959,4 +959,3 @@ class IEEE1588Port {
 };
 
 #endif
-

--- a/daemons/gptp/common/ieee1588.hpp
+++ b/daemons/gptp/common/ieee1588.hpp
@@ -95,6 +95,14 @@ typedef struct {
 	Event event;	//!< Event enumeration
 } event_descriptor_t;
 
+struct phy_delay
+{
+   int mb_tx_phy_delay;
+   int mb_rx_phy_delay;
+   int gb_tx_phy_delay;
+   int gb_rx_phy_delay;
+};
+
 /**
  * Provides a generic InterfaceLabel class
  */
@@ -441,8 +449,10 @@ static inline void TIMESTAMP_ADD_NS( Timestamp &ts, uint64_t ns ) {
  * Provides a generic interface for hardware timestamping
  */
 class HWTimestamper {
+
 protected:
 	uint8_t version; //!< HWTimestamper version
+	struct phy_delay delay;
 public:
 	/**
 	 * @brief Initializes the hardware timestamp unit
@@ -478,7 +488,7 @@ public:
 	{ return false; }
 
 	/**
-	 * @brief  Get the cross timestamping information. 
+	 * @brief  Get the cross timestamping information.
 	 * The gPTP subsystem uses these samples to calculate
 	 * ratios which can be used to translate or extrapolate
 	 * one clock into another clock reference. The gPTP service
@@ -501,7 +511,7 @@ public:
 	 * @param  sequenceId Sequence ID
 	 * @param  timestamp [out] Timestamp value
 	 * @param  clock_value [out] Clock value
-	 * @param  last Signalizes that it is the last timestamp to get. When TRUE, releases the lock when its done. 
+	 * @param  last Signalizes that it is the last timestamp to get. When TRUE, releases the lock when its done.
 	 * @return 0 no error, -1 error, -72 try again.
 	 */
 	virtual int HWTimestamper_txtimestamp(PortIdentity * identity,
@@ -516,7 +526,7 @@ public:
 	 * @param  sequenceId Sequence ID
 	 * @param  timestamp [out] Timestamp value
 	 * @param  clock_value [out] Clock value
-	 * @param  last Signalizes that it is the last timestamp to get. When TRUE, releases the lock when its done. 
+	 * @param  last Signalizes that it is the last timestamp to get. When TRUE, releases the lock when its done.
 	 * @return 0 no error, -1 error, -72 try again.
 	 */
 	virtual int HWTimestamper_rxtimestamp(PortIdentity * identity,
@@ -532,7 +542,7 @@ public:
 	 * @param  ppt_freq_offset [inout] Frequency offset in ppts
 	 * @return false
 	 * @todo  This code should be removed.  It was a hack to get a specific board
-	 * working. 
+	 * working.
 	 */
 	virtual bool HWTimestamper_get_extclk_offset(Timestamp * local_time,
 			int64_t * clk_offset,
@@ -570,6 +580,38 @@ public:
 	int getVersion() {
 		return version;
 	}
+	/**
+	 * @brief Initializes the PHY delay for TX and RX
+	 * @param [input] mb_tx_phy_delay, mb_rx_phy_delay, gb_tx_phy_delay, gb_rx_phy_delay
+	 * @return 0
+	 **/
+
+	 int init_phy_delay(int phy_delay[4])
+	 {
+		delay.gb_tx_phy_delay = phy_delay[0];
+		delay.gb_rx_phy_delay = phy_delay[1];
+		delay.mb_tx_phy_delay = phy_delay[2];
+		delay.mb_rx_phy_delay = phy_delay[3];
+
+
+		return 0;
+	 }
+
+	 /**
+	  * @brief Returns the the PHY delay for TX and RX
+	  * @param [input] struct phy_delay  pointer
+	  * @return 0
+	  **/
+
+	 int get_phy_delay (struct phy_delay *get_delay)
+	 {
+		get_delay->mb_tx_phy_delay = delay.mb_tx_phy_delay;
+		get_delay->mb_rx_phy_delay = delay.mb_rx_phy_delay;
+		get_delay->gb_tx_phy_delay = delay.gb_tx_phy_delay;
+		get_delay->gb_rx_phy_delay = delay.gb_rx_phy_delay;
+
+		return 0;
+	 }
 
 	/**
 	 * Default constructor. Sets version to zero.

--- a/daemons/gptp/common/ieee1588port.cpp
+++ b/daemons/gptp/common/ieee1588port.cpp
@@ -1,31 +1,31 @@
 /******************************************************************************
 
-  Copyright (c) 2009-2012, Intel Corporation 
+  Copyright (c) 2009-2012, Intel Corporation
   All rights reserved.
-  
-  Redistribution and use in source and binary forms, with or without 
+
+  Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:
-  
-   1. Redistributions of source code must retain the above copyright notice, 
+
+   1. Redistributions of source code must retain the above copyright notice,
       this list of conditions and the following disclaimer.
-  
-   2. Redistributions in binary form must reproduce the above copyright 
-      notice, this list of conditions and the following disclaimer in the 
+
+   2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
       documentation and/or other materials provided with the distribution.
-  
-   3. Neither the name of the Intel Corporation nor the names of its 
-      contributors may be used to endorse or promote products derived from 
+
+   3. Neither the name of the Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived from
       this software without specific prior written permission.
-  
+
   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
-  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
   POSSIBILITY OF SUCH DAMAGE.
 
@@ -55,7 +55,7 @@ OSThreadExitCode openPortWrapper(void *arg)
 	IEEE1588Port *port;
 
 	port = (IEEE1588Port *) arg;
-	if (port->openPort() == NULL)
+	if (port->openPort(port) == NULL)
 		return osthread_ok;
 	else
 		return osthread_error;
@@ -128,7 +128,7 @@ IEEE1588Port::IEEE1588Port
 	sync_count = 0;
 }
 
-bool IEEE1588Port::init_port()
+bool IEEE1588Port::init_port(int delay[4])
 {
 	if (!OSNetworkInterfaceFactory::buildInterface
 	    (&net_iface, factory_name_t("default"), net_label, _hw_timestamper))
@@ -146,6 +146,7 @@ bool IEEE1588Port::init_port()
 			_hw_timestamper = NULL;
 		}
 	}
+	_hw_timestamper->init_phy_delay(delay);
 
 	pdelay_rx_lock = lock_factory->createLock(oslock_recursive);
 	port_tx_lock = lock_factory->createLock(oslock_recursive);
@@ -169,7 +170,7 @@ void IEEE1588Port::startAnnounce() {
 
 bool IEEE1588Port::serializeState( void *buf, off_t *count ) {
 	bool ret = true;
-	
+
 	if( buf == NULL ) {
 		*count = sizeof(port_state)+sizeof(_peer_rate_offset)+
 			sizeof(asCapable)+sizeof(one_way_delay);
@@ -236,7 +237,7 @@ bool IEEE1588Port::serializeState( void *buf, off_t *count ) {
 
 bool IEEE1588Port::restoreSerializedState( void *buf, off_t *count ) {
   bool ret = true;
-  
+
   /* asCapable */
   if( ret && *count >= (off_t) sizeof( asCapable )) {
     memcpy( &asCapable, buf, sizeof( asCapable ));
@@ -288,9 +289,11 @@ bool IEEE1588Port::restoreSerializedState( void *buf, off_t *count ) {
   return ret;
 }
 
-void *IEEE1588Port::openPort(void)
+void *IEEE1588Port::openPort(IEEE1588Port *port)
 {
 	port_ready_condition->signal();
+	struct phy_delay get_delay;
+	port->_hw_timestamper->get_phy_delay(&get_delay);
 
 	while (1) {
 		PTPMessageCommon *msg;
@@ -299,7 +302,7 @@ void *IEEE1588Port::openPort(void)
 		net_result rrecv;
 		size_t length = sizeof(buf);
 
-		if ((rrecv = net_iface->nrecv(&remote, buf, length)) == net_succeed) {
+		if ((rrecv = net_iface->nrecv(&remote, buf, length,&get_delay)) == net_succeed) {
 			XPTPD_INFO("Processing network buffer");
 			msg = buildPTPMessage((char *)buf, (int)length, &remote,
 					    this);
@@ -374,7 +377,7 @@ void IEEE1588Port::processEvent(Event e)
 {
 	bool changed_external_master;
 	OSTimer *timer = timer_factory->createTimer();
-	
+
 	switch (e) {
 	case POWERUP:
 	case INITIALIZE:
@@ -386,11 +389,11 @@ void IEEE1588Port::processEvent(Event e)
 			unsigned long long interval4;
 			Event e3 = NULL_EVENT;
 			Event e4 = NULL_EVENT;
-			
+
 			if( port_state != PTP_MASTER ) {
 				_accelerated_sync_count = -1;
 			}
-			
+
 			if( port_state != PTP_SLAVE && port_state != PTP_MASTER ) {
 				fprintf( stderr, "Starting PDelay\n" );
 				startPDelay();
@@ -410,7 +413,7 @@ void IEEE1588Port::processEvent(Event e)
 					(ANNOUNCE_RECEIPT_TIMEOUT_MULTIPLIER*
 					 pow((double)2,getAnnounceInterval())*1000000000.0);
 			}
-      
+
 			port_ready_condition->wait_prelock();
 			listening_thread = thread_factory->createThread();
 			if (!listening_thread->
@@ -420,13 +423,13 @@ void IEEE1588Port::processEvent(Event e)
 				return;
 			}
 			port_ready_condition->wait();
-			
+
 			if (e3 != NULL_EVENT)
 				clock->addEventTimer(this, e3, interval3);
 			if (e4 != NULL_EVENT)
 				clock->addEventTimer(this, e4, interval4);
 		}
-		
+
 		clock->putTimerQLock();
 
 		break;
@@ -439,7 +442,7 @@ void IEEE1588Port::processEvent(Event e)
 			IEEE1588Port **ports;
 			clock->getPortList(number_ports, ports);
 
-			
+
 
 			/* Find EBest for all ports */
 			j = 0;
@@ -461,7 +464,7 @@ void IEEE1588Port::processEvent(Event e)
 
 			/* Check if we've changed */
 			{
-			  
+
 			  uint8_t LastEBestClockIdentity[PTP_CLOCK_IDENTITY_LENGTH];
 			  clock->getLastEBestIdentity().
 				  getIdentityString( LastEBestClockIdentity );
@@ -478,14 +481,14 @@ void IEEE1588Port::processEvent(Event e)
 				  changed_external_master = false;
 			  }
 			}
-			
+
 			if( clock->isBetterThan( EBest )) {
 				// We're Grandmaster, set grandmaster info to me
 				ClockIdentity clock_identity;
 				unsigned char priority1;
 				unsigned char priority2;
 				ClockQuality clock_quality;
-			  
+
 				clock_identity = getClock()->getClockIdentity();
 				getClock()->setGrandmasterClockIdentity( clock_identity );
 				priority1 = getClock()->getPriority1();
@@ -516,10 +519,10 @@ void IEEE1588Port::processEvent(Event e)
 						unsigned char priority1;
 						unsigned char priority2;
 						ClockQuality *clock_quality;
-						
+
 						ports[j]->recommendState
 							( PTP_SLAVE, changed_external_master );
-						
+
 						clock_identity = EBest->getGrandmasterClockIdentity();
 						getClock()->setGrandmasterClockIdentity(clock_identity);
 						priority1 = EBest->getGrandmasterPriority1();
@@ -529,7 +532,7 @@ void IEEE1588Port::processEvent(Event e)
 						clock_quality = EBest->getGrandmasterClockQuality();
 						getClock()->setGrandmasterClockQuality(*clock_quality);
 					} else {
-						/* Otherwise we are the master because we have 
+						/* Otherwise we are the master because we have
 						   sync'd to a better clock */
 						ports[j]->recommendState
 							(PTP_MASTER, changed_external_master);
@@ -566,7 +569,7 @@ void IEEE1588Port::processEvent(Event e)
 			    || port_state == PTP_PRE_MASTER) {
 				fprintf
 					(stderr,
-					 "*** %s Timeout Expired - Becoming Master\n", 
+					 "*** %s Timeout Expired - Becoming Master\n",
 					 e == ANNOUNCE_RECEIPT_TIMEOUT_EXPIRES ? "Announce" :
 					 "Sync" );
 				{
@@ -575,7 +578,7 @@ void IEEE1588Port::processEvent(Event e)
 				  unsigned char priority1;
 				  unsigned char priority2;
 				  ClockQuality clock_quality;
-				  
+
 				  clock_identity = getClock()->getClockIdentity();
 				  getClock()->setGrandmasterClockIdentity( clock_identity );
 				  priority1 = getClock()->getPriority1();
@@ -604,7 +607,7 @@ void IEEE1588Port::processEvent(Event e)
 				clock->addEventTimer
 					( this, SYNC_INTERVAL_TIMEOUT_EXPIRES, 16000000 );
 				startAnnounce();
-					// 
+					//
 			}
 		}
 
@@ -624,7 +627,7 @@ void IEEE1588Port::processEvent(Event e)
 				PortIdentity dest_id;
 				getPortIdentity(dest_id);
 				pdelay_req->setPortIdentity(&dest_id);
-				
+
 				{
 					Timestamp pending =
 					    PDELAY_PENDING_TIMESTAMP;
@@ -700,8 +703,8 @@ void IEEE1588Port::processEvent(Event e)
 						timeout : EVENT_TIMER_GRANULARITY;
 					clock->addEventTimer
 						(this, PDELAY_RESP_RECEIPT_TIMEOUT_EXPIRES, timeout );
-					
-					interval = 
+
+					interval =
 						((long long)
 						 (pow((double)2,getPDelayInterval())*1000000000.0)) -
 						wait_time*1000;
@@ -722,7 +725,7 @@ void IEEE1588Port::processEvent(Event e)
 				FrequencyRatio local_system_freq_offset;
 				int64_t local_system_offset;
 				long long wait_time = 0;
-				
+
 				uint32_t local_clock, nominal_clock_rate;
 
 				// Send a sync message and then a followup to broadcast
@@ -734,7 +737,7 @@ void IEEE1588Port::processEvent(Event e)
 					getTxLock();
 					sync->sendPort(this, NULL);
 					XPTPD_INFO("Sent SYNC message");
-					
+
 					int ts_good;
 					Timestamp sync_timestamp;
 					unsigned sync_timestamp_counter_value;
@@ -754,12 +757,12 @@ void IEEE1588Port::processEvent(Event e)
 								"error=%d", ts_good);
 						ts_good =
 							getTxTimestamp
-							(sync, sync_timestamp, 
+							(sync, sync_timestamp,
 							 sync_timestamp_counter_value, iter == 0);
 						req *= 2;
 					}
 					putTxLock();
-					
+
 					if (ts_good != 0) {
 						char msg
 							[HWTIMESTAMPER_EXTENDED_MESSAGE_SIZE];
@@ -781,7 +784,7 @@ void IEEE1588Port::processEvent(Event e)
 						XPTPD_INFO
 							("*** Unsuccessful Sync timestamp");
 					}
-					
+
 					PTPMessageFollowUp *follow_up;
 					if (ts_good == 0) {
 						follow_up =
@@ -801,12 +804,12 @@ void IEEE1588Port::processEvent(Event e)
 				   causing an update to local/system timestamp */
 				getDeviceTime
 					(system_time, device_time, local_clock, nominal_clock_rate);
-				
+
 				XPTPD_INFO
 					("port::processEvent(): System time: %u,%u Device Time: %u,%u",
 					 system_time.seconds_ls, system_time.nanoseconds,
 					 device_time.seconds_ls, device_time.nanoseconds);
-				
+
 				local_system_offset =
 			    TIMESTAMP_TO_NS(system_time) -
 			    TIMESTAMP_TO_NS(device_time);
@@ -839,7 +842,7 @@ void IEEE1588Port::processEvent(Event e)
 				  clock->addEventTimer
 					  ( this, SYNC_INTERVAL_TIMEOUT_EXPIRES, wait_time );
 			  }
-			  
+
 			}
 			break;
 	case ANNOUNCE_INTERVAL_TIMEOUT_EXPIRES:
@@ -952,7 +955,7 @@ void IEEE1588Port::becomeSlave( bool restart_syntonization ) {
 		(pow((double)2,getAnnounceInterval())*1000000000.0)));
   fprintf( stderr, "Switching to Slave\n" );
   if( restart_syntonization ) clock->newSyntonizationSetPoint();
-  
+
   return;
 }
 

--- a/daemons/gptp/linux/src/linux_hal_common.cpp
+++ b/daemons/gptp/linux/src/linux_hal_common.cpp
@@ -1,31 +1,31 @@
 /******************************************************************************
 
-  Copyright (c) 2009-2012, Intel Corporation 
+  Copyright (c) 2009-2012, Intel Corporation
   All rights reserved.
-  
-  Redistribution and use in source and binary forms, with or without 
+
+  Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:
-  
-   1. Redistributions of source code must retain the above copyright notice, 
+
+   1. Redistributions of source code must retain the above copyright notice,
       this list of conditions and the following disclaimer.
-  
-   2. Redistributions in binary form must reproduce the above copyright 
-      notice, this list of conditions and the following disclaimer in the 
+
+   2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
       documentation and/or other materials provided with the distribution.
-  
-   3. Neither the name of the Intel Corporation nor the names of its 
-      contributors may be used to endorse or promote products derived from 
+
+   3. Neither the name of the Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived from
       this software without specific prior written permission.
-  
+
   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
-  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
   POSSIBILITY OF SUCH DAMAGE.
 
@@ -89,7 +89,7 @@ net_result LinuxNetworkInterface::send
 	addr->toOctetArray( remote->sll_addr );
 
 	if( timestamp ) {
-#ifndef ARCH_INTELCE	   
+#ifndef ARCH_INTELCE
 		net_lock.lock();
 #endif
 		err = sendto
@@ -113,7 +113,7 @@ void LinuxNetworkInterface::disable_clear_rx_queue() {
 	struct packet_mreq mr_8021as;
 	int err;
 	char buf[256];
-	
+
 	if( !net_lock.lock() ) {
 		fprintf( stderr, "D rx lock failed\n" );
 		_exit(0);
@@ -133,9 +133,9 @@ void LinuxNetworkInterface::disable_clear_rx_queue() {
 			  ifindex );
 		return;
 	}
-  
+
 	while( recvfrom( sd_event, buf, 256, MSG_DONTWAIT, NULL, 0 ) != -1 );
-	
+
 	return;
 }
 
@@ -193,9 +193,9 @@ void *LinuxTimerQueueHandler( void *arg ) {
 	sigset_t waitfor;
 	struct timespec timeout;
 	timeout.tv_sec = 0; timeout.tv_nsec = 100000000; /* 100 ms */
-	
+
 	sigemptyset( &waitfor );
-	
+
 	while( !timerq->stop ) {
 		siginfo_t info;
 		LinuxTimerQueueMap_t::iterator iter;
@@ -255,7 +255,7 @@ OSTimerQueue *LinuxTimerQueueFactory::createOSTimerQueue
 	return ret;
 }
 
-	
+
 
 bool LinuxTimerQueue::addEvent
 ( unsigned long micros, int type, ostimerq_handler func,
@@ -275,7 +275,7 @@ bool LinuxTimerQueue::addEvent
 	while( timerQueueMap.find( key ) != timerQueueMap.end() ) {
 		++key;
 	}
-		
+
 	{
 		struct itimerspec its;
 		memset(&(outer_arg->sevp), 0, sizeof(outer_arg->sevp));
@@ -296,7 +296,7 @@ bool LinuxTimerQueue::addEvent
 		err = timer_settime( outer_arg->timer_handle, 0, &its, NULL );
 		if( err < 0 ) {
 			fprintf
-				( stderr, "Failed to arm timer: %s\n", 
+				( stderr, "Failed to arm timer: %s\n",
 				  strerror( errno ));
 			return false;
 		}
@@ -357,7 +357,7 @@ unsigned long LinuxTimer::sleep(unsigned long micros) {
 
 struct TicketingLockPrivate {
 	pthread_cond_t condition;
-	pthread_mutex_t cond_lock;      
+	pthread_mutex_t cond_lock;
 };
 
 bool TicketingLock::lock( bool *got ) {
@@ -365,7 +365,7 @@ bool TicketingLock::lock( bool *got ) {
 	bool yield = false;
 	bool ret = true;
 	if( !init_flag ) return false;
-	
+
 	if( pthread_mutex_lock( &_private->cond_lock ) != 0 ) {
 		ret = false;
 		goto done;
@@ -386,15 +386,15 @@ bool TicketingLock::lock( bool *got ) {
 	}
 
 	if( got != NULL ) *got = true;
-	
+
  unlock:
 	if( pthread_mutex_unlock( &_private->cond_lock ) != 0 ) {
 		ret = false;
 		goto done;
 	}
-		
+
 	if( yield ) pthread_yield();
-	
+
  done:
 	return ret;
 }
@@ -402,7 +402,7 @@ bool TicketingLock::lock( bool *got ) {
 bool TicketingLock::unlock() {
 	bool ret = true;
 	if( !init_flag ) return false;
-		
+
 	if( pthread_mutex_lock( &_private->cond_lock ) != 0 ) {
 		ret = false;
 		goto done;
@@ -437,7 +437,7 @@ bool TicketingLock::init() {
 	cond_ticket_issue = 0;
 	cond_ticket_serving = 0;
 	init_flag = true;
-    
+
 	return true;
 }
 
@@ -485,7 +485,7 @@ OSLockResult LinuxLock::lock() {
 	int lock_c;
 	lock_c = pthread_mutex_lock(&_private->mutex);
 	if(lock_c != 0) {
-		fprintf( stderr, "LinuxLock: lock failed %d\n", lock_c );  
+		fprintf( stderr, "LinuxLock: lock failed %d\n", lock_c );
 		return oslock_fail;
 	}
 	return oslock_ok;
@@ -502,7 +502,7 @@ OSLockResult LinuxLock::unlock() {
 	int lock_c;
 	lock_c = pthread_mutex_unlock(&_private->mutex);
 	if(lock_c != 0) {
-		fprintf( stderr, "LinuxLock: unlock failed %d\n", lock_c );  
+		fprintf( stderr, "LinuxLock: unlock failed %d\n", lock_c );
 		return oslock_fail;
 	}
 	return oslock_ok;
@@ -635,7 +635,7 @@ bool LinuxSharedMemoryIPC::init( OS_IPC_ARG *barg ) {
 	if( grp == NULL ) {
 		XPTPD_ERROR( "Group %s not found, will try root (0) instead", group_name );
 	}
-		
+
 	shm_fd = shm_open( SHM_NAME, O_RDWR | O_CREAT, 0660 );
 	if( shm_fd == -1 ) {
 		XPTPD_ERROR( "shm_open(): %s", strerror(errno) );
@@ -675,7 +675,7 @@ bool LinuxSharedMemoryIPC::init( OS_IPC_ARG *barg ) {
 	}
 	return true;
  exit_unlink:
-	shm_unlink( SHM_NAME ); 
+	shm_unlink( SHM_NAME );
  exit_error:
 	return false;
 }
@@ -724,20 +724,20 @@ bool LinuxNetworkInterfaceFactory::createInterface
 	struct packet_mreq mr_8021as;
 	LinkLayerAddress addr;
 	int ifindex;
-		
+
 	LinuxNetworkInterface *net_iface_l = new LinuxNetworkInterface();
-		
+
 	if( !net_iface_l->net_lock.init()) {
 		XPTPD_ERROR( "Failed to initialize network lock");
 		return false;
 	}
-		
+
 	InterfaceName *ifname = dynamic_cast<InterfaceName *>(label);
 	if( ifname == NULL ){
 		XPTPD_ERROR( "ifname == NULL");
 		return false;
 	}
-		
+
 	net_iface_l->sd_general = socket( PF_PACKET, SOCK_DGRAM, 0 );
 	if( net_iface_l->sd_general == -1 ) {
 		XPTPD_ERROR( "failed to open general socket: %s", strerror(errno));
@@ -749,7 +749,7 @@ bool LinuxNetworkInterfaceFactory::createInterface
 			( "failed to open event socket: %s \n", strerror(errno));
 		return false;
 	}
-		
+
 	memset( &device, 0, sizeof(device));
 	ifname->toString( device.ifr_name, IFNAMSIZ );
 	err = ioctl( net_iface_l->sd_event, SIOCGIFHWADDR, &device );
@@ -758,7 +758,7 @@ bool LinuxNetworkInterfaceFactory::createInterface
 			( "Failed to get interface address: %s", strerror( errno ));
 		return false;
 	}
-		
+
 	addr = LinkLayerAddress( (uint8_t *)&device.ifr_hwaddr.sa_data );
 	net_iface_l->local_addr = addr;
 	err = ioctl( net_iface_l->sd_event, SIOCGIFINDEX, &device );
@@ -783,19 +783,19 @@ bool LinuxNetworkInterfaceFactory::createInterface
 			  ifindex );
 		return false;
 	}
-		
+
 	memset( &ifsock_addr, 0, sizeof( ifsock_addr ));
 	ifsock_addr.sll_family = AF_PACKET;
 	ifsock_addr.sll_ifindex = ifindex;
 	ifsock_addr.sll_protocol = PLAT_htons( PTP_ETHERTYPE );
 	err = bind
 		( net_iface_l->sd_event, (sockaddr *) &ifsock_addr,
-		  sizeof( ifsock_addr ));	
-	if( err == -1 ) { 
+		  sizeof( ifsock_addr ));
+	if( err == -1 ) {
 		XPTPD_ERROR( "Call to bind() failed: %s", strerror(errno) );
 		return false;
 	}
-		
+
 	net_iface_l->timestamper =
 		dynamic_cast <LinuxTimestamper *>(timestamper);
 	if(net_iface_l->timestamper == NULL) {
@@ -808,7 +808,6 @@ bool LinuxNetworkInterfaceFactory::createInterface
 		return false;
 	}
 	*net_iface = net_iface_l;
-		
+
 	return true;
 }
-

--- a/daemons/gptp/linux/src/linux_hal_common.hpp
+++ b/daemons/gptp/linux/src/linux_hal_common.hpp
@@ -1,31 +1,31 @@
 /******************************************************************************
 
-  Copyright (c) 2012, Intel Corporation 
+  Copyright (c) 2012, Intel Corporation
   All rights reserved.
-  
-  Redistribution and use in source and binary forms, with or without 
+
+  Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:
-  
-   1. Redistributions of source code must retain the above copyright notice, 
+
+   1. Redistributions of source code must retain the above copyright notice,
       this list of conditions and the following disclaimer.
-  
-   2. Redistributions in binary form must reproduce the above copyright 
-      notice, this list of conditions and the following disclaimer in the 
+
+   2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
       documentation and/or other materials provided with the distribution.
-  
-   3. Neither the name of the Intel Corporation nor the names of its 
-      contributors may be used to endorse or promote products derived from 
+
+   3. Neither the name of the Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived from
       this software without specific prior written permission.
-  
+
   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
-  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
   POSSIBILITY OF SUCH DAMAGE.
 
@@ -68,7 +68,7 @@ struct TicketingLockPrivate;
  * Provides the type for the TicketingLock private structure
  */
 typedef struct TicketingLockPrivate * TicketingLockPrivate_t;
-	
+
 /**
  * TicketingLock: Implements the ticket lock algorithm.
  * A ticket lock consists of two counters, one containing the
@@ -176,7 +176,7 @@ public:
 	 * an error on the transmit side, net_fatal if error on reception
 	 */
 	virtual net_result nrecv
-	( LinkLayerAddress *addr, uint8_t *payload, size_t &length );
+	( LinkLayerAddress *addr, uint8_t *payload, size_t &length, struct phy_delay *delay );
 
 	/**
 	 * @brief  Disables rx socket descriptor and and clears the rx queue
@@ -448,7 +448,7 @@ public:
 	/**
 	 * @brief Creates Linux timer queue
 	 * @param clock [in] Pointer to IEEE15588Clock type
-	 * @return Pointer to OSTimerQueue 
+	 * @return Pointer to OSTimerQueue
 	 */
 	virtual OSTimerQueue *createOSTimerQueue( IEEE1588Clock *clock );
 };

--- a/examples/common/listener_mrp_client.c
+++ b/examples/common/listener_mrp_client.c
@@ -29,6 +29,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 int control_socket;
 volatile int talker = 0;
 unsigned char stream_id[8];
+unsigned char dst_mac[6];
 volatile int halt_tx = 0;
 
 volatile int domain_a_valid = 0;
@@ -87,6 +88,12 @@ int msg_process(char *buf, int buflen)
 		{
 			sscanf(&buf[l],"%02x",&id);
 			stream_id[j] = (unsigned char)id;
+		}
+		l+=3;
+		for(j = 0; j < 6 ; l+=2, j++)
+		{
+			sscanf(&buf[l],"%02x",&id);
+			dst_mac[j] = (unsigned char)id;
 		}
 		talker = 1;
 	}

--- a/examples/common/listener_mrp_client.c
+++ b/examples/common/listener_mrp_client.c
@@ -26,21 +26,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 /* global variables */
 
-int control_socket;
-volatile int talker = 0;
-unsigned char stream_id[8];
-unsigned char dst_mac[6];
-volatile int halt_tx = 0;
-
-volatile int domain_a_valid = 0;
-int domain_class_a_id = 0;
-int domain_class_a_priority = 0;
-u_int16_t domain_class_a_vid = 0;
-
-volatile int domain_b_valid = 0;
-int domain_class_b_id = 0;
-int domain_class_b_priority = 0;
-u_int16_t domain_class_b_vid = 0;
+struct listener_context global_struct_listener;
 pthread_t monitor_thread;
 pthread_attr_t monitor_attr;
 
@@ -48,12 +34,37 @@ pthread_attr_t monitor_attr;
  * private
  */
 
+int mrp_listener_client_init(void)
+{
+	int i;
+	global_struct_listener.control_socket=-1;
+	global_struct_listener.talker = 0;
+	global_struct_listener.halt_tx = 0;
+	global_struct_listener.domain_a_valid = 0;
+	global_struct_listener.domain_class_a_id = 0;
+	global_struct_listener.domain_class_a_priority = 0;
+	global_struct_listener.domain_class_a_vid = 0;
+	global_struct_listener.domain_b_valid = 0;
+	global_struct_listener.domain_class_b_id = 0;
+	global_struct_listener.domain_class_b_priority = 0;
+	global_struct_listener.domain_class_b_vid = 0;
+	for (i=0;i<8;i++)
+	{
+		global_struct_listener.stream_id[i]=0;
+	}
+	for (i=0;i<6;i++)
+	{
+		global_struct_listener.dst_mac[i]=0;
+	}
+	return 0;
+}
+
 int send_msg(char *data, int data_len)
 {
 	//printf("Inside send msg\n");
 	struct sockaddr_in addr;
 
-	if (control_socket == -1)
+	if (global_struct_listener.control_socket == -1)
 		return -1;
 	if (data == NULL)
 		return -1;
@@ -63,7 +74,7 @@ int send_msg(char *data, int data_len)
 	addr.sin_port = htons(MRPD_PORT_DEFAULT);
 	addr.sin_addr.s_addr = inet_addr("127.0.0.1");
 	inet_aton("127.0.0.1", &addr.sin_addr);
-	return sendto(control_socket, data, data_len, 0,
+	return sendto(global_struct_listener.control_socket, data, data_len, 0,
 		(struct sockaddr*)&addr, (socklen_t)sizeof(addr));
 }
 
@@ -72,7 +83,6 @@ int msg_process(char *buf, int buflen)
 	uint32_t id;
 	int j, l=0;
 	unsigned int vid;
-	//unsigned int id;
 	unsigned int priority;
 
 	fprintf(stderr, "Msg: %s\n", buf);
@@ -87,15 +97,15 @@ int msg_process(char *buf, int buflen)
 		for(j = 0; j < 8 ; l+=2, j++)
 		{
 			sscanf(&buf[l],"%02x",&id);
-			stream_id[j] = (unsigned char)id;
+			global_struct_listener.stream_id[j] = (unsigned char)id;
 		}
 		l+=3;
 		for(j = 0; j < 6 ; l+=2, j++)
 		{
 			sscanf(&buf[l],"%02x",&id);
-			dst_mac[j] = (unsigned char)id;
+			global_struct_listener.dst_mac[j] = (unsigned char)id;
 		}
-		talker = 1;
+		global_struct_listener.talker = 1;
 	}
 
 	if (strncmp(buf, "SJO D:", 6) == 0)
@@ -109,17 +119,17 @@ int msg_process(char *buf, int buflen)
 
 		if (id == 6)
 		{
-			domain_class_a_id = id;
-			domain_class_a_priority = priority;
-			domain_class_a_vid = vid;
-			domain_a_valid = 1;
+			global_struct_listener.domain_class_a_id = id;
+			global_struct_listener.domain_class_a_priority = priority;
+			global_struct_listener.domain_class_a_vid = vid;
+			global_struct_listener.domain_a_valid = 1;
 		}
 		else
 		{
-			domain_class_b_id = id;
-			domain_class_b_priority = priority;
-			domain_class_b_vid = vid;
-			domain_b_valid = 1;
+			global_struct_listener.domain_class_b_id = id;
+			global_struct_listener.domain_class_b_priority = priority;
+			global_struct_listener.domain_class_b_vid = vid;
+			global_struct_listener.domain_b_valid = 1;
 		}
 		l+=4;
 
@@ -134,13 +144,13 @@ int msg_process(char *buf, int buflen)
 int create_socket() // TODO FIX! =:-|
 {
 	struct sockaddr_in addr;
-	control_socket = socket(AF_INET, SOCK_DGRAM, 0);
+	global_struct_listener.control_socket = socket(AF_INET, SOCK_DGRAM, 0);
 
 	/** in POSIX fd 0,1,2 are reserved */
-	if (2 > control_socket)
+	if (2 > global_struct_listener.control_socket)
 	{
-		if (-1 > control_socket)
-			close(control_socket);
+		if (-1 > global_struct_listener.control_socket)
+			close(global_struct_listener.control_socket);
 	return -1;
 	}
 
@@ -148,10 +158,10 @@ int create_socket() // TODO FIX! =:-|
 	addr.sin_family = AF_INET;
 	addr.sin_port = htons(0);
 
-	if(0 > (bind(control_socket, (struct sockaddr*)&addr, sizeof(addr))))
+	if(0 > (bind(global_struct_listener.control_socket, (struct sockaddr*)&addr, sizeof(addr))))
 	{
 		fprintf(stderr, "Could not bind socket.\n");
-		close(control_socket);
+		close(global_struct_listener.control_socket);
 		return -1;
 	}
 	return 0;
@@ -171,8 +181,8 @@ void *mrp_monitor_thread(void *arg)
 	msgbuf = (char *)malloc(MAX_MRPD_CMDSZ);
 	if (NULL == msgbuf)
 		return NULL;
-	while (!halt_tx) {
-		fds.fd = control_socket;
+	while (!global_struct_listener.halt_tx) {
+		fds.fd = global_struct_listener.control_socket;
 		fds.events = POLLIN;
 		fds.revents = 0;
 		rc = poll(&fds, 1, 100);
@@ -195,7 +205,7 @@ void *mrp_monitor_thread(void *arg)
 		msg.msg_namelen = sizeof(client_addr);
 		msg.msg_iov = &iov;
 		msg.msg_iovlen = 1;
-		bytes = recvmsg(control_socket, &msg, 0);
+		bytes = recvmsg(global_struct_listener.control_socket, &msg, 0);
 		if (bytes < 0)
 			continue;
 		msg_process(msgbuf, bytes);
@@ -250,7 +260,7 @@ int mrp_get_domain(int *class_a_id, int *a_priority, u_int16_t * a_vid,
 	free(msgbuf);
 	if (ret != 1500)
 		return -1;
-	while (!halt_tx && (domain_a_valid == 0) && (domain_b_valid == 0))
+	while (!global_struct_listener.halt_tx && (global_struct_listener.domain_a_valid == 0) && (global_struct_listener.domain_b_valid == 0))
 		usleep(20000);
 	*class_a_id = 0;
 	*a_priority = 0;
@@ -258,15 +268,15 @@ int mrp_get_domain(int *class_a_id, int *a_priority, u_int16_t * a_vid,
 	*class_b_id = 0;
 	*b_priority = 0;
 	*b_vid = 0;
-	if (domain_a_valid) {
-		*class_a_id = domain_class_a_id;
-		*a_priority = domain_class_a_priority;
-		*a_vid = domain_class_a_vid;
+	if (global_struct_listener.domain_a_valid) {
+		*class_a_id = global_struct_listener.domain_class_a_id;
+		*a_priority = global_struct_listener.domain_class_a_priority;
+		*a_vid = global_struct_listener.domain_class_a_vid;
 	}
-	if (domain_b_valid) {
-		*class_b_id = domain_class_b_id;
-		*b_priority = domain_class_b_priority;
-		*b_vid = domain_class_b_vid;
+	if (global_struct_listener.domain_b_valid) {
+		*class_b_id = global_struct_listener.domain_class_b_id;
+		*b_priority = global_struct_listener.domain_class_b_priority;
+		*b_vid = global_struct_listener.domain_class_b_vid;
 	}
 	return 0;
 }
@@ -293,7 +303,7 @@ int join_vlan(u_int16_t vid)
 
 int await_talker()
 {
-	while (0 == talker)
+	while (0 == global_struct_listener.talker)
 		;
 	return 0;
 }
@@ -308,10 +318,10 @@ int send_ready()
 		return -1;
 	memset(databuf, 0, 1500);
 	sprintf(databuf, "S+L:L=%02x%02x%02x%02x%02x%02x%02x%02x, D=2",
-		     stream_id[0], stream_id[1],
-		     stream_id[2], stream_id[3],
-		     stream_id[4], stream_id[5],
-		     stream_id[6], stream_id[7]);
+		     global_struct_listener.stream_id[0], global_struct_listener.stream_id[1],
+		     global_struct_listener.stream_id[2], global_struct_listener.stream_id[3],
+		     global_struct_listener.stream_id[4], global_struct_listener.stream_id[5],
+		     global_struct_listener.stream_id[6], global_struct_listener.stream_id[7]);
 	rc = send_msg(databuf, 1500);
 	free(databuf);
 
@@ -331,10 +341,10 @@ int send_leave()
 		return -1;
 	memset(databuf, 0, 1500);
 	sprintf(databuf, "S-L:L=%02x%02x%02x%02x%02x%02x%02x%02x, D=3",
-		     stream_id[0], stream_id[1],
-		     stream_id[2], stream_id[3],
-		     stream_id[4], stream_id[5],
-		     stream_id[6], stream_id[7]);
+		     global_struct_listener.stream_id[0], global_struct_listener.stream_id[1],
+		     global_struct_listener.stream_id[2], global_struct_listener.stream_id[3],
+		     global_struct_listener.stream_id[4], global_struct_listener.stream_id[5],
+		     global_struct_listener.stream_id[6], global_struct_listener.stream_id[7]);
 	rc = send_msg(databuf, 1500);
 	free(databuf);
 

--- a/examples/common/listener_mrp_client.c
+++ b/examples/common/listener_mrp_client.c
@@ -75,8 +75,6 @@ int msg_process(char *buf, int buflen)
 	unsigned int priority;
 
 	fprintf(stderr, "Msg: %s\n", buf);
-	
-	//printf("Inside msg_process\n");
 
 	if (strncmp(buf, "SNE T:", 6) == 0 || strncmp(buf, "SJO T:", 6) == 0)
 	{
@@ -101,15 +99,15 @@ int msg_process(char *buf, int buflen)
 		sscanf(&(buf[l]), "%d", &priority);
 		l=l+4;
 		sscanf(&(buf[l]), "%x", &vid);
-		
-		if (id == 6) 
+
+		if (id == 6)
 		{
 			domain_class_a_id = id;
 			domain_class_a_priority = priority;
 			domain_class_a_vid = vid;
 			domain_a_valid = 1;
-		} 
-		else 
+		}
+		else
 		{
 			domain_class_b_id = id;
 			domain_class_b_priority = priority;
@@ -117,33 +115,10 @@ int msg_process(char *buf, int buflen)
 			domain_b_valid = 1;
 		}
 		l+=4;
-		
+
 	}
 	return 0;
 }
-
-/*int recv_msg()
-{
-	char *databuf;
-	int bytes = 0;
-	int ret;
-
-	databuf = (char *)malloc(1500);
-	if (NULL == databuf)
-		return -1;
-
-	memset(databuf, 0, 1500);
-	bytes = recv(control_socket, databuf, 1500, 0);
-	if (bytes <= -1)
-	{
-		free(databuf);
-		return -1;
-	}
-	ret = msg_process(databuf, bytes);
-	free(databuf);
-
-	return ret;
-}*/
 
 /*
  * public
@@ -153,7 +128,7 @@ int create_socket() // TODO FIX! =:-|
 {
 	struct sockaddr_in addr;
 	control_socket = socket(AF_INET, SOCK_DGRAM, 0);
-		
+
 	/** in POSIX fd 0,1,2 are reserved */
 	if (2 > control_socket)
 	{
@@ -161,12 +136,12 @@ int create_socket() // TODO FIX! =:-|
 			close(control_socket);
 	return -1;
 	}
-	
+
 	memset(&addr, 0, sizeof(addr));
 	addr.sin_family = AF_INET;
 	addr.sin_port = htons(0);
-	
-	if(0 > (bind(control_socket, (struct sockaddr*)&addr, sizeof(addr)))) 
+
+	if(0 > (bind(control_socket, (struct sockaddr*)&addr, sizeof(addr))))
 	{
 		fprintf(stderr, "Could not bind socket.\n");
 		close(control_socket);
@@ -232,7 +207,6 @@ int mrp_monitor(void)
 }
 
 int report_domain_status(int *class_id, int *priority, u_int16_t *vid)
-//int report_domain_status()
 {
 	char* msgbuf;
 	int rc;
@@ -241,7 +215,6 @@ int report_domain_status(int *class_id, int *priority, u_int16_t *vid)
 	if (NULL == msgbuf)
 		return -1;
 	memset(msgbuf, 0, 1500);
-	//sprintf(msgbuf,"S+D:C=6,P=3,V=0002");
 	sprintf(msgbuf, "S+D:C=%d,P=%d,V=%04x", *class_id, *priority, *vid);
 	rc = send_msg(msgbuf, 1500);
 	free(msgbuf);
@@ -257,7 +230,7 @@ int mrp_get_domain(int *class_a_id, int *a_priority, u_int16_t * a_vid,
 {
 	char *msgbuf;
 	int ret;
-	
+
 	/* we may not get a notification if we are joining late,
 	 * so query for what is already there ...
 	 */
@@ -267,7 +240,6 @@ int mrp_get_domain(int *class_a_id, int *a_priority, u_int16_t * a_vid,
 	memset(msgbuf, 0, 1500);
 	sprintf(msgbuf, "S??");
 	ret = send_msg(msgbuf, 1500);
-	//printf("After send msg\n");
 	free(msgbuf);
 	if (ret != 1500)
 		return -1;
@@ -293,7 +265,6 @@ int mrp_get_domain(int *class_a_id, int *a_priority, u_int16_t * a_vid,
 }
 
 int join_vlan(u_int16_t vid)
-//int join_vlan()
 {
 	char *msgbuf;
 	int rc;
@@ -302,7 +273,6 @@ int join_vlan(u_int16_t vid)
 	if (NULL == msgbuf)
 		return -1;
 	memset(msgbuf, 0, 1500);
-	//sprintf(msgbuf, "V++:I=0002");
 	sprintf(msgbuf, "V++:I=%04x\n",vid);
 	printf("Joing VLAN %s\n",msgbuf);
 	rc = send_msg(msgbuf, 1500);
@@ -316,8 +286,8 @@ int join_vlan(u_int16_t vid)
 
 int await_talker()
 {
-	while (0 == talker)	
-		;//recv_msg();
+	while (0 == talker)
+		;
 	return 0;
 }
 

--- a/examples/common/listener_mrp_client.h
+++ b/examples/common/listener_mrp_client.h
@@ -46,21 +46,25 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // TODO move these in a talker_context struct + init func
 
-extern int control_socket;
-extern volatile int talker;
-extern unsigned char stream_id[8];
-extern unsigned char dst_mac[6];
-extern volatile int halt_tx;
+struct listener_context
+{
+	int control_socket;
+	volatile int talker;
+	unsigned char stream_id[8];
+	unsigned char dst_mac[6];
+	volatile int halt_tx;
+	volatile int domain_a_valid;
+	int domain_class_a_id;
+	int domain_class_a_priority;
+	u_int16_t domain_class_a_vid;
+	volatile int domain_b_valid;
+	int domain_class_b_id;
+	int domain_class_b_priority;
+	u_int16_t domain_class_b_vid;
+}global_struct_listener;
 
-extern volatile int domain_a_valid;
-extern int domain_class_a_id;
-extern int domain_class_a_priority;
-extern u_int16_t domain_class_a_vid;
+extern struct listener_context global_struct_listener;
 
-extern volatile int domain_b_valid;
-extern int domain_class_b_id;
-extern int domain_class_b_priority;
-extern u_int16_t domain_class_b_vid;
 
 
 /* functions */
@@ -74,5 +78,6 @@ int send_ready();
 int send_leave();
 int mrp_disconnect();
 int mrp_get_domain(int *class_a_id, int *a_priority, u_int16_t * a_vid, int *class_b_id, int *b_priority, u_int16_t * b_vid);
+int mrp_listener_client_init(void);
 
 #endif /* _LISTENER_MRP_CLIENT_H_ */

--- a/examples/common/listener_mrp_client.h
+++ b/examples/common/listener_mrp_client.h
@@ -49,6 +49,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 extern int control_socket;
 extern volatile int talker;
 extern unsigned char stream_id[8];
+extern unsigned char dst_mac[6];
 extern volatile int halt_tx;
 
 extern volatile int domain_a_valid;

--- a/examples/common/listener_mrp_client.h
+++ b/examples/common/listener_mrp_client.h
@@ -67,8 +67,6 @@ extern u_int16_t domain_class_b_vid;
 int create_socket();
 int mrp_monitor(void);
 int report_domain_status(int *class_id, int *priority, u_int16_t *vid);
-//int report_domain_status();
-//int join_vlan();
 int join_vlan(u_int16_t vid);
 int await_talker();
 int send_ready();

--- a/examples/common/listener_mrp_client.h
+++ b/examples/common/listener_mrp_client.h
@@ -44,9 +44,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 /* global variables */
 
-// TODO move these in a talker_context struct + init func
-
-struct listener_context
+struct mrp_listener_ctx
 {
 	int control_socket;
 	volatile int talker;
@@ -61,23 +59,28 @@ struct listener_context
 	int domain_class_b_id;
 	int domain_class_b_priority;
 	u_int16_t domain_class_b_vid;
-}global_struct_listener;
+};
 
-extern struct listener_context global_struct_listener;
+struct mrp_domain_attr
+{
+	int id;
+	int priority;
+	u_int16_t vid;
+};
 
 
 
 /* functions */
 
-int create_socket();
-int mrp_monitor(void);
-int report_domain_status(int *class_id, int *priority, u_int16_t *vid);
-int join_vlan(u_int16_t vid);
-int await_talker();
-int send_ready();
-int send_leave();
-int mrp_disconnect();
-int mrp_get_domain(int *class_a_id, int *a_priority, u_int16_t * a_vid, int *class_b_id, int *b_priority, u_int16_t * b_vid);
-int mrp_listener_client_init(void);
+int create_socket(struct mrp_listener_ctx *ctx);
+int mrp_monitor(struct mrp_listener_ctx *ctx);
+int report_domain_status(struct mrp_domain_attr *class_a, struct mrp_listener_ctx *ctx);
+int join_vlan(struct mrp_domain_attr *class_a, struct mrp_listener_ctx *ctx);
+int await_talker(struct mrp_listener_ctx *ctx);
+int send_ready(struct mrp_listener_ctx *ctx);
+int send_leave(struct mrp_listener_ctx *ctx);
+int mrp_disconnect(struct mrp_listener_ctx *ctx);
+int mrp_get_domain(struct mrp_listener_ctx *ctx, struct mrp_domain_attr *class_a, struct mrp_domain_attr *class_b);
+int mrp_listener_client_init(struct mrp_listener_ctx *ctx);
 
 #endif /* _LISTENER_MRP_CLIENT_H_ */

--- a/examples/common/listener_mrp_client.h
+++ b/examples/common/listener_mrp_client.h
@@ -34,8 +34,13 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <string.h>
 #include <stdio.h> // TODO fprintf, to be removed
 #include <unistd.h>
+#include <netinet/in.h>
+#include <pthread.h>
+#include <poll.h>
 
 #include "mrpd.h"
+#include "mrp.h"
+#include "msrp.h"
 
 /* global variables */
 
@@ -44,15 +49,31 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 extern int control_socket;
 extern volatile int talker;
 extern unsigned char stream_id[8];
+extern volatile int halt_tx;
+
+extern volatile int domain_a_valid;
+extern int domain_class_a_id;
+extern int domain_class_a_priority;
+extern u_int16_t domain_class_a_vid;
+
+extern volatile int domain_b_valid;
+extern int domain_class_b_id;
+extern int domain_class_b_priority;
+extern u_int16_t domain_class_b_vid;
+
 
 /* functions */
 
 int create_socket();
-int report_domain_status();
-int join_vlan();
+int mrp_monitor(void);
+int report_domain_status(int *class_id, int *priority, u_int16_t *vid);
+//int report_domain_status();
+//int join_vlan();
+int join_vlan(u_int16_t vid);
 int await_talker();
 int send_ready();
 int send_leave();
 int mrp_disconnect();
+int mrp_get_domain(int *class_a_id, int *a_priority, u_int16_t * a_vid, int *class_b_id, int *b_priority, u_int16_t * b_vid);
 
 #endif /* _LISTENER_MRP_CLIENT_H_ */

--- a/examples/common/talker_mrp_client.c
+++ b/examples/common/talker_mrp_client.c
@@ -3,30 +3,30 @@
   Copyright (c) 2012, Intel Corporation
   Copyright (c) 2014, Parrot SA
   All rights reserved.
-  
-  Redistribution and use in source and binary forms, with or without 
+
+  Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:
-  
-   1. Redistributions of source code must retain the above copyright notice, 
+
+   1. Redistributions of source code must retain the above copyright notice,
       this list of conditions and the following disclaimer.
-  
-   2. Redistributions in binary form must reproduce the above copyright 
-      notice, this list of conditions and the following disclaimer in the 
+
+   2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
       documentation and/or other materials provided with the distribution.
-  
-   3. Neither the name of the Intel Corporation nor the names of its 
-      contributors may be used to endorse or promote products derived from 
+
+   3. Neither the name of the Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived from
       this software without specific prior written permission.
-  
+
   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
-  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
   POSSIBILITY OF SUCH DAMAGE.
 
@@ -512,7 +512,6 @@ int mrp_get_domain(int *class_a_id, int *a_priority, u_int16_t * a_vid,
 {
 	char *msgbuf;
 	int ret;
-	printf("Inside mrp_get_domain()\n");
 
 	/* we may not get a notification if we are joining late,
 	 * so query for what is already there ...
@@ -534,9 +533,7 @@ int mrp_get_domain(int *class_a_id, int *a_priority, u_int16_t * a_vid,
 	*class_b_id = 0;
 	*b_priority = 0;
 	*b_vid = 0;
-	printf("domain_a_valid - %d",domain_a_valid);
 	if (domain_a_valid) {
-	    printf("Inside if - domain_a_valid\n");
 		*class_a_id = domain_class_a_id;
 		*a_priority = domain_class_a_priority;
 		*a_vid = domain_class_a_vid;
@@ -549,7 +546,7 @@ int mrp_get_domain(int *class_a_id, int *a_priority, u_int16_t * a_vid,
 	return 0;
 }
 
-int mrp_join_vlan()
+int mrp_join_vlan(u_int16_t vid)
 {
 	char *msgbuf;
 	int rc;
@@ -558,7 +555,7 @@ int mrp_join_vlan()
 	if (NULL == msgbuf)
 		return -1;
 	memset(msgbuf, 0, 1500);
-	sprintf(msgbuf, "V++:I=0002");
+	sprintf(msgbuf, "V++:I=%04x\n",vid);
 	rc = send_mrp_msg(msgbuf, 1500);
 	free(msgbuf);
 
@@ -597,4 +594,3 @@ int recv_mrp_okay()
 		usleep(20000);
 	return 0;
 }
-

--- a/examples/common/talker_mrp_client.c
+++ b/examples/common/talker_mrp_client.c
@@ -512,6 +512,7 @@ int mrp_get_domain(int *class_a_id, int *a_priority, u_int16_t * a_vid,
 {
 	char *msgbuf;
 	int ret;
+	printf("Inside mrp_get_domain()\n");
 
 	/* we may not get a notification if we are joining late,
 	 * so query for what is already there ...
@@ -533,7 +534,9 @@ int mrp_get_domain(int *class_a_id, int *a_priority, u_int16_t * a_vid,
 	*class_b_id = 0;
 	*b_priority = 0;
 	*b_vid = 0;
+	printf("domain_a_valid - %d",domain_a_valid);
 	if (domain_a_valid) {
+	    printf("Inside if - domain_a_valid\n");
 		*class_a_id = domain_class_a_id;
 		*a_priority = domain_class_a_priority;
 		*a_vid = domain_class_a_vid;

--- a/examples/common/talker_mrp_client.c
+++ b/examples/common/talker_mrp_client.c
@@ -40,27 +40,10 @@
 
 
 
-extern struct talker_context global_struct_talker;
+struct talker_context global_struct_talker;
 
 volatile int mrp_okay;
 volatile int mrp_error = 0;;
-
-
-/*int control_socket = -1;
-volatile int halt_tx = 0;
-volatile int listeners = 0;
-volatile int domain_a_valid = 0;
-int domain_class_a_id = 0;
-int domain_class_a_priority = 0;
-u_int16_t domain_class_a_vid = 0;
-
-volatile int domain_b_valid = 0;
-int domain_class_b_id = 0;
-int domain_class_b_priority = 0;
-u_int16_t domain_class_b_vid = 0;
-unsigned char monitor_stream_id[] = { 0, 0, 0, 0, 0, 0, 0, 0 };*/
-
-
 pthread_t monitor_thread;
 pthread_attr_t monitor_attr;
 
@@ -68,7 +51,7 @@ pthread_attr_t monitor_attr;
 /*
  * private
  */
- 
+
 int mrp_talker_client_init(void)
 {
 	int i;

--- a/examples/common/talker_mrp_client.h
+++ b/examples/common/talker_mrp_client.h
@@ -54,9 +54,27 @@
 
 // TODO move these in a talker_context struct + init func
 
-extern volatile int halt_tx;
-extern volatile int listeners;
+struct talker_context
+{
+	int control_socket;
+	volatile int halt_tx;
+	volatile int domain_a_valid;
+	int domain_class_a_id;
+	int domain_class_a_priority;
+	u_int16_t domain_class_a_vid;
+	volatile int domain_b_valid;
+	int domain_class_b_id;
+	int domain_class_b_priority;
+	u_int16_t domain_class_b_vid;
+	unsigned char monitor_stream_id[8];
+	volatile int listeners;
+}global_struct_talker;
+
+extern struct talker_context global_struct_talker;
 extern volatile int mrp_error;
+/*extern volatile int halt_tx;
+extern volatile int listeners;
+
 
 extern volatile int domain_a_valid;
 extern int domain_class_a_id;
@@ -66,7 +84,7 @@ extern u_int16_t domain_class_a_vid;
 extern volatile int domain_b_valid;
 extern int domain_class_b_id;
 extern int domain_class_b_priority;
-extern u_int16_t domain_class_b_vid;
+extern u_int16_t domain_class_b_vid;*/
 
 /* functions */
 
@@ -79,5 +97,5 @@ int mrp_advertise_stream(uint8_t * streamid, uint8_t * destaddr, u_int16_t vlan,
 int mrp_unadvertise_stream(uint8_t * streamid, uint8_t * destaddr, u_int16_t vlan, int pktsz, int interval, int priority, int latency);
 int mrp_await_listener(unsigned char *streamid);
 int mrp_get_domain(int *class_a_id, int *a_priority, u_int16_t * a_vid, int *class_b_id, int *b_priority, u_int16_t * b_vid);
-
+int mrp_talker_client_init(void);
 #endif /* _TALKER_MRP_CLIENT_H_ */

--- a/examples/common/talker_mrp_client.h
+++ b/examples/common/talker_mrp_client.h
@@ -78,5 +78,6 @@ int mrp_join_vlan(void);
 int mrp_advertise_stream(uint8_t * streamid, uint8_t * destaddr, u_int16_t vlan, int pktsz, int interval, int priority, int latency);
 int mrp_unadvertise_stream(uint8_t * streamid, uint8_t * destaddr, u_int16_t vlan, int pktsz, int interval, int priority, int latency);
 int mrp_await_listener(unsigned char *streamid);
+int mrp_get_domain(int *class_a_id, int *a_priority, u_int16_t * a_vid, int *class_b_id, int *b_priority, u_int16_t * b_vid);
 
 #endif /* _TALKER_MRP_CLIENT_H_ */

--- a/examples/common/talker_mrp_client.h
+++ b/examples/common/talker_mrp_client.h
@@ -3,30 +3,30 @@
   Copyright (c) 2012, Intel Corporation
   Copyright (c) 2014, Parrot SA
   All rights reserved.
-  
-  Redistribution and use in source and binary forms, with or without 
+
+  Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are met:
-  
-   1. Redistributions of source code must retain the above copyright notice, 
+
+   1. Redistributions of source code must retain the above copyright notice,
       this list of conditions and the following disclaimer.
-  
-   2. Redistributions in binary form must reproduce the above copyright 
-      notice, this list of conditions and the following disclaimer in the 
+
+   2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
       documentation and/or other materials provided with the distribution.
-  
-   3. Neither the name of the Intel Corporation nor the names of its 
-      contributors may be used to endorse or promote products derived from 
+
+   3. Neither the name of the Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived from
       this software without specific prior written permission.
-  
+
   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
-  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
   POSSIBILITY OF SUCH DAMAGE.
 
@@ -74,7 +74,7 @@ int mrp_connect(void);
 int mrp_disconnect(void);
 int mrp_monitor(void);
 int mrp_register_domain(int *class_id, int *priority, u_int16_t *vid);
-int mrp_join_vlan(void);
+int mrp_join_vlan(u_int16_t vid);
 int mrp_advertise_stream(uint8_t * streamid, uint8_t * destaddr, u_int16_t vlan, int pktsz, int interval, int priority, int latency);
 int mrp_unadvertise_stream(uint8_t * streamid, uint8_t * destaddr, u_int16_t vlan, int pktsz, int interval, int priority, int latency);
 int mrp_await_listener(unsigned char *streamid);

--- a/examples/common/talker_mrp_client.h
+++ b/examples/common/talker_mrp_client.h
@@ -52,7 +52,7 @@
 
 /* global variables */
 
-struct talker_context
+struct mrp_talker_ctx
 {
 	int control_socket;
 	volatile int halt_tx;
@@ -66,21 +66,27 @@ struct talker_context
 	u_int16_t domain_class_b_vid;
 	unsigned char monitor_stream_id[8];
 	volatile int listeners;
-}global_struct_talker;
+};
 
-extern struct talker_context global_struct_talker;
+struct mrp_domain_attr
+{
+	int id;
+	int priority;
+	u_int16_t vid;
+};
+
+
 extern volatile int mrp_error;
 
 /* functions */
 
-int mrp_connect(void);
-int mrp_disconnect(void);
-int mrp_monitor(void);
-int mrp_register_domain(int *class_id, int *priority, u_int16_t *vid);
-int mrp_join_vlan(u_int16_t vid);
-int mrp_advertise_stream(uint8_t * streamid, uint8_t * destaddr, u_int16_t vlan, int pktsz, int interval, int priority, int latency);
-int mrp_unadvertise_stream(uint8_t * streamid, uint8_t * destaddr, u_int16_t vlan, int pktsz, int interval, int priority, int latency);
-int mrp_await_listener(unsigned char *streamid);
-int mrp_get_domain(int *class_a_id, int *a_priority, u_int16_t * a_vid, int *class_b_id, int *b_priority, u_int16_t * b_vid);
-int mrp_talker_client_init(void);
+int mrp_connect(struct mrp_talker_ctx *ctx);
+int mrp_disconnect(struct mrp_talker_ctx *ctx);
+int mrp_register_domain(struct mrp_domain_attr *reg_class, struct mrp_talker_ctx *ctx);
+int mrp_join_vlan(struct mrp_domain_attr *reg_class, struct mrp_talker_ctx *ctx);
+int mrp_advertise_stream(uint8_t * streamid, uint8_t * destaddr, int pktsz, int interval, int latency, struct mrp_talker_ctx *ctx);
+int mrp_unadvertise_stream(uint8_t * streamid, uint8_t * destaddr, int pktsz, int interval, int latency, struct mrp_talker_ctx *ctx);
+int mrp_await_listener(unsigned char *streamid, struct mrp_talker_ctx *ctx);
+int mrp_get_domain(struct mrp_talker_ctx *ctx, struct mrp_domain_attr *class_a, struct mrp_domain_attr *class_b);
+int mrp_talker_client_init(struct mrp_talker_ctx *ctx);
 #endif /* _TALKER_MRP_CLIENT_H_ */

--- a/examples/common/talker_mrp_client.h
+++ b/examples/common/talker_mrp_client.h
@@ -52,8 +52,6 @@
 
 /* global variables */
 
-// TODO move these in a talker_context struct + init func
-
 struct talker_context
 {
 	int control_socket;
@@ -72,19 +70,6 @@ struct talker_context
 
 extern struct talker_context global_struct_talker;
 extern volatile int mrp_error;
-/*extern volatile int halt_tx;
-extern volatile int listeners;
-
-
-extern volatile int domain_a_valid;
-extern int domain_class_a_id;
-extern int domain_class_a_priority;
-extern u_int16_t domain_class_a_vid;
-
-extern volatile int domain_b_valid;
-extern int domain_class_b_id;
-extern int domain_class_b_priority;
-extern u_int16_t domain_class_b_vid;*/
 
 /* functions */
 

--- a/examples/jackd-listener/Makefile
+++ b/examples/jackd-listener/Makefile
@@ -2,7 +2,7 @@ CC ?= gcc
 OPT = -O2 -g
 CFLAGS = $(OPT) -Wall -Wextra -Wno-parentheses -std=gnu99
 INCFLAGS = -I../../daemons/mrpd -I../common -I../../daemons/common
-LDLIBS = -lpcap -lsndfile -ljack
+LDLIBS = -lpcap -lsndfile -ljack -lpthread
 
 all: jack_listener
 

--- a/examples/jackd-talker/Makefile
+++ b/examples/jackd-talker/Makefile
@@ -1,6 +1,6 @@
 CC ?= gcc
 OPT = -O2 -g
-CFLAGS = $(OPT) -Wall -Wextra -Wno-parentheses -std=gnu99
+CFLAGS = $(OPT) $(INCFLAGS) -Wall -Wextra -Wno-parentheses -std=gnu99
 INCFLAGS = -I../../lib/igb -I../../daemons/mrpd -I../common -I../../daemons/common
 LDLIBS = -ligb -lpci -lrt -pthread -ljack
 LDFLAGS = -L../../lib/igb
@@ -24,4 +24,3 @@ jackd_talker.o: jackd_talker.c defines.h jack.h
 clean:
 	$(RM) jackd_talker
 	$(RM) `find . -name "*~" -o -name "*.[oa]" -o -name "\#*\#" -o -name TAGS -o -name core -o -name "*.orig"`
-

--- a/examples/jackd-talker/jack.c
+++ b/examples/jackd-talker/jack.c
@@ -8,9 +8,8 @@
 #include <jack/ringbuffer.h>
 #include "jack.h"
 #include "defines.h"
+#include "talker_mrp_client.h"
 
-extern volatile int halt_tx;
-extern volatile int listeners;
 extern volatile int glob_unleash_jack;
 
 static jack_port_t** inputports;
@@ -30,18 +29,18 @@ static int process(jack_nframes_t nframes, void* arg)
 {
 	int cnt;
 	static int total;
-	(void) arg; /* unused */
+	struct mrp_talker_ctx *ctx = (struct mrp_talker_ctx *) arg;
 
 	/* Do nothing until we're ready to begin. */
 	if (!glob_unleash_jack) {
 		printf ("nothing to do\n");
 		return 0;
 	}
-	
+
 	for(int i = 0; i < CHANNELS; i++) {
 		in[i] = jack_port_get_buffer(inputports[i], nframes);
 	}
-		
+
 	for (size_t i = 0; i < nframes; i++) {
 		for(int j = 0; j < CHANNELS; j++) {
 			total++;
@@ -54,7 +53,7 @@ static int process(jack_nframes_t nframes, void* arg)
 			} else {
 				printf ("Only %i bytes available after %i samples\n",
 						cnt, total);
-				halt_tx = 1;
+				ctx->halt_tx = 1;
 			}
 		}
 	}
@@ -70,13 +69,13 @@ static int process(jack_nframes_t nframes, void* arg)
 
 void jack_shutdown(void* arg)
 {
-	(void) arg; /* unused */
+	struct mrp_talker_ctx *ctx = (struct mrp_talker_ctx *) arg;
 
 	printf("JACK shutdown\n");
-	halt_tx = 1;
+	ctx->halt_tx = 1;
 }
 
-jack_client_t* init_jack(void)
+jack_client_t* init_jack(struct mrp_talker_ctx *ctx)
 {
 	jack_client_t *client;
 	const char *client_name = "simple_talker";
@@ -98,8 +97,8 @@ jack_client_t* init_jack(void)
 		fprintf (stderr, "unique name `%s' assigned\n", client_name);
 	}
 
-	jack_set_process_callback(client, process, 0);
-	jack_on_shutdown(client, jack_shutdown, 0);
+	jack_set_process_callback(client, process, (void *)ctx);
+	jack_on_shutdown(client, jack_shutdown, (void *)ctx);
 
 	if (jack_activate (client))
 		fprintf (stderr, "cannot activate client");
@@ -115,15 +114,15 @@ jack_client_t* init_jack(void)
 	for(int i = 0; i < CHANNELS; i++)
 	{
 		char* portName;
-		if (asprintf(&portName, "input%d", i) < 0) 
+		if (asprintf(&portName, "input%d", i) < 0)
 		{
 			fprintf(stderr, "Could not create portname for port %d", i);
 			exit(EXIT_FAILURE);
-		}	
-		
+		}
+
 		inputports[i] = jack_port_register (client, portName,
 				JACK_DEFAULT_AUDIO_TYPE, JackPortIsInput, 0);
-		if (NULL == inputports[i]) 
+		if (NULL == inputports[i])
 		{
 			fprintf (stderr, "cannot register input port \"%d\"!\n", i);
 			jack_client_close (client);

--- a/examples/jackd-talker/jack.h
+++ b/examples/jackd-talker/jack.h
@@ -2,9 +2,10 @@
 #define _AVB_JACK_H
 
 #define DEFAULT_RINGBUFFER_SIZE 32768
+extern struct mrp_talker_ctx *ctx;
 
 /* Prototypes */
-jack_client_t* init_jack(void);
+jack_client_t* init_jack(struct mrp_talker_ctx *ctx);
 void stop_jack(jack_client_t* client);
 
 #endif /* _AVB_JACK_H */

--- a/examples/simple_listener/Makefile
+++ b/examples/simple_listener/Makefile
@@ -2,7 +2,7 @@ CC ?= gcc
 OPT = -O2 -g
 CFLAGS = $(OPT) -Wall -Wextra -Wno-parentheses
 INCFLAGS = -I../../daemons/mrpd -I../common -I../../daemons/common
-LDLIBS = -lpcap -lsndfile
+LDLIBS = -lpcap -lsndfile -pthread
 
 all: simple_listener
 

--- a/examples/simple_listener/simple_listener.c
+++ b/examples/simple_listener/simple_listener.c
@@ -174,7 +174,7 @@ int main(int argc, char *argv[])
 	char* dev = NULL;
 	char errbuf[PCAP_ERRBUF_SIZE];
 	struct bpf_program comp_filter_exp;		/* The compiled filter expression */
-	char filter_exp[] = "ether dst 91:E0:F0:00:0e:80";	/* The filter expression */
+	char filter_exp[100];				/* The filter expression */
 	int rc, class_a_id, a_priority, class_b_id, b_priority;
 	u_int16_t a_vid,b_vid;
 
@@ -284,6 +284,7 @@ int main(int argc, char *argv[])
 	fprintf(stdout,"Got session pcap handler.\n");
 #endif /* DEBUG */
 	/* compile and apply filter */
+	sprintf(filter_exp,"ether dst %02x:%02x:%02x:%02x:%02x:%02x",dst_mac[0],dst_mac[1],dst_mac[2],dst_mac[3],dst_mac[4],dst_mac[5]);
 	if (-1 == pcap_compile(glob_pcap_handle, &comp_filter_exp, filter_exp, 0, PCAP_NETMASK_UNKNOWN))
 	{
 		fprintf(stderr, "Could not parse filter %s: %s\n", filter_exp, pcap_geterr(glob_pcap_handle));

--- a/examples/simple_listener/simple_listener.c
+++ b/examples/simple_listener/simple_listener.c
@@ -73,7 +73,7 @@ static void help()
 		"Options:\n"
 		"    -h  show this message\n"
 		"    -i  specify interface for AVB connection\n"
-		"    -f  set the name of the output wav-file\n" 
+		"    -f  set the name of the output wav-file\n"
 		"\n" "%s" "\n", version_str);
 	exit(EXIT_FAILURE);
 }
@@ -99,7 +99,7 @@ void pcap_callback(u_char* args, const struct pcap_pkthdr* packet_header, const 
 #endif /* DEBUG*/
 
 	if (0 == memcmp(glob_ether_type,eth_header->type,sizeof(eth_header->type)))
-	{		
+	{
 		test_stream_id = (unsigned char*)(packet + ETHERNET_HEADER_SIZE + SEVENTEEN22_HEADER_PART1_SIZE);
 
 #if DEBUG
@@ -118,7 +118,7 @@ void pcap_callback(u_char* args, const struct pcap_pkthdr* packet_header, const 
 #endif /* DEBUG*/
 			buf = (uint32_t*) (packet + HEADER_SIZE);
 			for(i = 0; i < SAMPLES_PER_FRAME * CHANNELS; i += 2)
-			{	
+			{
 				memcpy(&frame[0], &buf[i], sizeof(frame));
 
 				frame[0] = ntohl(frame[0]);   /* convert to host-byte order */
@@ -130,7 +130,7 @@ void pcap_callback(u_char* args, const struct pcap_pkthdr* packet_header, const 
 
 				sf_writef_int(glob_snd_file, (const int *)frame, 1);
 			}
-		}	
+		}
 	}
 }
 
@@ -161,7 +161,7 @@ void sigint_handler(int signum)
 		pcap_close(glob_pcap_handle);
 	}
 #endif /* PCAP */
-	
+
 #if LIBSND
 	sf_write_sync(glob_snd_file);
 	sf_close(glob_snd_file);
@@ -181,11 +181,11 @@ int main(int argc, char *argv[])
 	signal(SIGINT, sigint_handler);
 
 	int c;
-	while((c = getopt(argc, argv, "hi:f:")) > 0) 
+	while((c = getopt(argc, argv, "hi:f:")) > 0)
 	{
-		switch (c) 
+		switch (c)
 		{
-		case 'h': 
+		case 'h':
 			help();
 			break;
 		case 'i':
@@ -211,10 +211,9 @@ int main(int argc, char *argv[])
 	rc = mrp_monitor();
 	if (rc)
 	{
-		printf("failed creating MRG monitor thread\n");
+		printf("failed creating MRP monitor thread\n");
 		return EXIT_FAILURE;
 	}
-	//printf("Before get_domain\n");
 	rc=mrp_get_domain(&class_a_id, &a_priority, &a_vid, &class_b_id, &b_priority, &b_vid);
 	if (rc)
 	{
@@ -225,21 +224,19 @@ int main(int argc, char *argv[])
 	printf("detected domain Class A PRIO=%d VID=%04x...\n",a_priority,a_vid);
 
 	rc = report_domain_status(&class_a_id,&a_priority,&a_vid);
-	//rc = report_domain_status();
 	if (rc) {
 		printf("report_domain_status failed\n");
 		return EXIT_FAILURE;
 	}
 
 	rc = join_vlan(a_vid);
-	//rc = join_vlan();
 	if (rc) {
 		printf("join_vlan failed\n");
 		return EXIT_FAILURE;
 	}
 
 	fprintf(stdout,"Waiting for talker...\n");
-	await_talker();	
+	await_talker();
 
 #if DEBUG
 	fprintf(stdout,"Send ready-msg...\n");
@@ -249,12 +246,12 @@ int main(int argc, char *argv[])
 		printf("send_ready failed\n");
 		return EXIT_FAILURE;
 	}
-		
+
 #if LIBSND
 	SF_INFO* sf_info = (SF_INFO*)malloc(sizeof(SF_INFO));
 
 	memset(sf_info, 0, sizeof(SF_INFO));
-	
+
 	sf_info->samplerate = SAMPLES_PER_SECOND;
 	sf_info->channels = CHANNELS;
 	sf_info->format = SF_FORMAT_WAV | SF_FORMAT_PCM_24;
@@ -264,13 +261,13 @@ int main(int argc, char *argv[])
 		fprintf(stderr, "Wrong format.");
 		return EXIT_FAILURE;
 	}
-			
+
 	if (NULL == (glob_snd_file = sf_open(file_name, SFM_WRITE, sf_info)))
 	{
 		fprintf(stderr, "Could not create file.");
 		return EXIT_FAILURE;
 	}
-	fprintf(stdout,"Created file called %s\n", file_name);	
+	fprintf(stdout,"Created file called %s\n", file_name);
 #endif /* LIBSND */
 
 #if PCAP

--- a/examples/simple_listener/simple_listener.c
+++ b/examples/simple_listener/simple_listener.c
@@ -110,7 +110,7 @@ void pcap_callback(u_char* args, const struct pcap_pkthdr* packet_header, const 
 			     test_stream_id[6], test_stream_id[7]);
 #endif /* DEBUG*/
 
-		if (0 == memcmp(test_stream_id, stream_id, sizeof(STREAM_ID_SIZE)))
+		if (0 == memcmp(test_stream_id, global_struct_listener.stream_id, sizeof(STREAM_ID_SIZE)))
 		{
 
 #if DEBUG
@@ -140,15 +140,15 @@ void sigint_handler(int signum)
 
 	fprintf(stdout,"Received signal %d:leaving...\n", signum);
 
-	if (0 != talker) {
+	if (0 != global_struct_listener.talker) {
 		ret = send_leave();
 		if (ret)
 			printf("send_leave failed\n");
 	}
 
-	if (2 > control_socket)
+	if (2 > global_struct_listener.control_socket)
 	{
-		close(control_socket);
+		close(global_struct_listener.control_socket);
 		ret = mrp_disconnect();
 		if (ret)
 			printf("mrp_disconnect failed\n");
@@ -201,6 +201,13 @@ int main(int argc, char *argv[])
 
 	if ((NULL == dev) || (NULL == file_name))
 		help();
+
+	rc = mrp_listener_client_init();
+	if (rc)
+	{
+		printf("failed to initialize global variables\n");
+		return EXIT_FAILURE;
+	}
 
 	if (create_socket())
 	{
@@ -284,7 +291,7 @@ int main(int argc, char *argv[])
 	fprintf(stdout,"Got session pcap handler.\n");
 #endif /* DEBUG */
 	/* compile and apply filter */
-	sprintf(filter_exp,"ether dst %02x:%02x:%02x:%02x:%02x:%02x",dst_mac[0],dst_mac[1],dst_mac[2],dst_mac[3],dst_mac[4],dst_mac[5]);
+	sprintf(filter_exp,"ether dst %02x:%02x:%02x:%02x:%02x:%02x",global_struct_listener.dst_mac[0],global_struct_listener.dst_mac[1],global_struct_listener.dst_mac[2],global_struct_listener.dst_mac[3],global_struct_listener.dst_mac[4],global_struct_listener.dst_mac[5]);
 	if (-1 == pcap_compile(glob_pcap_handle, &comp_filter_exp, filter_exp, 0, PCAP_NETMASK_UNKNOWN))
 	{
 		fprintf(stderr, "Could not parse filter %s: %s\n", filter_exp, pcap_geterr(glob_pcap_handle));

--- a/examples/simple_talker/simple_talker.c
+++ b/examples/simple_talker/simple_talker.c
@@ -479,6 +479,7 @@ int main(int argc, char *argv[])
 	uint8_t dest_addr[6];
 	size_t packet_size;
 
+
 	for (;;) {
 		c = getopt(argc, argv, "hi:t:");
 		if (c < 0)
@@ -489,8 +490,7 @@ int main(int argc, char *argv[])
 			break;
 		case 'i':
 			if (interface) {
-				printf
-				    ("only one interface per daemon is supported\n");
+			printf("only one interface per daemon is supported\n");
 				usage();
 			}
 			interface = strdup(optarg);
@@ -578,10 +578,17 @@ int main(int argc, char *argv[])
 	/* 
 	 * should use mrp_get_domain() but this is a simplification
 	 */
-	domain_a_valid = 1;
+	/*domain_a_valid = 1;
 	domain_class_a_id = MSRP_SR_CLASS_A;
 	domain_class_a_priority = MSRP_SR_CLASS_A_PRIO;
-	domain_class_a_vid = 2;
+	domain_class_a_vid = 2;*/
+	
+	//Using mrp_get_domain() - Srinath
+	rc = mrp_get_domain(&domain_class_a_id, &domain_class_a_priority, &domain_class_a_vid,&domain_class_b_id, &domain_class_b_priority, &domain_class_b_vid);
+	if (rc) {
+		printf("failed calling msp_get_domain()\n");
+		return EXIT_FAILURE;
+	}
 	printf("detected domain Class A PRIO=%d VID=%04x...\n", domain_class_a_priority,
 	       domain_class_a_vid);
 

--- a/examples/simple_talker/simple_talker.c
+++ b/examples/simple_talker/simple_talker.c
@@ -510,9 +510,13 @@ int main(int argc, char *argv[])
 		fprintf( stderr, "Must specify valid transport\n" );
 		usage();
 	}
-	
-	mrp_talker_client_init();
-	
+
+	rc = mrp_talker_client_init();
+	if (rc) {
+		printf("MRP talker client initialization failed\n");
+		return errno;
+	}
+
 	rc = mrp_connect();
 	if (rc) {
 		printf("socket creation failed\n");

--- a/kill_process.sh
+++ b/kill_process.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+kill `pgrep simple_talker`
+kill `pgrep daemon_cl`
+kill `pgrep msrp`
+

--- a/kill_process.sh
+++ b/kill_process.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-kill `pgrep simple_talker`
-kill `pgrep daemon_cl`
-kill `pgrep msrp`
-

--- a/kmod/igb/startup.sh
+++ b/kmod/igb/startup.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 
 # Network interface name (e.g. Fedora=p2p1, Ubuntu=eth2, OpenSUSE=ens01)
-#INTERFACE=p2p1
-#Changed INTERFACE for Ubuntu
-INTERFACE=eth3
+INTERFACE=p2p1
 
 # Replace default interface if provided by argument
 if [ -n "$1" ]

--- a/kmod/igb/startup.sh
+++ b/kmod/igb/startup.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 # Network interface name (e.g. Fedora=p2p1, Ubuntu=eth2, OpenSUSE=ens01)
-INTERFACE=p2p1
+#INTERFACE=p2p1
+#Changed INTERFACE for Ubuntu
+INTERFACE=eth3
 
 # Replace default interface if provided by argument
 if [ -n "$1" ]


### PR DESCRIPTION
Simple talker and simple listener look for the advertiserd stream id and vlan id instead of using default hardcoded values. The gPTP daemon has a CLI interface for PHY delays instead of using hardcoded values for i20 card. Refactored global variables into a context structure.

I am an intern at HARMAN and I worked with Craig and Levi when doing these changes.