### PR TITLE
Create pool of tx buffers from multiple dma pages.

### DIFF
--- a/lib/avtp_pipeline/platform/Linux/rawsock/igb_rawsock.c
+++ b/lib/avtp_pipeline/platform/Linux/rawsock/igb_rawsock.c
@@ -151,7 +151,7 @@ U8 *igbRawsockGetTxFrame(void *pvRawsock, bool blocking, unsigned int *len)
 
 	U8 *ret = NULL;
 
-	rawsock->tx_packet = igbGetTxPacket(rawsock->igb_dev, rawsock->queue);
+	rawsock->tx_packet = igbGetTxPacket(rawsock->igb_dev);
 
 	if (rawsock->tx_packet) {
 		*len = rawsock->base.frameSize;
@@ -217,4 +217,15 @@ int igbRawsockSend(void *pvRawsock)
 
 	AVB_TRACE_EXIT(AVB_TRACE_RAWSOCK_DETAIL);
 	return 1;
+}
+
+int igbRawsockTxBufLevel(void *pvRawsock)
+{
+	AVB_TRACE_ENTRY(AVB_TRACE_RAWSOCK_DETAIL);
+	igb_rawsock_t *rawsock = (igb_rawsock_t*)pvRawsock;
+
+	int nInUse = igbTxBufLevel(rawsock->igb_dev);
+
+	AVB_TRACE_EXIT(AVB_TRACE_RAWSOCK_DETAIL);
+	return nInUse;
 }

--- a/lib/avtp_pipeline/platform/Linux/rawsock/igb_rawsock.c
+++ b/lib/avtp_pipeline/platform/Linux/rawsock/igb_rawsock.c
@@ -150,8 +150,24 @@ U8 *igbRawsockGetTxFrame(void *pvRawsock, bool blocking, unsigned int *len)
 	}
 
 	U8 *ret = NULL;
+	int bBufferBusyReported = 0;
 
-	rawsock->tx_packet = igbGetTxPacket(rawsock->igb_dev);
+	do {
+		rawsock->tx_packet = igbGetTxPacket(rawsock->igb_dev);
+		if (!rawsock->tx_packet && blocking) {
+			if (0 == bBufferBusyReported) {
+				if (!rawsock->txOutOfBuffer) {
+					AVB_LOGF_DEBUG("Getting TX frame (%p): TX buffer busy", rawsock);
+				}
+				++rawsock->txOutOfBuffer;
+				++rawsock->txOutOfBufferCyclic;
+			} else if (1 == bBufferBusyReported) {
+				AVB_LOGF_DEBUG("Getting TX frame (%p): TX buffer busy after usleep(10) verify if there are any late frames", rawsock);
+			}
+			++bBufferBusyReported;
+			usleep(10);
+		}
+	} while (!rawsock->tx_packet && blocking);
 
 	if (rawsock->tx_packet) {
 		*len = rawsock->base.frameSize;
@@ -200,8 +216,7 @@ bool igbRawsockTxFrameReady(void *pvRawsock, U8 *pBuffer, unsigned int len)
 
 	err = igb_xmit(rawsock->igb_dev, rawsock->queue, rawsock->tx_packet);
 	if (err) {
-		IF_LOG_INTERVAL(1000) AVB_LOGF_ERROR("igb_xmit failed: %s", strerror(err));
-		// TODO: what to do in this case? retry?
+		AVB_LOGF_ERROR("igb_xmit failed: %s", strerror(err));
 	}
 
 	AVB_TRACE_EXIT(AVB_TRACE_RAWSOCK_DETAIL);
@@ -229,3 +244,33 @@ int igbRawsockTxBufLevel(void *pvRawsock)
 	AVB_TRACE_EXIT(AVB_TRACE_RAWSOCK_DETAIL);
 	return nInUse;
 }
+
+unsigned long igbRawsockGetTXOutOfBuffers(void *pvRawsock)
+{
+	AVB_TRACE_ENTRY(AVB_TRACE_RAWSOCK);
+	unsigned long counter = 0;
+	igb_rawsock_t *rawsock = (igb_rawsock_t*)pvRawsock;
+
+	if(VALID_TX_RAWSOCK(rawsock)) {
+		counter = rawsock->txOutOfBuffer;
+	}
+
+	AVB_TRACE_EXIT(AVB_TRACE_RAWSOCK);
+	return counter;
+}
+
+unsigned long igbRawsockGetTXOutOfBuffersCyclic(void *pvRawsock)
+{
+	AVB_TRACE_ENTRY(AVB_TRACE_RAWSOCK);
+	unsigned long counter = 0;
+	igb_rawsock_t *rawsock = (igb_rawsock_t*)pvRawsock;
+
+	if(VALID_TX_RAWSOCK(rawsock)) {
+		counter = rawsock->txOutOfBufferCyclic;
+		rawsock->txOutOfBufferCyclic = 0;
+	}
+
+	AVB_TRACE_EXIT(AVB_TRACE_RAWSOCK);
+	return counter;
+}
+

