### PR TITLE
daemon_cl: Fixes PPS out-of-phase issue.

### DIFF
--- a/daemons/gptp/linux/src/linux_hal_i210.cpp
+++ b/daemons/gptp/linux/src/linux_hal_i210.cpp
@@ -140,10 +140,6 @@ bool LinuxTimestamperGeneric::HWTimestamper_PPS_start( ) {
 	ctrl |= 0x400000; // set bit 22 SDP0 enabling output
 	igb_writereg(&igb_private->igb_dev, IGB_CTRL, ctrl );
 
-	igb_readreg( &igb_private->igb_dev, TSAUXC, &tsauxc );
-	tsauxc |= 0x14;
-	igb_writereg( &igb_private->igb_dev, TSAUXC, tsauxc );
-
 	igb_readreg(&igb_private->igb_dev, TSSDP, &tssdp);
 	tssdp &= ~0x40; // Set SDP0 output to freq clock 0
 	tssdp |= 0x80; 
@@ -152,20 +148,24 @@ bool LinuxTimestamperGeneric::HWTimestamper_PPS_start( ) {
 	igb_readreg(&igb_private->igb_dev, TSSDP, &tssdp);
 	tssdp |= 0x100; // set bit 8 -> SDP0 Time Sync Output
 	igb_writereg(&igb_private->igb_dev, TSSDP, tssdp);
-  
+
+	igb_readreg( &igb_private->igb_dev, TSAUXC, &tsauxc );
+	tsauxc |= 0x14;
+	igb_writereg( &igb_private->igb_dev, TSAUXC, tsauxc );
+
 	igb_unlock( &igb_private->igb_dev );
 
 	return true;
 }
 
 bool LinuxTimestamperGeneric::HWTimestamper_PPS_stop() {
-	unsigned tssdp;
-	
+	unsigned tsauxc;
+
 	if( !igb_private->igb_initd ) return false;
-	
-	igb_readreg(&igb_private->igb_dev, TSSDP, &tssdp);
-	tssdp &= ~0x100; // set bit 8 -> SDP0 Time Sync Output
-	igb_writereg(&igb_private->igb_dev, TSSDP, tssdp);
-	
+
+	igb_readreg( &igb_private->igb_dev, TSAUXC, &tsauxc );
+	tsauxc &= ~0x14; // set bit 4 and bit 2 -> AUXC ST0 and EN_CLK0
+	igb_writereg( &igb_private->igb_dev, TSAUXC, tsauxc );
+
 	return true;
 }


### PR DESCRIPTION
From I210 datasheet section
7.8.3.3.3 "Synchronized Output Clock on SDP Pins":
The clock out drives initially a logical '0' level on the selected SDP.
If the TSAUXC.ST0/1 flag is cleared, it happens instantly when setting the
TSAUXC.EN_CLK0/1 bit.
Otherwise it happens when the SYSTIM is >= the TRGTTIM.

Before the fix, when stopping PPS, only the SDP pin is disabled.
Therefore when starting PPS again, as soon as the SDP pin is enabled,
the clock output starts.

This fix will correctly clear the TSAUXC.ST0/1 and TSAUXC.EN_CLK0/1 bits
when stopping PPS. This will ensure that the clock output only happen
when the SYSTIM is >= the TRGTTIM.

Signed-off-by: Roland Hii <roland.king.guan.hii@intel.com>