### PR TITLE
Added function igb_get_mac_addr().

### DIFF
--- a/lib/igb/igb.c
+++ b/lib/igb/igb.c
@@ -1537,3 +1537,18 @@ igb_set_class_bandwidth2(device_t *dev,
 	return error;
 }
 
+int igb_get_mac_addr(device_t *dev, u_int8_t mac_addr[ETH_ADDR_LEN])
+{
+	struct adapter	*adapter;
+	struct e1000_hw *hw;
+
+	if (NULL == dev) return EINVAL;
+	adapter = (struct adapter *)dev->private_data;
+	if (NULL == adapter) return ENXIO;
+
+	hw = &adapter->hw;
+
+	memcpy(mac_addr, hw->mac.addr, ETH_ADDR_LEN);
+	return 0;
+}
+

--- a/lib/igb/igb.h
+++ b/lib/igb/igb.h
@@ -100,6 +100,8 @@ void	igb_writereg(device_t *dev, u_int32_t reg, u_int32_t data);
 int igb_lock( device_t *dev );
 int igb_unlock( device_t *dev );
 
+int igb_get_mac_addr(device_t *dev, u_int8_t mac_addr[6]);
+
 #endif /* _IGB_H_DEFINED_ */
 
 


### PR DESCRIPTION
libigb reads mac address from hardware but doesn't provide function to access it. This pull request adds such function.