### PR TITLE
igb_avb: Support 32bit app on 64bit kernel.

### DIFF
--- a/kmod/igb/igb_main.c
+++ b/kmod/igb/igb_main.c
@@ -2602,7 +2602,7 @@ static int igb_probe(struct pci_dev *pdev,
 			pci_using_dac = 1;
 	} else {
 		err = dma_set_mask(pci_dev_to_dev(pdev), DMA_BIT_MASK(32));
-		if (err) {
+		if (!err) {
 			err = dma_set_coherent_mask(pci_dev_to_dev(pdev),
 				DMA_BIT_MASK(32));
 			if (err) {

--- a/kmod/igb/kcompat.h
+++ b/kmod/igb/kcompat.h
@@ -76,6 +76,12 @@
 #else
 #endif /* NAPI */
 
+#ifdef SUPPORT_32BIT_IOCTL
+#ifndef CONFIG_IGB_SUPPORT_32BIT_IOCTL
+#define CONFIG_IGB_SUPPORT_32BIT_IOCTL
+#endif
+#endif /* SUPPORT_32BIT_IOCTL */
+
 /* Dynamic LTR and deeper C-State support disable/enable */
 
 /* packet split disable/enable */


### PR DESCRIPTION
I got a problem that 32-bit application(talker) fails to run on 64-bit kernel.
There are two problems.
* 'compat_ioctl' callback should be added on file_operations.
* If memory address for DMA is over 32bits, user application calls 'mmap()' with wrong address.<BR/>
 In detail,<BR/>
 Application queries memory address for 'mmap()' with ioctl().<BR/>
 But if the address for DMA is reserved bigger than 4GB(32bits),<BR/>
 application gets clipped address on the result of ioctl().<BR/>
 After then, wrong address is used at calling 'mmap()'.

And one more trivial patch is added for typo.
 