### PR TITLE
MRP: correct listener attribute merge bug

### DIFF
--- a/daemons/mrpd/msrp.c
+++ b/daemons/mrpd/msrp.c
@@ -99,6 +99,7 @@ void msrp_print_debug_info(int evt, const struct msrp_attribute *attrib)
 
 		}
 #endif
+#if 0
 		if (MSRP_TALKER_ADV_TYPE == attrib->type) {
 			state_mc_states = mrp_print_status(
 						&(attrib->applicant),
@@ -106,6 +107,17 @@ void msrp_print_debug_info(int evt, const struct msrp_attribute *attrib)
 			mrpd_log_printf("MSRP Talker event %s, %s\n",
 				     mrp_event_string(evt),
 				     state_mc_states);		
+
+		}
+#endif
+		if (MSRP_LISTENER_TYPE == attrib->type) {
+			state_mc_states = mrp_print_status(
+						&(attrib->applicant),
+						&(attrib->registrar));
+			mrpd_log_printf("MSRP Listener (state = %d) event %s, %s\n",
+					attrib->substate,
+					mrp_event_string(evt),
+					state_mc_states);		
 
 		}
 	}

--- a/daemons/mrpd/msrp.c
+++ b/daemons/mrpd/msrp.c
@@ -160,7 +160,23 @@ struct msrp_attribute *msrp_lookup(struct msrp_attribute *rattrib)
 	}
 	return NULL;
 }
+#ifdef MRP_CPPUTEST /* MSRP_PDU_TEST */
+struct msrp_attribute *msrp_lookup_stream_declaration(uint32_t decl_type, uint8_t streamID[8])
+{
+	struct msrp_attribute *attrib;
+	struct msrp_attribute *found_attrib;
 
+	attrib = msrp_alloc();
+	if (NULL == attrib) {
+		return NULL;
+	}
+	attrib->type = decl_type;
+	memcpy(attrib->attribute.talk_listen.StreamID, streamID, 8);
+	found_attrib = msrp_lookup(attrib);
+	free(attrib);
+	return found_attrib;
+}
+#endif
 int msrp_add(struct msrp_attribute *rattrib)
 {
 	struct msrp_attribute *attrib;

--- a/daemons/mrpd/msrp.c
+++ b/daemons/mrpd/msrp.c
@@ -367,14 +367,14 @@ int msrp_merge(struct msrp_attribute *rattrib)
 			}
 			/*
 			 * Listener attributes declared locally have
-			 * attrib->direction set to MSRP_DIRECTION_LISTENER.
+			 * attrib->operation set to MSRP_OPERATION_DECLARE.
 			 *
 			 * Listener attributes declared externally have
-			 * attrib->direction set to MSRP_DIRECTION_TALKER.
+			 * attrib->operation set to MSRP_OPERATION_REGISTER.
 			 *
 			 * Support merging the substate only when the directions match.
 			 */
