### PR TITLE
Fix wrong behaviour with wrong seqIDs on sync messages 

### DIFF
--- a/daemons/gptp/common/avbts_message.hpp
+++ b/daemons/gptp/common/avbts_message.hpp
@@ -806,6 +806,11 @@ public:
 		preciseOriginTimestamp = timestamp;
 	}
 
+	/**
+	 * @brief  Sets the clock source time interface (802.1AS 9.2)
+	 * @param  fup Follow up message
+	 * @return void
+	 */
     void setClockSourceTime(FollowUpTLV *fup)
     {
         tlv.setGMTimeBaseIndicator(fup->getGMTimeBaseIndicator());

--- a/daemons/gptp/common/avbts_port.hpp
+++ b/daemons/gptp/common/avbts_port.hpp
@@ -233,10 +233,16 @@ class IEEE1588Port {
 	static const int64_t ONE_WAY_DELAY_DEFAULT = 3600000000000;
 	static const int64_t INVALID_LINKDELAY = 3600000000000;
 	static const int64_t NEIGHBOR_PROP_DELAY_THRESH = 800;
+	static const unsigned int SYNC_RECEIPT_THRESH = 5;
 	/* Signed value allows this to be negative result because of inaccurate
 	   timestamp */
 	int64_t one_way_delay;
     int64_t neighbor_prop_delay_thresh;
+
+	/*Sync threshold*/
+	unsigned int sync_receipt_thresh;
+	unsigned int wrongSeqIDCounter;
+
 	/* Implementation Specific data/methods */
 	IEEE1588Clock *clock;
 
@@ -916,6 +922,72 @@ class IEEE1588Port {
         int64_t abs_delay = (one_way_delay < 0 ? -one_way_delay : one_way_delay);
 
         return (abs_delay <= neighbor_prop_delay_thresh);
+	}
+
+	/**
+	 * @brief  Sets the internal variabl sync_receipt_thresh, which is the
+	 * flag that monitors the amount of wrong syncs enabled before switching
+	 * the ptp to master.
+	 * @param  th Threshold to be set
+	 * @return void
+	 */
+	void setSyncReceiptThresh(unsigned int th)
+	{
+		sync_receipt_thresh = th;
+	}
+
+	/**
+	 * @brief  Gets the internal variabl sync_receipt_thresh, which is the
+	 * flag that monitors the amount of wrong syncs enabled before switching
+	 * the ptp to master.
+	 * @return sync_receipt_thresh value
+	 */
+	unsigned int getSyncReceiptThresh(void)
+	{
+		return sync_receipt_thresh;
+	}
+
+	/**
+	 * @brief  Sets the wrongSeqIDCounter variable
+	 * @param  cnt Value to be set
+	 * @return void
+	 */
+	void setWrongSeqIDCounter(unsigned int cnt)
+	{
+		wrongSeqIDCounter = cnt;
+	}
+
+	/**
+	 * @brief  Gets the wrongSeqIDCounter value
+	 * @param  [out] cnt Pointer to the counter value. It must be valid
+	 * @return TRUE if ok and lower than the syncReceiptThreshold value. FALSE otherwise
+	 */
+	bool getWrongSeqIDCounter(unsigned int *cnt)
+	{
+		if( cnt == NULL )
+		{
+			return false;
+		}
+		*cnt = wrongSeqIDCounter;
+
+		return( *cnt < getSyncReceiptThresh() );
+	}
+
+	/**
+	 * @brief  Increments the wrongSeqIDCounter value
+	 * @param  [out] cnt Pointer to the counter value. Must be valid
+	 * @return TRUE if incremented value is lower than the syncReceiptThreshold. FALSE otherwise.
+	 */
+
+	bool incWrongSeqIDCounter(unsigned int *cnt)
+	{
+		if( cnt == NULL )
+		{
+			return false;
+		}
+		*cnt = ++wrongSeqIDCounter;
+
+		return ( *cnt < getSyncReceiptThresh() );
 	}
 
     /**

--- a/daemons/gptp/common/gptp_cfg.cpp
+++ b/daemons/gptp/common/gptp_cfg.cpp
@@ -116,7 +116,16 @@ int GptpIniParser::iniCallBack(void *user, const char *section, const char *name
                 parser->_config.neighborPropDelayThresh = nt;
             }
         }
-
+        else if( parseMatch(name, "syncReceiptThresh") )
+        {
+            errno = 0;
+            char *pEnd;
+            unsigned int st = strtoul(value, &pEnd, 10);
+            if( *pEnd == '\0' && errno == 0) {
+                valOK = true;
+                parser->_config.syncReceiptThresh = st;
+            }
+        }
     }
     else if( parseMatch(section, "eth") )
     {

--- a/daemons/gptp/common/gptp_cfg.hpp
+++ b/daemons/gptp/common/gptp_cfg.hpp
@@ -39,17 +39,26 @@ https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
 #include "ini.h"
 #include "ieee1588.hpp"
 
-class GptpIniParser {
+/**
+ * Provides the gptp interface for
+ * the iniParser external module
+ */
+class GptpIniParser
+{
     public:
 
-        /*Public types*/
-        typedef struct {
+        /**
+         * Container with the information to get from the .ini file
+         */
+        typedef struct
+        {
             /*ptp data set*/
             unsigned char priority1;
 
             /*port data set*/
             unsigned int announceReceiptTimeout;
             unsigned int syncReceiptTimeout;
+            unsigned int syncReceiptThresh;		//!< Number of wrong sync messages that will trigger a switch to master
             int64_t neighborPropDelayThresh;
             PortState port_state;
 
@@ -63,77 +72,107 @@ class GptpIniParser {
         ~GptpIniParser();
 
         /**
-         * @brief
+         * @brief  Reads the parser Error value
          * @param  void
-         * @return
+         * @return Parser Error
          */
         int parserError(void);
 
         /**
-         * @brief
+         * @brief  Reads priority1 config value
          * @param  void
-         * @return
+         * @return priority1
          */
         unsigned char getPriority1(void)
         {
             return _config.priority1;
         }
 
+        /**
+         * @brief  Reads the announceReceiptTimeout configuration value
+         * @param  void
+         * @return announceRecepitTimeout value from .ini file
+         */
         unsigned int getAnnounceReceiptTimeout(void)
         {
             return _config.announceReceiptTimeout;
         }
 
+        /**
+         * @brief  Reads the syncRecepitTimeout configuration value
+         * @param  void
+         * @return syncRecepitTimeout value from the .ini file
+         */
         unsigned int getSyncReceiptTimeout(void)
         {
             return _config.syncReceiptTimeout;
         }
 
+        /**
+         * @brief  Reads the TX PHY DELAY GB value from the configuration file
+         * @param  void
+         * @return gb_tx_phy_delay value from the .ini file
+         */
         int getPhyDelayGbTx(void)
         {
             return _config.phyDelay.gb_tx_phy_delay;
         }
 
+        /**
+         * @brief  Reads the RX PHY DELAY GB value from the configuration file
+         * @param  void
+         * @return gb_rx_phy_delay value from the .ini file
+         */
         int getPhyDelayGbRx(void)
         {
             return _config.phyDelay.gb_rx_phy_delay;
         }
 
+        /**
+         * @brief  Reads the TX PHY DELAY MB value from the configuration file
+         * @param  void
+         * @return mb_tx_phy_delay value from the .ini file
+         */
         int getPhyDelayMbTx(void)
         {
             return _config.phyDelay.mb_tx_phy_delay;
         }
 
+        /**
+         * @brief  Reads the RX PHY DELAY MB valye from the configuration file
+         * @param  void
+         * @return mb_rx_phy_delay value from the .ini file
+         */
         int getPhyDelayMbRx(void)
         {
             return _config.phyDelay.mb_rx_phy_delay;
         }
 
+        /**
+         * @brief  Reads the neighbohr propagation delay threshold from the configuration file
+         * @param  void
+         * @return neighborPropDelayThresh value from the .ini file
+         */
         int64_t getNeighborPropDelayThresh(void)
         {
             return _config.neighborPropDelayThresh;
+        }
+
+        /**
+         * @brief  Reads the sync receipt threshold from the configuration file
+         * @param  getSyncReceiptThresh
+         * @return syncRecepitThresh value from the .ini file
+         */
+        unsigned int getSyncReceiptThresh(void)
+        {
+            return _config.syncReceiptThresh;
         }
 
     private:
         int _error;
         gptp_cfg_t _config;
 
-        /**
-         * @brief
-         * @param  user
-         * @param  section
-         * @param  name
-         * @param  value
-         * @return
-         */
         static int iniCallBack(void *user, const char *section, const char *name, const char *value);
-
-        /**
-         * @brief
-         * @param  s1
-         * @param  s2
-         * @return
-         */
         static bool parseMatch(const char *s1, const char *s2);
 };
 

--- a/daemons/gptp/common/ieee1588port.cpp
+++ b/daemons/gptp/common/ieee1588port.cpp
@@ -107,7 +107,9 @@ IEEE1588Port::IEEE1588Port
 	_hw_timestamper = timestamper;
 
 	one_way_delay = ONE_WAY_DELAY_DEFAULT;
-    neighbor_prop_delay_thresh = NEIGHBOR_PROP_DELAY_THRESH;
+	neighbor_prop_delay_thresh = NEIGHBOR_PROP_DELAY_THRESH;
+	sync_receipt_thresh = SYNC_RECEIPT_THRESH;
+	wrongSeqIDCounter = 0;
 
 	_peer_rate_offset = 1.0;
 

--- a/daemons/gptp/common/ptp_message.cpp
+++ b/daemons/gptp/common/ptp_message.cpp
@@ -933,8 +933,15 @@ void PTPMessageFollowUp::processMessage(IEEE1588Port * port)
 
 	if (sync->getSequenceId() != sequenceId || sync_id != *sourcePortIdentity)
 	{
+		unsigned int cnt = 0;
+
+		if( !port->incWrongSeqIDCounter(&cnt) )
+		{
+			port->becomeMaster( true );
+			port->setWrongSeqIDCounter(0);
+		}
 		XPTPD_ERROR
-		    ("Received Follow Up but cannot find corresponding Sync");
+		    ("Received Follow Up %d times but cannot find corresponding Sync", cnt);
 		goto done;
 	}
 

--- a/daemons/gptp/gptp_cfg.ini
+++ b/daemons/gptp/gptp_cfg.ini
@@ -8,10 +8,10 @@ priority1 = 248
 
 [port]
 
-#
+# TODO
 announceReceiptTimeout = 3
 
-#
+# TODO
 syncReceiptTimeout = 3
 
 # Neighbor propagation delay threshold in nanoseconds
@@ -21,6 +21,13 @@ syncReceiptTimeout = 3
 # user may be using a converter to fibre and the software wont know until the
 # administrator changes it.
 neighborPropDelayThresh = 800
+
+# Sync Receipt Threshold
+# This value defines the number of syncs with wrong seqID that will trigger
+# the ptp slave to become master (it will start announcing)
+# Normally sync messages are sent every 125ms, so setting it to 8 will allow
+# up to 1 second of wrong messages before switching
+syncReceiptThresh = 8
 
 [eth]
 

--- a/daemons/gptp/linux/src/daemon_cl.cpp
+++ b/daemons/gptp/linux/src/daemon_cl.cpp
@@ -319,10 +319,16 @@ int main(int argc, char **argv)
             fprintf(stdout, "phy_delay_mb_tx: %d\n", iniParser.getPhyDelayMbTx());
             fprintf(stdout, "phy_delay_mb_rx: %d\n", iniParser.getPhyDelayMbRx());
             fprintf(stdout, "neighborPropDelayThresh: %ld\n", iniParser.getNeighborPropDelayThresh());
+            fprintf(stdout, "syncReceiptThreshold: %d\n", iniParser.getSyncReceiptThresh());
 
             /* If using config file, set the neighborPropDelayThresh.
              * Otherwise it will use its default value (800ns) */
             port->setNeighPropDelayThresh(iniParser.getNeighborPropDelayThresh());
+
+            /* If using config file, set the syncReceiptThreshold, otherwise
+             * it will use the default value (SYNC_RECEIPT_THRESH)
+             */
+            port->setSyncReceiptThresh(iniParser.getSyncReceiptThresh());
 
             /*Only overwrites phy_delay default values if not input_delay switch enabled*/
             if(!input_delay)


### PR DESCRIPTION
Fixes Issue #135 

On the followUP messages, it is checked if the amount of wrong syncMessages is over a threshold, and if that is true, gPTP switches to master.

This patch was validated using the UNH-IOL tools for gPTP. 