--- a/lib/avtp_pipeline/platform/Linux/rawsock/igb_rawsock.h
+++ b/lib/avtp_pipeline/platform/Linux/rawsock/igb_rawsock.h
@@ -40,6 +40,8 @@ typedef struct {
 	device_t *igb_dev;
 	struct igb_packet *tx_packet;
 	int queue;
+	unsigned long txOutOfBuffer;
+	unsigned long txOutOfBufferCyclic;
 } igb_rawsock_t;
 
 void *igbRawsockOpen(igb_rawsock_t* rawsock, const char *ifname, bool rx_mode, bool tx_mode, U16 ethertype, U32 frame_size, U32 num_frames);
@@ -57,5 +59,9 @@ bool igbRawsockTxFrameReady(void *pvRawsock, U8 *pBuffer, unsigned int len);
 int igbRawsockSend(void *pvRawsock);
 
 int igbRawsockTxBufLevel(void *pvRawsock);
+
+unsigned long igbRawsockGetTXOutOfBuffers(void *pvRawsock);
+
+unsigned long igbRawsockGetTXOutOfBuffersCyclic(void *pvRawsock);
 
 #endif

--- a/lib/avtp_pipeline/platform/Linux/rawsock/igb_rawsock.h
+++ b/lib/avtp_pipeline/platform/Linux/rawsock/igb_rawsock.h
@@ -56,4 +56,6 @@ bool igbRawsockTxFrameReady(void *pvRawsock, U8 *pBuffer, unsigned int len);
 
 int igbRawsockSend(void *pvRawsock);
 
+int igbRawsockTxBufLevel(void *pvRawsock);
+
 #endif

--- a/lib/avtp_pipeline/platform/Linux/rawsock/openavb_rawsock.c
+++ b/lib/avtp_pipeline/platform/Linux/rawsock/openavb_rawsock.c
@@ -194,6 +194,7 @@ void *openavbRawsockOpen(const char *ifname_uri, bool rx_mode, bool tx_mode, U16
 		cb->txFillHdr = baseRawsockTxFillHdr;
 		cb->txFrameReady = igbRawsockTxFrameReady;
 		cb->send = igbRawsockSend;
+		cb->txBufLevel = igbRawsockTxBufLevel;
 		cb->getRxFrame = pcapRawsockGetRxFrame;
 		cb->rxParseHdr = simpleRawsockRxParseHdr;
 		cb->rxMulticast = pcapRawsockRxMulticast;

--- a/lib/avtp_pipeline/platform/Linux/rawsock/openavb_rawsock.c
+++ b/lib/avtp_pipeline/platform/Linux/rawsock/openavb_rawsock.c
@@ -199,6 +199,8 @@ void *openavbRawsockOpen(const char *ifname_uri, bool rx_mode, bool tx_mode, U16
 		cb->rxParseHdr = simpleRawsockRxParseHdr;
 		cb->rxMulticast = pcapRawsockRxMulticast;
 		cb->getAddr = baseRawsockGetAddr;
+		cb->getTXOutOfBuffers = igbRawsockGetTXOutOfBuffers;
+		cb->getTXOutOfBuffersCyclic = igbRawsockGetTXOutOfBuffersCyclic;
 
 		// call constructor
 		pvRawsock = igbRawsockOpen((igb_rawsock_t*)rawsock, ifname, rx_mode, tx_mode, ethertype, frame_size, num_frames);

--- a/lib/avtp_pipeline/platform/x86_i210/openavb_ether_hal.h
+++ b/lib/avtp_pipeline/platform/x86_i210/openavb_ether_hal.h
@@ -36,17 +36,22 @@ https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
 
 #include "igb.h"
 
-#define IGB_MTU 256
-#define IGB_QUEUES 2
+#define IGB_MTU 1522
+
+// how many pages to alloc for tx buffers (2 frames fit in one page)
+#define IGB_PAGES 20
+
 #define IGB_LAUNCHTIME_ENABLED 0
 
 device_t *igbAcquireDevice();
 
 void igbReleaseDevice(device_t *igb_dev);
 
-struct igb_packet *igbGetTxPacket(device_t* dev, int queue);
+struct igb_packet *igbGetTxPacket(device_t* dev);
 
 void igbRelTxPacket(device_t* dev, int queue, struct igb_packet *tx_packet);
+
+int igbTxBufLevel(device_t *dev);
 
 bool igbGetMacAddr(U8 mac_addr[ETH_ALEN]);
 


### PR DESCRIPTION
This allows to run many talkers without any changes to igb_avb driver.