-			if (rattrib->direction == attrib->direction) {
+			if (rattrib->operation == attrib->operation) {
 				attrib->substate = rattrib->substate;
 			}
 			attrib->registrar.mrp_state = MRP_MT_STATE;	/* ugly - force a notify */
@@ -1482,8 +1482,8 @@ int msrp_recv_msg()
 						    MSRP_TALKER_ADV_TYPE;
 
 						/* note this ISNT from us ... */
-						attrib->direction =
-						    MSRP_DIRECTION_LISTENER;
+						attrib->operation =
+						    MSRP_OPERATION_REGISTER;
 
 						memcpy(attrib->attribute.
 						       talk_listen.StreamID,
@@ -1744,8 +1744,8 @@ int msrp_recv_msg()
 						    MSRP_TALKER_FAILED_TYPE;
 
 						/* NOTE this isn't from us */
-						attrib->direction =
-						    MSRP_DIRECTION_LISTENER;
+						attrib->operation =
+						    MSRP_OPERATION_REGISTER;
 
 						memcpy(attrib->attribute.
 						       talk_listen.StreamID,
@@ -2274,7 +2274,7 @@ msrp_emit_talkervectors(unsigned char *msgbuf, unsigned char *msgbuf_eof,
 			continue;
 		}
 #ifdef CHECK
-		if (MSRP_DIRECTION_LISTENER == attrib->direction) {
+		if (MSRP_OPERATION_REGISTER == attrib->direction) {
 			attrib = attrib->next;
 			continue;
 		}
@@ -3412,6 +3412,7 @@ static int msrp_cmd_join_or_new_stream(struct msrpdu_talker_fail *talker_ad,
 		return -1;
 	}
 	attrib->type = attrib_type;
+	attrib->operation = MSRP_OPERATION_DECLARE;
 	attrib->attribute.talk_listen = *talker_ad;
 	msrp_event(mrp_event, attrib);
 	return 0;
@@ -3475,7 +3476,7 @@ static int msrp_cmd_report_listener_status(struct msrpdu_talker_fail *talker_ad,
 		return -1;
 	}
 	attrib->type = MSRP_LISTENER_TYPE;
-	attrib->direction = MSRP_DIRECTION_LISTENER;
+	attrib->operation = MSRP_OPERATION_DECLARE;
 	attrib->substate = substate;
 	attrib->attribute.talk_listen = *talker_ad;
 	msrp_event(MRP_EVENT_NEW, attrib);

--- a/daemons/mrpd/msrp.c
+++ b/daemons/mrpd/msrp.c
@@ -353,7 +353,18 @@ int msrp_merge(struct msrp_attribute *rattrib)
 				if (talker_missing)
 					break;
 			}
-			attrib->substate = rattrib->substate;
+			/*
+			 * Listener attributes declared locally have
+			 * attrib->direction set to MSRP_DIRECTION_LISTENER.
+			 *
+			 * Listener attributes declared externally have
+			 * attrib->direction set to MSRP_DIRECTION_TALKER.
+			 *
+			 * Support merging the substate only when the directions match.
+			 */
+			if (rattrib->direction == attrib->direction) {
+				attrib->substate = rattrib->substate;
+			}
 			attrib->registrar.mrp_state = MRP_MT_STATE;	/* ugly - force a notify */
 		}
 		break;

--- a/daemons/mrpd/msrp.c
+++ b/daemons/mrpd/msrp.c
@@ -329,20 +329,23 @@ int msrp_merge(struct msrp_attribute *rattrib)
 		 * TalkerFailed <- TalkerAdvertise and
 		 * TalkerAdvertise <- TalkerFailed
 		 */
-		attrib->attribute.talk_listen.FailureInformation.FailureCode =
-		    rattrib->attribute.talk_listen.FailureInformation.
-		    FailureCode;
-		memcpy(attrib->attribute.talk_listen.FailureInformation.
-		       BridgeID,
-		       rattrib->attribute.talk_listen.FailureInformation.
-		       BridgeID, 8);
+		if (rattrib->operation == attrib->operation) {
+
+			attrib->attribute.talk_listen.FailureInformation.FailureCode =
+				rattrib->attribute.talk_listen.FailureInformation.
+				FailureCode;
+			memcpy(attrib->attribute.talk_listen.FailureInformation.
+				BridgeID,
+				rattrib->attribute.talk_listen.FailureInformation.
+				BridgeID, 8);
 #ifdef ENABLE_MERGED_LATENCY
-		attrib->attribute.talk_listen.AccumulatedLatency =
-		    rattrib->attribute.talk_listen.AccumulatedLatency;
+			attrib->attribute.talk_listen.AccumulatedLatency =
+				rattrib->attribute.talk_listen.AccumulatedLatency;
 #endif 
-		if (attrib->type != rattrib->type) {
-			attrib->type = rattrib->type;
-			attrib->registrar.mrp_state = MRP_MT_STATE;	/* ugly - force a notify */
+			if (attrib->type != rattrib->type) {
+				attrib->type = rattrib->type;
+				attrib->registrar.mrp_state = MRP_MT_STATE;	/* ugly - force a notify */
+			}
 		}
 		break;
 	case MSRP_LISTENER_TYPE:

--- a/daemons/mrpd/msrp.h
+++ b/daemons/mrpd/msrp.h
@@ -195,4 +195,5 @@ int msrp_interesting_id_count(void);
 
 #ifdef MRP_CPPUTEST
 struct msrp_attribute *msrp_lookup(struct msrp_attribute *rattrib);
+struct msrp_attribute *msrp_lookup_stream_declaration(uint32_t decl_type, uint8_t streamID[8]);
 #endif

--- a/daemons/mrpd/msrp.h
+++ b/daemons/mrpd/msrp.h
@@ -141,8 +141,12 @@ typedef struct msrpdu_domain {
 #define MSRP_SR_CLASS_A_PRIO	3
 #define MSRP_SR_CLASS_B_PRIO	2
 
-#define MSRP_DIRECTION_TALKER	0
-#define MSRP_DIRECTION_LISTENER	1
+/*
+ * Differentiate between attribute declare and register
+ * (see section 10.2 IEEE802.1Q-2011)
+ */
+#define MSRP_OPERATION_REGISTER 0   /* from network */
+#define MSRP_OPERATION_DECLARE  1   /* from local client application */
 
 struct msrp_attribute {
 	struct msrp_attribute *prev;
@@ -153,7 +157,7 @@ struct msrp_attribute {
 		msrpdu_domain_t domain;
 	} attribute;
 	uint32_t substate;	/*for listener events */
-	uint32_t direction;	/*for listener events */
+	uint32_t operation;	/* DECLARE or REGISTER */
 	mrp_applicant_attribute_t applicant;
 	mrp_registrar_attribute_t registrar;
 };

--- a/daemons/mrpd/tests/simple/mrp_doubles.c
+++ b/daemons/mrpd/tests/simple/mrp_doubles.c
@@ -266,7 +266,7 @@ void dump_msrp_attrib(struct msrp_attribute *attr)
 		       attr->attribute.domain.SRclassVID);
 	}
 	printf("substate: %u\n", attr->substate);
-	printf("direction: %u\n", attr->direction);
+	printf("operation: %u\n", attr->operation);
 	printf("applicant:\n");
 	printf("  mrp_state: %d\n", attr->applicant.mrp_state);
 	printf("  tx: %d\n", attr->applicant.tx);

--- a/daemons/mrpd/tests/simple/mrp_doubles.c
+++ b/daemons/mrpd/tests/simple/mrp_doubles.c
@@ -178,6 +178,7 @@ TRACE
 	(void)sockfd; /* unused */
 	(void)flags;  /* unused */
 	memcpy(test_state.tx_PDU, buf, len);
+	test_state.tx_PDU_len = len;
         test_state.sent_count++;
         return len;
 }

--- a/daemons/mrpd/tests/simple/mrp_doubles.h
+++ b/daemons/mrpd/tests/simple/mrp_doubles.h
@@ -85,6 +85,7 @@ struct mrpd_test_state {
 	unsigned char rx_PDU[MAX_FRAME_SIZE];
 	unsigned char tx_PDU[MAX_FRAME_SIZE];
 	unsigned int rx_PDU_len;
+	size_t tx_PDU_len;
 	int sent_count;
 
 	/* MSRP Events */

--- a/daemons/mrpd/tests/simple/msrp_tests.cpp
+++ b/daemons/mrpd/tests/simple/msrp_tests.cpp
@@ -592,3 +592,68 @@ TEST(MsrpTestGroup, Listener_State_Transition_With_Rx_rIn)
 	CHECK(MSRP_LISTENER_READY == attrib->substate);
 
 }
+
+/*
+* Talker Advertise to Talker Failed transition in the presence of
+* a rIn! from switch while waiting for a transmit opportunity.
+*/
+TEST(MsrpTestGroup, TalkerAdvertise_To_Failed_Transition_With_Rx_rIn)
+{
+	char cmd_string1[] = "S++:S=" STREAM_ID \
+		",A=" STREAM_DA \
+		",V=" VLAN_ID \
+		",Z=" TSPEC_MAX_FRAME_SIZE \
+		",I=" TSPEC_MAX_FRAME_INTERVAL \
+		",P=" PRIORITY_AND_RANK \
+		",L=" ACCUMULATED_LATENCY;
+
+	char cmd_string2[] = "S++:S=" STREAM_ID \
+		",A=" STREAM_DA \
+		",V=" VLAN_ID \
+		",Z=" TSPEC_MAX_FRAME_SIZE \
+		",I=" TSPEC_MAX_FRAME_INTERVAL \
+		",P=" PRIORITY_AND_RANK \
+		",L=" ACCUMULATED_LATENCY \
+		",B=" BRIDGE_ID \
+		",C=" FAILURE_CODE;
+
+	uint8_t thisStreamID[8] = { 0xDE, 0xAD, 0xBE, 0xEF, 0xBA, 0xDF, 0xCA, 0x11 };
+	struct msrp_attribute *attrib;
+	int rv;
+
+	/* declare Talker Advertise */
+	msrp_recv_cmd(cmd_string1, sizeof(cmd_string1), &client);
+	CHECK(msrp_tests_cmd_ok(test_state.ctl_msg_data));
+
+	attrib = msrp_lookup_stream_declaration(MSRP_TALKER_ADV_TYPE, thisStreamID);
+	CHECK(NULL != attrib);
+	CHECK(MSRP_TALKER_ADV_TYPE == attrib->type);
+
+	/* cause Talker Advertise to be sent */
+	msrp_event(MRP_EVENT_TX, NULL);
+	CHECK(1 == test_state.sent_count);
+
+	/* declare Talker Failed */
+	msrp_recv_cmd(cmd_string2, sizeof(cmd_string2), &client);
+	CHECK(msrp_tests_cmd_ok(test_state.ctl_msg_data));
+
+	attrib = msrp_lookup_stream_declaration(MSRP_TALKER_FAILED_TYPE, thisStreamID);
+	CHECK(NULL != attrib);
+	CHECK(MSRP_TALKER_FAILED_TYPE == attrib->type);
+
+	/* Rx pdu with Talker Adverise in it.
+	* Loop the Tx PDU back into the the Rx PDU path. This won't actually send a rIn!
+	* event, but the effect should be the same.
+	*/
+	memcpy(test_state.rx_PDU, test_state.tx_PDU, test_state.tx_PDU_len);
+	test_state.rx_PDU_len = test_state.tx_PDU_len;
+	rv = msrp_recv_msg();
+	LONGS_EQUAL(0, rv);
+
+	/* Check Listener declaration type */
+	attrib = msrp_lookup_stream_declaration(MSRP_TALKER_FAILED_TYPE, thisStreamID);
+	CHECK(NULL != attrib);
+	CHECK(MSRP_TALKER_FAILED_TYPE == attrib->type);
+
+}
+


### PR DESCRIPTION
This set of checkins restricts listener attribute merging to only occur in the direction of listener attribute propagation. It address issue #338 where a received PDU from a switch overwrote the declared listener attribute.