### PR TITLE
Fixes: Wrong output from log messages on 64bit machines.

### DIFF
--- a/lib/avtp_pipeline/avtp/openavb_avtp.c
+++ b/lib/avtp_pipeline/avtp/openavb_avtp.c
@@ -443,7 +443,7 @@ openavbRC openavbAvtpRxInit(
 static void x_avtpRxFrame(avtp_stream_t *pStream, U8 *pFrame, U32 frameLen)
 {
 	AVB_TRACE_ENTRY(AVB_TRACE_AVTP_DETAIL);
-	AVB_LOGF_DEBUG("pFrame=%8.8p, len=%u", pFrame, frameLen);
+	AVB_LOGF_DEBUG("pFrame=%p, len=%u", pFrame, frameLen);
 	U8 subtype, flags, flags2, rxSeq, nLost, avtpVersion;
 	U8 *pRead = pFrame;
 

--- a/lib/avtp_pipeline/avtp/openavb_avtp_time.c
+++ b/lib/avtp_pipeline/avtp/openavb_avtp_time.c
@@ -331,7 +331,7 @@ bool openavbAvtpTimeIsPast(avtp_time_t *pAvtpTime)
 
 			if (nsNow + pAvtpTime->maxLatencyNsec < pAvtpTime->timeNsec) {
 				IF_LOG_INTERVAL(100) {
-					AVB_LOGF_INFO("Timestamp out of range: Now:%llu TSTime%llu MaxLatency:%lluns Delta:%lluns", nsNow, pAvtpTime->timeNsec, pAvtpTime->maxLatencyNsec, pAvtpTime->timeNsec - nsNow);
+					AVB_LOGF_INFO("Timestamp out of range: Now:%" PRIu64 " TSTime%" PRIu64 " MaxLatency:%" PRIu64 "ns Delta:%" PRIu64 "ns", nsNow, pAvtpTime->timeNsec, pAvtpTime->maxLatencyNsec, pAvtpTime->timeNsec - nsNow);
 				}
 				return TRUE;
 			}
@@ -362,7 +362,7 @@ bool openavbAvtpTimeIsPastTime(avtp_time_t *pAvtpTime, U64 nSecTime)
 
 		if (nSecTime + pAvtpTime->maxLatencyNsec < pAvtpTime->timeNsec) {
 			IF_LOG_INTERVAL(100) {
-				AVB_LOGF_INFO("Timestamp out of range: Now:%llu TSTime%llu MaxLatency:%lluns Delta:%lluns", nSecTime, pAvtpTime->timeNsec, pAvtpTime->maxLatencyNsec, pAvtpTime->timeNsec - nSecTime);
+				AVB_LOGF_INFO("Timestamp out of range: Now:%" PRIu64 "TSTime%" PRIu64 " MaxLatency:%" PRIu64 " ns Delta:%" PRIu64 "ns", nSecTime, pAvtpTime->timeNsec, pAvtpTime->maxLatencyNsec, pAvtpTime->timeNsec - nSecTime);
 			}
 			return TRUE;
 		}

--- a/lib/avtp_pipeline/platform/Linux/endpoint/openavb_endpoint_client_osal.c
+++ b/lib/avtp_pipeline/platform/Linux/endpoint/openavb_endpoint_client_osal.c
@@ -51,7 +51,7 @@ static bool openavbEptClntSendToServer(int h, openavbEndpointMessage_t *msg)
 	}
 
 	ssize_t nWrite = write(h, msg, OPENAVB_ENDPOINT_MSG_LEN);
-	AVB_LOGF_VERBOSE("Sent message, len=%d, nWrite=%d", OPENAVB_ENDPOINT_MSG_LEN, nWrite);
+	AVB_LOGF_VERBOSE("Sent message, len=%zu, nWrite=%zu", OPENAVB_ENDPOINT_MSG_LEN, nWrite);
 
 	if (nWrite < OPENAVB_ENDPOINT_MSG_LEN) {
 		if (nWrite < 0) {

--- a/lib/avtp_pipeline/platform/Linux/endpoint/openavb_endpoint_server_osal.c
+++ b/lib/avtp_pipeline/platform/Linux/endpoint/openavb_endpoint_server_osal.c
@@ -78,7 +78,7 @@ static bool openavbEptSrvrSendToClient(int h, openavbEndpointMessage_t *msg)
 	}
 
 	ssize_t nWrite = write(csock, msg, OPENAVB_ENDPOINT_MSG_LEN);
-	AVB_LOGF_VERBOSE("Sent message, len=%d, nWrite=%d", OPENAVB_ENDPOINT_MSG_LEN, nWrite);
+	AVB_LOGF_VERBOSE("Sent message, len=%zu, nWrite=%zu", OPENAVB_ENDPOINT_MSG_LEN, nWrite);
 	if (nWrite < OPENAVB_ENDPOINT_MSG_LEN) {
 		if (nWrite < 0) {
 			AVB_LOGF_ERROR("Failed to write socket: %s", strerror(errno));
@@ -203,7 +203,7 @@ void openavbEptSrvrService(void)
 					openavbEndpointMessage_t  msgBuf;
 					memset(&msgBuf, 0, OPENAVB_ENDPOINT_MSG_LEN);
 					ssize_t nRead = read(csock, &msgBuf, OPENAVB_ENDPOINT_MSG_LEN);
-					AVB_LOGF_VERBOSE("Socket read h=%d,fd=%d: read=%d, expect=%d", i, csock, nRead, OPENAVB_ENDPOINT_MSG_LEN);
+					AVB_LOGF_VERBOSE("Socket read h=%d,fd=%d: read=%zu, expect=%zu", i, csock, nRead, OPENAVB_ENDPOINT_MSG_LEN);
 					
 					if (nRead < OPENAVB_ENDPOINT_MSG_LEN) {
 						// sock closed

--- a/lib/avtp_pipeline/platform/Linux/intf_h264_gst/openavb_intf_h264_gst.c
+++ b/lib/avtp_pipeline/platform/Linux/intf_h264_gst/openavb_intf_h264_gst.c
@@ -402,7 +402,7 @@ static void *openavbIntfH264RtpGstRxThreadfn(void *pv)
 			}
 			else
 			{
-				AVB_LOGF_INFO("The Buf %x  %d skipped, OO!!", rxBuf, bufrd);
+				AVB_LOGF_INFO("The Buf %p  %d skipped, OO!!", rxBuf, bufrd);
 			}
 		}
 		else
@@ -512,7 +512,7 @@ bool openavbIntfH264RtpGstRxCB(media_q_t *pMediaQ)
 			if (mdif >= NBUFS)
 			{
 				openavbMediaQTailPull(pMediaQ);
-				AVB_LOGF_INFO("Rx async queue full, dropping (%lu - %lu = %lu)", bufwr, bufrd, mdif);
+				AVB_LOGF_INFO("Rx async queue full, dropping (%" PRIu32 " - %" PRIu32 " = %" PRIu32 ")", bufwr, bufrd, mdif);
 				moreSourcePackets = FALSE;
 				continue;
 			}

--- a/lib/avtp_pipeline/platform/Linux/intf_mjpeg_gst/openavb_intf_mjpeg_gst.c
+++ b/lib/avtp_pipeline/platform/Linux/intf_mjpeg_gst/openavb_intf_mjpeg_gst.c
@@ -321,7 +321,7 @@ static void *openavbIntfMjpegGstRxThreadfn(void *pv)
 			}
 			else
 			{
-				AVB_LOGF_INFO("The Buf %x  %d skipped, OO!!", rxBuf, bufrd);
+				AVB_LOGF_INFO("The Buf %p  %d skipped, OO!!", rxBuf, bufrd);
 			}
 		}
 		else
@@ -431,7 +431,7 @@ bool openavbIntfMjpegGstRxCB(media_q_t *pMediaQ)
 			if (mdif >= NBUFS)
 			{
 				openavbMediaQTailPull(pMediaQ);
-				AVB_LOGF_INFO("Rx async queue full, dropping (%lu - %lu = %lu)", bufwr, bufrd, mdif);
+				AVB_LOGF_INFO("Rx async queue full, dropping (%" PRIu32 " - %" PRIu32 " = %" PRIu32 ")", bufwr, bufrd, mdif);
 				moreSourcePackets = FALSE;
 				continue;
 			}
@@ -467,7 +467,7 @@ bool openavbIntfMjpegGstRxCB(media_q_t *pMediaQ)
 				// all fragments should have the same timestamp
 				if(pPvtData->frame_timestamp != fragment_timestamp)
 				{
-					AVB_LOGF_ERROR("Mapping is wrong. Fragment timestamp should be %lu instead of %lu",
+					AVB_LOGF_ERROR("Mapping is wrong. Fragment timestamp should be %" PRIu32 " instead of %" PRIu32,
 					               pPvtData->frame_timestamp, fragment_timestamp);
 				}
 			}

--- a/lib/avtp_pipeline/platform/Linux/intf_mpeg2ts_file/openavb_intf_mpeg2ts_file.c
+++ b/lib/avtp_pipeline/platform/Linux/intf_mpeg2ts_file/openavb_intf_mpeg2ts_file.c
@@ -498,7 +498,7 @@ double openavbIntfMpeg2tsFileComputeDuration(pvt_data_t* pPvtData, unsigned char
 			pPvtData->fPIDStatusTable[idx].firstRealTime = timeNow;
 			pPvtData->fPIDStatusTable[idx].lastRealTime = timeNow;
 			pPvtData->fPIDStatusTable[idx].lastPacketNum = 0;
-			AVB_LOGF_VERBOSE("PID 0x%x, FIRST PCR 0x%08x+%d:%03x == %f @ %f, pkt #%lu\n", pid, pcrBaseHigh, pkt[10]>>7, pcrExt, fClock, timeNow, pPvtData->fTSPacketCount);
+			AVB_LOGF_VERBOSE("PID 0x%x, FIRST PCR 0x%08x+%d:%03x == %f @ %f, pkt #%lf\n", pid, pcrBaseHigh, pkt[10]>>7, pcrExt, fClock, timeNow, pPvtData->fTSPacketCount);
 		} else {
 			// We've seen this PID's PCR before; update our per-packet duration estimate:
 			double packetsSinceLast = (pPvtData->fTSPacketCount -pPvtData->fPIDStatusTable[idx].lastPacketNum);
@@ -535,7 +535,7 @@ double openavbIntfMpeg2tsFileComputeDuration(pvt_data_t* pPvtData, unsigned char
 				pPvtData->fPIDStatusTable[idx].firstClock = fClock;
 				pPvtData->fPIDStatusTable[idx].firstRealTime = timeNow;
 			}
-			AVB_LOGF_VERBOSE("PID 0x%x, PCKT_CNT %lu PCR 0x%08x+%d:%03x == %f @ %f (diffs %f @ %f), pkt #%lu, discon %d => this duration %f, new estimate %f, mean PCR period=%f\n",
+			AVB_LOGF_VERBOSE("PID 0x%x, PCKT_CNT %lf PCR 0x%08x+%d:%03x == %f @ %f (diffs %f @ %f), pkt #%lf, discon %d => this duration %f, new estimate %f, mean PCR period=%f\n",
 					pid, pPvtData->fTSPacketCount, pcrBaseHigh, pkt[10]>>7, pcrExt, fClock, timeNow, fClock - pPvtData->fPIDStatusTable[idx].firstClock, timeNow - pPvtData->fPIDStatusTable[idx].firstRealTime, pPvtData->fTSPacketCount, discontinuity_indicator != 0, durationPerPacket, pPvtData->fTSPacketDurationEstimate, meanPCRPeriod );
 		}
 		pPvtData->fPIDStatusTable[idx].lastClock = fClock;

--- a/lib/avtp_pipeline/platform/Linux/openavb_os_services_osal.h
+++ b/lib/avtp_pipeline/platform/Linux/openavb_os_services_osal.h
@@ -124,7 +124,7 @@ thread##_type	thread##_ThreadData
 		error=FALSE;																			\
 		if (threadhandle##_ThreadData.err != 0) 												\
 		{   																					\
-			AVB_LOGF_ERROR("Thread error: %s code:", message, threadhandle##_ThreadData.err);   \
+			AVB_LOGF_ERROR("Thread error: %s code: %d", message, threadhandle##_ThreadData.err);   \
 			error=TRUE; 																		\
 			break;  																			\
 		}   																					\

--- a/lib/avtp_pipeline/platform/Linux/openavb_time_osal.c
+++ b/lib/avtp_pipeline/platform/Linux/openavb_time_osal.c
@@ -77,8 +77,8 @@ static bool x_timeInit(void) {
 		return FALSE;
 	}
 
-	AVB_LOGF_INFO("local_time = %llu", gPtpTD.local_time);
-	AVB_LOGF_INFO("ml_phoffset = %lld, ls_phoffset = %lld", gPtpTD.ml_phoffset, gPtpTD.ls_phoffset);
+	AVB_LOGF_INFO("local_time = %" PRIu64, gPtpTD.local_time);
+	AVB_LOGF_INFO("ml_phoffset = %" PRId64 ", ls_phoffset = %" PRId64, gPtpTD.ml_phoffset, gPtpTD.ls_phoffset);
 	AVB_LOGF_INFO("ml_freqffset = %Lf, ls_freqoffset = %Lf", gPtpTD.ml_freqoffset, gPtpTD.ls_freqoffset);
 
 	AVB_TRACE_EXIT(AVB_TRACE_TIME);

--- a/lib/avtp_pipeline/platform/Linux/rawsock/ring_rawsock.c
+++ b/lib/avtp_pipeline/platform/Linux/rawsock/ring_rawsock.c
@@ -77,7 +77,7 @@ void* ringRawsockOpen(ring_rawsock_t *rawsock, const char *ifname, bool rx_mode,
 	}
 	rawsock->bufferSize = rawsock->base.frameSize + rawsock->bufHdrSize;
 	rawsock->frameCount = num_frames;
-	AVB_LOGF_DEBUG("frameSize=%d, bufHdrSize=%d(%d+%d) bufferSize=%d, frameCount=%d",
+	AVB_LOGF_DEBUG("frameSize=%d, bufHdrSize=%d(%d+%zu) bufferSize=%d, frameCount=%d",
 				   rawsock->base.frameSize, rawsock->bufHdrSize, val, sizeof(struct sockaddr_ll),
 				   rawsock->bufferSize, rawsock->frameCount);
 
@@ -128,7 +128,7 @@ void* ringRawsockOpen(ring_rawsock_t *rawsock, const char *ifname, bool rx_mode,
 
 	// Call MMAP to get access to the memory used for the ring
 	rawsock->memSize = rawsock->blockCount * rawsock->blockSize;
-	AVB_LOGF_DEBUG("memSize=%d (%d, %d), sock=%d",
+	AVB_LOGF_DEBUG("memSize=%zu (%d, %d), sock=%d",
 				   rawsock->memSize,
 				   rawsock->blockCount,
 				   rawsock->blockSize,

--- a/lib/avtp_pipeline/tl/openavb_listener.c
+++ b/lib/avtp_pipeline/tl/openavb_listener.c
@@ -121,7 +121,7 @@ void listenerStopStream(tl_state_t *pTLState)
 	openavbListenerAddStat(pTLState, TL_STAT_RX_LOST, openavbAvtpLost(pListenerData->avtpHandle));
 	openavbListenerAddStat(pTLState, TL_STAT_RX_BYTES, openavbAvtpBytes(pListenerData->avtpHandle));
 
-	AVB_LOGF_INFO("RX "STREAMID_FORMAT", Totals: calls=%lld, frames=%lld, lost=%lld, bytes=%lld",
+	AVB_LOGF_INFO("RX "STREAMID_FORMAT", Totals: calls=%" PRIu64 "frames=%" PRIu64 "lost=%" PRIu64 "bytes=%" PRIu64,
 		STREAMID_ARGS(&pListenerData->streamID),
 		openavbListenerGetStat(pTLState, TL_STAT_RX_CALLS),
 		openavbListenerGetStat(pTLState, TL_STAT_RX_FRAMES),

--- a/lib/avtp_pipeline/tl/openavb_talker.c
+++ b/lib/avtp_pipeline/tl/openavb_talker.c
@@ -104,8 +104,8 @@ bool talkerStartStream(tl_state_t *pTLState)
 	U32 SRKbps = ((unsigned long)pTalkerData->classRate * (unsigned long)pCfg->max_interval_frames * (unsigned long)pStream->frameLen * 8L) / 1000;
 	U32 DataKbps = ((unsigned long)pTalkerData->wakeRate * (unsigned long)pCfg->max_interval_frames * (unsigned long)pStream->frameLen * 8L) / 1000;
 
-	AVB_LOGF_INFO(STREAMID_FORMAT", sr-rate=%lu, data-rate=%lu, frames=%u, size=%u, batch=%u, sleep=%" PRId64 ", sr-Kbps=%d, data-Kbps=%d",
-		STREAMID_ARGS(&pTalkerData->streamID), (unsigned long)(pTalkerData->classRate), (unsigned long)(pTalkerData->wakeRate),
+	AVB_LOGF_INFO(STREAMID_FORMAT", sr-rate=%" PRIu32 ", data-rate=%lu, frames=%" PRIu16 ", size=%" PRIu16 ", batch=%" PRIu32 ", sleep=%" PRIu64 "us, sr-Kbps=%d, data-Kbps=%d",
+		STREAMID_ARGS(&pTalkerData->streamID), pTalkerData->classRate, pTalkerData->wakeRate,
 		pTalkerData->tSpec.maxIntervalFrames, pTalkerData->tSpec.maxFrameSize,
 		pCfg->batch_factor, pTalkerData->intervalNS / 1000, SRKbps, DataKbps);
 
@@ -164,7 +164,7 @@ void talkerStopStream(tl_state_t *pTLState)
 //	openavbTalkerAddStat(pTLState, TL_STAT_TX_LATE, 0);		// Can't calulate at this time
 	openavbTalkerAddStat(pTLState, TL_STAT_TX_BYTES, openavbAvtpBytes(pTalkerData->avtpHandle));
 
-	AVB_LOGF_INFO("TX "STREAMID_FORMAT", Totals: calls=%lld, frames=%lld, late=%lld, bytes=%lld, TXOutOfBuffs=%ld",
+	AVB_LOGF_INFO("TX "STREAMID_FORMAT", Totals: calls=%" PRIu64 ", frames=%" PRIu64 ", late=%" PRIu64 ", bytes=%" PRIu64 ", TXOutOfBuffs=%ld",
 		STREAMID_ARGS(&pTalkerData->streamID),
 		openavbTalkerGetStat(pTLState, TL_STAT_TX_CALLS),
 		openavbTalkerGetStat(pTLState, TL_STAT_TX_FRAMES),


### PR DESCRIPTION
Details: Used macros for print formating eg. PRIu64 or PRIu32 so the expected
         and supplied formats match. Also changed format specifiers when they weren't matching
         expected format: eg. "llu" to "lu".