### PR TITLE
New: VLAN ID can be configured for no endpoint builds.

### DIFF
--- a/lib/avtp_pipeline/intf_ctrl/ctrl_talker.ini
+++ b/lib/avtp_pipeline/intf_ctrl/ctrl_talker.ini
@@ -96,6 +96,9 @@ max_transmit_deficit_usec = 50000
 # Ethernet Interface Name. Only needed on some platforms when stack is built with no endpoint functionality
 # ifname = eth0
 
+# vlan_id: VLAN Identifier (1-4094). Used in "no endpoint" builds. Defaults to 2.
+# vlan_id = 2
+
 #####################################################################
 # Mapping module configuration
 #####################################################################

--- a/lib/avtp_pipeline/intf_echo/echo_talker.ini
+++ b/lib/avtp_pipeline/intf_echo/echo_talker.ini
@@ -93,6 +93,9 @@ report_seconds = 1
 # Ethernet Interface Name. Only needed on some platforms when stack is built with no endpoint functionality
 # ifname = eth0
 
+# vlan_id: VLAN Identifier (1-4094). Used in "no endpoint" builds. Defaults to 2.
+# vlan_id = 2
+
 #####################################################################
 # Mapping module configuration
 #####################################################################

--- a/lib/avtp_pipeline/intf_echo/echo_talker_auto.ini
+++ b/lib/avtp_pipeline/intf_echo/echo_talker_auto.ini
@@ -93,6 +93,9 @@ report_seconds = 1
 # Ethernet Interface Name. Only needed on some platforms when stack is built with no endpoint functionality
 # ifname = eth0
 
+# vlan_id: VLAN Identifier (1-4094). Used in "no endpoint" builds. Defaults to 2.
+# vlan_id = 2
+
 #####################################################################
 # Mapping module configuration
 #####################################################################

--- a/lib/avtp_pipeline/intf_null/null_talker.ini
+++ b/lib/avtp_pipeline/intf_null/null_talker.ini
@@ -93,6 +93,9 @@ max_transmit_deficit_usec = 50000
 # Ethernet Interface Name. Only needed on some platforms when stack is built with no endpoint functionality
 # ifname = eth0
 
+# vlan_id: VLAN Identifier (1-4094). Used in "no endpoint" builds. Defaults to 2.
+# vlan_id = 2
+
 #####################################################################
 # Mapping module configuration
 #####################################################################

--- a/lib/avtp_pipeline/intf_tonegen/tonegen_talker.ini
+++ b/lib/avtp_pipeline/intf_tonegen/tonegen_talker.ini
@@ -78,6 +78,9 @@ max_transit_usec = 2000
 # Ethernet Interface Name. Only needed on some platforms when stack is built with no endpoint functionality
 # ifname = eth0
 
+# vlan_id: VLAN Identifier (1-4094). Used in "no endpoint" builds. Defaults to 2.
+# vlan_id = 2
+
 #####################################################################
 # Mapping module configuration
 #####################################################################

--- a/lib/avtp_pipeline/intf_viewer/latency_talker.ini
+++ b/lib/avtp_pipeline/intf_viewer/latency_talker.ini
@@ -103,6 +103,9 @@ max_transmit_deficit_usec = 50000
 # Ethernet Interface Name. Only needed on some platforms when stack is built with no endpoint functionality
 # ifname = eth0
 
+# vlan_id: VLAN Identifier (1-4094). Used in "no endpoint" builds. Defaults to 2.
+# vlan_id = 2
+
 #####################################################################
 # Mapping module configuration
 #####################################################################

--- a/lib/avtp_pipeline/platform/Linux/intf_alsa/aaf_file_talker.ini
+++ b/lib/avtp_pipeline/platform/Linux/intf_alsa/aaf_file_talker.ini
@@ -74,6 +74,9 @@ max_transit_usec = 50000
 # Ethernet Interface Name. Only needed on some platforms when stack is built with no endpoint functionality
 # ifname = eth0
 
