### PR TITLE
gptplocaltime() function added.

### DIFF
--- a/daemons/gptp/linux/src/ipcdef.hpp
+++ b/daemons/gptp/linux/src/ipcdef.hpp
@@ -47,7 +47,7 @@ typedef struct {
 	int64_t ls_phoffset;			//!< Local to system phase offset
 	FrequencyRatio ml_freqoffset;	//!< Master to local frequency offset
 	FrequencyRatio ls_freqoffset;	//!< Local to system frequency offset
-	int64_t local_time;				//!< Local time of last update
+	uint64_t local_time;				//!< Local time of last update
 	uint32_t sync_count;			//!< Sync messages count
 	uint32_t pdelay_count;			//!< pdelay messages count
 	PortState port_state;			//!< gPTP port state. It can assume values defined at ::PortState

--- a/daemons/gptp/windows/daemon_cl/ipcdef.hpp
+++ b/daemons/gptp/windows/daemon_cl/ipcdef.hpp
@@ -53,7 +53,7 @@ typedef struct {
 	int64_t ls_phoffset;
 	FrequencyRatio ml_freqoffset;
 	FrequencyRatio ls_freqoffset;
-	int64_t local_time;
+	uint64_t local_time;
 	uint32_t sync_count;
 	uint32_t pdelay_count;
 	PortState port_state;

--- a/examples/common/avb.c
+++ b/examples/common/avb.c
@@ -151,7 +151,7 @@ bool gptplocaltime(const gPtpTimeData * td, uint64_t* now_local)
 	if (clock_gettime(CLOCK_REALTIME, &sys_time) != 0)
 		return false;
 
-	now_system = sys_time.tv_sec * 1000000000 + sys_time.tv_nsec;
+	now_system = (uint64_t)sys_time.tv_sec * 1000000000ULL + (uint64_t)sys_time.tv_nsec;
 
 	system_time = td->local_time + td->ls_phoffset;
 	delta_system = now_system - system_time;

--- a/examples/common/avb.c
+++ b/examples/common/avb.c
@@ -137,6 +137,30 @@ int gptpscaling(gPtpTimeData * td, char *memory_offset_buffer)
 	return true;
 }
 
+bool gptplocaltime(const gPtpTimeData * td, uint64_t* now_local)
+{
+	struct timespec sys_time;
+	uint64_t now_system;
+	uint64_t system_time;
+	int64_t delta_local;
+	int64_t delta_system;
+
+	if (!td || !now_local)
+		return false;
+
+	if (clock_gettime(CLOCK_REALTIME, &sys_time) != 0)
+		return false;
+
+	now_system = sys_time.tv_sec * 1000000000 + sys_time.tv_nsec;
+
+	system_time = td->local_time + td->ls_phoffset;
+	delta_system = now_system - system_time;
+	delta_local = td->ls_freqoffset * delta_system;
+	*now_local = td->local_time + delta_local;
+
+	return true;
+}
+
 /* setters & getters for seventeen22_header */
 void avb_set_1722_cd_indicator(seventeen22_header *h1722, uint64_t cd_indicator)
 {

--- a/examples/common/avb.c
+++ b/examples/common/avb.c
@@ -129,9 +129,9 @@ int gptpscaling(gPtpTimeData * td, char *memory_offset_buffer)
 	memcpy(td, memory_offset_buffer + sizeof(pthread_mutex_t), sizeof(*td));
 	pthread_mutex_unlock((pthread_mutex_t *) memory_offset_buffer);
 
-	fprintf(stderr, "ml_phoffset = %lld, ls_phoffset = %lld\n",
+	fprintf(stderr, "ml_phoffset = %" PRId64 ", ls_phoffset = %" PRId64 "\n",
 		td->ml_phoffset, td->ls_phoffset);
-	fprintf(stderr, "ml_freqffset = %d, ls_freqoffset = %d\n",
+	fprintf(stderr, "ml_freqffset = %Lf, ls_freqoffset = %Lf\n",
 		td->ml_freqoffset, td->ls_freqoffset);
 
 	return true;

--- a/examples/common/avb.h
+++ b/examples/common/avb.h
@@ -105,7 +105,7 @@ typedef struct {
 	int64_t ls_phoffset;
 	FrequencyRatio ml_freqoffset;
 	FrequencyRatio ls_freqoffset;
-	int64_t local_time;
+	uint64_t local_time;
 } gPtpTimeData;
 
 typedef enum { false = 0, true = 1 } bool;

--- a/examples/common/avb.h
+++ b/examples/common/avb.h
@@ -112,6 +112,8 @@ int pci_connect(device_t * igb_dev);
 
 int gptpscaling(gPtpTimeData * td, char *memory_offset_buffer);
 
+bool gptplocaltime(const gPtpTimeData * td, uint64_t* now_local);
+
 void gptpdeinit(int shm_fd, char *memory_offset_buffer);
 
 int gptpinit(int *shm_fd, char **memory_offset_buffer);

--- a/examples/common/avb.h
+++ b/examples/common/avb.h
@@ -98,11 +98,13 @@ typedef struct __attribute__ ((packed)) {
 	uint8_t h_protocol[2];
 } eth_header;
 
+typedef long double FrequencyRatio;
+
 typedef struct { 
 	int64_t ml_phoffset;
 	int64_t ls_phoffset;
-	int32_t ml_freqoffset;
-	int32_t ls_freqoffset;
+	FrequencyRatio ml_freqoffset;
+	FrequencyRatio ls_freqoffset;
 	int64_t local_time;
 } gPtpTimeData;
 

--- a/examples/jackd-talker/jackd_talker.c
+++ b/examples/jackd-talker/jackd_talker.c
@@ -72,7 +72,7 @@ typedef struct {
 	int64_t ls_phoffset;
 	FrequencyRatio ml_freqoffset;
 	FrequencyRatio ls_freqoffset;
-	int64_t local_time;
+	uint64_t local_time;
 } gPtpTimeData;
 
 typedef struct __attribute__ ((packed)) {

--- a/examples/jackd-talker/jackd_talker.c
+++ b/examples/jackd-talker/jackd_talker.c
@@ -65,12 +65,14 @@
 #define PACKET_IPG (125000) /* (1) packet every 125 usec */
 #define PKT_SZ (100)
 
-typedef struct { 
-  int64_t ml_phoffset;
-  int64_t ls_phoffset;
-  long double ml_freqoffset;
-  long double ls_freqoffset;
-  int64_t local_time;
+typedef long double FrequencyRatio;
+
+typedef struct {
+	int64_t ml_phoffset;
+	int64_t ls_phoffset;
+	FrequencyRatio ml_freqoffset;
+	FrequencyRatio ls_freqoffset;
+	int64_t local_time;
 } gPtpTimeData;
 
 typedef struct __attribute__ ((packed)) {

--- a/examples/simple_talker/simple_talker.c
+++ b/examples/simple_talker/simple_talker.c
@@ -79,7 +79,7 @@ typedef struct {
 	int64_t ls_phoffset;
 	FrequencyRatio ml_freqoffset;
 	FrequencyRatio ls_freqoffset;
-	int64_t local_time;
+	uint64_t local_time;
 } gPtpTimeData;
 
 typedef struct __attribute__ ((packed)) {

--- a/examples/simple_talker/simple_talker.c
+++ b/examples/simple_talker/simple_talker.c
@@ -72,12 +72,14 @@
 #define L4_PORT ((uint16_t)5004)
 #define PKT_SZ (100)
 
+typedef long double FrequencyRatio;
+
 typedef struct {
-  int64_t ml_phoffset;
-  int64_t ls_phoffset;
-  long double ml_freqoffset;
-  long double ls_freqoffset;
-  uint64_t local_time;
+	int64_t ml_phoffset;
+	int64_t ls_phoffset;
+	FrequencyRatio ml_freqoffset;
+	FrequencyRatio ls_freqoffset;
+	int64_t local_time;
 } gPtpTimeData;
 
 typedef struct __attribute__ ((packed)) {


### PR DESCRIPTION
It can be used to quickly get localtime calculated from current system time and values provided by gptp deamon (frequency offsets and phase offsets).