+# vlan_id: VLAN Identifier (1-4094). Used in "no endpoint" builds. Defaults to 2.
+# vlan_id = 2
+
 #####################################################################
 # Mapping module configuration
 #####################################################################

--- a/lib/avtp_pipeline/platform/Linux/intf_alsa/aaf_talker.ini
+++ b/lib/avtp_pipeline/platform/Linux/intf_alsa/aaf_talker.ini
@@ -89,6 +89,9 @@ max_transmit_deficit_usec = 50000
 # Ethernet Interface Name. Only needed on some platforms when stack is built with no endpoint functionality
 # ifname = eth0
 
+# vlan_id: VLAN Identifier (1-4094). Used in "no endpoint" builds. Defaults to 2.
+# vlan_id = 2
+
 #####################################################################
 # Mapping module configuration
 #####################################################################

--- a/lib/avtp_pipeline/platform/Linux/intf_alsa/alsa_talker.ini
+++ b/lib/avtp_pipeline/platform/Linux/intf_alsa/alsa_talker.ini
@@ -87,6 +87,9 @@ max_transmit_deficit_usec = 50000
 # Ethernet Interface Name. Only needed on some platforms when stack is built with no endpoint functionality
 # ifname = eth0
 
+# vlan_id: VLAN Identifier (1-4094). Used in "no endpoint" builds. Defaults to 2.
+# vlan_id = 2
+
 #####################################################################
 # Mapping module configuration
 #####################################################################

--- a/lib/avtp_pipeline/platform/Linux/intf_mjpeg_gst/mjpeg_gst_talker.ini
+++ b/lib/avtp_pipeline/platform/Linux/intf_mjpeg_gst/mjpeg_gst_talker.ini
@@ -93,6 +93,9 @@ max_transmit_deficit_usec = 50000
 # Ethernet Interface Name. Only needed on some platforms when stack is built with no endpoint functionality
 # ifname = eth0
 
+# vlan_id: VLAN Identifier (1-4094). Used in "no endpoint" builds. Defaults to 2.
+# vlan_id = 2
+
 #####################################################################
 # Mapping module configuration
 #####################################################################

--- a/lib/avtp_pipeline/platform/Linux/intf_mpeg2ts_file/mpeg2ts_file_talker.ini
+++ b/lib/avtp_pipeline/platform/Linux/intf_mpeg2ts_file/mpeg2ts_file_talker.ini
@@ -93,6 +93,9 @@ raw_rx_buffers = 100
 # Ethernet Interface Name. Only needed on some platforms when stack is built with no endpoint functionality
 # ifname = eth0
 
+# vlan_id: VLAN Identifier (1-4094). Used in "no endpoint" builds. Defaults to 2.
+# vlan_id = 2
+
 #####################################################################
 # Mapping module configuration
 #####################################################################

--- a/lib/avtp_pipeline/platform/Linux/intf_mpeg2ts_gst/mpeg2ts_gst_talker.ini
+++ b/lib/avtp_pipeline/platform/Linux/intf_mpeg2ts_gst/mpeg2ts_gst_talker.ini
@@ -83,6 +83,9 @@ max_transmit_deficit_usec = 50000
 # Ethernet Interface Name. Only needed on some platforms when stack is built with no endpoint functionality
 # ifname = eth0
 
+# vlan_id: VLAN Identifier (1-4094). Used in "no endpoint" builds. Defaults to 2.
+# vlan_id = 2
+
 #####################################################################
 # Mapping module configuration
 #####################################################################

--- a/lib/avtp_pipeline/platform/Linux/intf_wav_file/wav_file_talker.ini
+++ b/lib/avtp_pipeline/platform/Linux/intf_wav_file/wav_file_talker.ini
@@ -78,6 +78,9 @@ max_transit_usec = 2000
 # Ethernet Interface Name. Only needed on some platforms when stack is built with no endpoint functionality
 # ifname = eth0
 
+# vlan_id: VLAN Identifier (1-4094). Used in "no endpoint" builds. Defaults to 2.
+# vlan_id = 2
+
 #####################################################################
 # Mapping module configuration
 #####################################################################

--- a/lib/avtp_pipeline/platform/Linux/tl/openavb_tl_osal.c
+++ b/lib/avtp_pipeline/platform/Linux/tl/openavb_tl_osal.c
@@ -303,6 +303,18 @@ static int openavbTLCfgCallback(void *user, const char *tlSection, const char *n
 			valOK = TRUE;
 		}
 	}
+	else if (MATCH(name, "vlan_id")) {
+		errno = 0;
+		long tmp;
+		tmp = strtol(value, &pEnd, 0);
+		// vlanID is 12 bit field
+		if (*pEnd == '\0' && errno == 0
+			&& tmp >= 0x0
+			&& tmp <= 0xFFF) {
+			pCfg->vlan_id = tmp;
+			valOK = TRUE;
+		}
+	}
 
 	else if (MATCH(name, "map_lib")) {
 		if (pTLState->mapLib.libName)

--- a/lib/avtp_pipeline/tl/openavb_talker_no_endpoint.c
+++ b/lib/avtp_pipeline/tl/openavb_talker_no_endpoint.c
@@ -74,12 +74,14 @@ bool openavbTLRunTalkerInit(tl_state_t *pTLState)
 	pTalkerData->streamID.uniqueID = pCfg->stream_uid;
 	if (pCfg->sr_class == SR_CLASS_A) {
 		pTalkerData->classRate = 8000;
-		pTalkerData->vlanID = SR_CLASS_A_DEFAULT_VID;
+		pTalkerData->vlanID = pCfg->vlan_id == VLAN_NULL ?
+					SR_CLASS_A_DEFAULT_VID : pCfg->vlan_id;
 		pTalkerData->vlanPCP = SR_CLASS_A_DEFAULT_PRIORITY;
 	}
 	else if (pCfg->sr_class == SR_CLASS_B) {
 		pTalkerData->classRate = 4000;
-		pTalkerData->vlanID = SR_CLASS_B_DEFAULT_VID;
+		pTalkerData->vlanID = pCfg->vlan_id == VLAN_NULL ?
+					SR_CLASS_B_DEFAULT_VID : pCfg->vlan_id;
 		pTalkerData->vlanPCP = SR_CLASS_B_DEFAULT_PRIORITY;
 	}
 	memcpy(&pTalkerData->destAddr, &pCfg->dest_addr.mac->ether_addr_octet, ETH_ALEN);

--- a/lib/avtp_pipeline/tl/openavb_tl.c
+++ b/lib/avtp_pipeline/tl/openavb_tl.c
@@ -395,6 +395,7 @@ EXTERN_DLL_EXPORT void openavbTLInitCfg(openavb_tl_cfg_t *pCfg)
 	pCfg->rx_signal_mode = 1;
 	pCfg->pMapInitFn = NULL;
 	pCfg->pIntfInitFn = NULL;
+	pCfg->vlan_id = VLAN_NULL;
 
 	AVB_TRACE_EXIT(AVB_TRACE_TL);
 }

--- a/lib/avtp_pipeline/tl/openavb_tl_pub.h
+++ b/lib/avtp_pipeline/tl/openavb_tl_pub.h
@@ -75,6 +75,9 @@ typedef enum {
 /// Maximum size of interface name
 #define IFNAMSIZE 16
 
+/// Indicatates that VLAN ID is not set in configuration
+#define VLAN_NULL UINT16_MAX
+
 /// Structure containing configuration of the host
 typedef struct {
 	/// Role of the host
@@ -122,6 +125,8 @@ typedef struct {
 	bool tx_blocking_in_intf;
 	/// Network interface name. Not used on all platforms.
 	char ifname[IFNAMSIZE];
+	/// VLAN ID
+	U16 vlan_id;
 	/// When set incoming packets will trigger a signal to the stream task to wakeup.
 	bool rx_signal_mode;
 


### PR DESCRIPTION
Details: You can specify VLAN Identifier in talker ini file.
Syntax is vlan_id = 5; Default value is 2 for both class A and class B streams.