### PR TITLE
Handles lost of Resp and Fup messages

### DIFF
--- a/daemons/gptp/common/avbts_message.hpp
+++ b/daemons/gptp/common/avbts_message.hpp
@@ -949,6 +949,8 @@ class PTPMessagePathDelayRespFollowUp:public PTPMessageCommon {
 	PortIdentity *requestingPortIdentity;
 
 	PTPMessagePathDelayRespFollowUp(void) { }
+
+	const static uint16_t SEQID_DIFF_THRESHOLD = 4;
 public:
 	/**
 	 * Builds the PTPMessagePathDelayRespFollowUp object

--- a/daemons/gptp/common/avbts_message.hpp
+++ b/daemons/gptp/common/avbts_message.hpp
@@ -949,8 +949,6 @@ class PTPMessagePathDelayRespFollowUp:public PTPMessageCommon {
 	PortIdentity *requestingPortIdentity;
 
 	PTPMessagePathDelayRespFollowUp(void) { }
-
-	static const unsigned int SEQID_DIFF_THRESHOLD = 5;
 public:
 	/**
 	 * Builds the PTPMessagePathDelayRespFollowUp object

--- a/daemons/gptp/common/avbts_message.hpp
+++ b/daemons/gptp/common/avbts_message.hpp
@@ -950,7 +950,6 @@ class PTPMessagePathDelayRespFollowUp:public PTPMessageCommon {
 
 	PTPMessagePathDelayRespFollowUp(void) { }
 
-	const static uint16_t SEQID_DIFF_THRESHOLD = 4;
 public:
 	/**
 	 * Builds the PTPMessagePathDelayRespFollowUp object

--- a/daemons/gptp/common/avbts_message.hpp
+++ b/daemons/gptp/common/avbts_message.hpp
@@ -949,6 +949,8 @@ class PTPMessagePathDelayRespFollowUp:public PTPMessageCommon {
 	PortIdentity *requestingPortIdentity;
 
 	PTPMessagePathDelayRespFollowUp(void) { }
+
+	static const unsigned int SEQID_DIFF_THRESHOLD = 5;
 public:
 	/**
 	 * Builds the PTPMessagePathDelayRespFollowUp object

--- a/daemons/gptp/common/avbts_port.hpp
+++ b/daemons/gptp/common/avbts_port.hpp
@@ -403,13 +403,14 @@ class IEEE1588Port {
 		}
 		if(!ascap){
 			_peer_offset_init = false;
+			setSeqIdAsCapableThreshCounter(0);
 		}
 		asCapable = ascap;
 	}
 
 	/**
 	 * @brief  Gets the asCapable flag
-	 * @return asCapable flag
+	 * @return asCapable flag.
 	 */
 	bool getAsCapable() { return( asCapable ); }
 
@@ -1025,16 +1026,20 @@ class IEEE1588Port {
 	 * @param  [out] cnt Pointer to the counter value. Must be valid
 	 * @return TRUE if incremented value is lower than the syncReceiptThreshold. FALSE otherwise.
 	 */
-
 	bool incWrongSeqIDCounter(unsigned int *cnt)
 	{
-        if( cnt == NULL )
-        {
-            return false;
-        }
-		*cnt = ++wrongSeqIDCounter;
+		if( getAsCapable() )
+		{
+			wrongSeqIDCounter++;
+		}
+		bool ret = wrongSeqIDCounter < getSyncReceiptThresh();
 
-		return ( *cnt < getSyncReceiptThresh() );
+		if( cnt != NULL)
+		{
+			*cnt = wrongSeqIDCounter;
+		}
+
+		return ret;
 	}
 
     /**
@@ -1064,7 +1069,11 @@ class IEEE1588Port {
      */
 	bool incSeqIdAsCapableThreshCounter(void)
 	{
-		return( ++seqIdAsCapableThreshCounter < getSeqIdAsCapableThresh() );
+		if( getAsCapable() )
+		{
+			seqIdAsCapableThreshCounter++;
+		}
+		return(seqIdAsCapableThreshCounter < getSeqIdAsCapableThresh() );
 	}
 
     /**

--- a/daemons/gptp/common/avbts_port.hpp
+++ b/daemons/gptp/common/avbts_port.hpp
@@ -234,8 +234,6 @@ class IEEE1588Port {
 	static const int64_t INVALID_LINKDELAY = 3600000000000;
 	static const int64_t NEIGHBOR_PROP_DELAY_THRESH = 800;
 	static const unsigned int DEFAULT_SYNC_RECEIPT_THRESH = 5;
-	static const unsigned int DEFAULT_SEQID_ASCAPABLE_THRESHOLD = 5;
-	static const uint16_t DEFAULT_LOSTPDELAY_RESP_THRESH = 3;
 
 	/* Signed value allows this to be negative result because of inaccurate
 	   timestamp */
@@ -245,14 +243,6 @@ class IEEE1588Port {
 	/*Sync threshold*/
 	unsigned int sync_receipt_thresh;
 	unsigned int wrongSeqIDCounter;
-
-	/*SeqID threshold*/
-	unsigned int seqIdAsCapableThresh;
-	unsigned int seqIdAsCapableThreshCounter;
-
-	/*Lost PDelayFUPs*/
-	uint16_t lastSeqId;
-	uint16_t lostPdelayRespThresh;
 
 	/* Implementation Specific data/methods */
 	IEEE1588Clock *clock;
@@ -403,7 +393,6 @@ class IEEE1588Port {
 		}
 		if(!ascap){
 			_peer_offset_init = false;
-			setSeqIdAsCapableThreshCounter(0);
 		}
 		asCapable = ascap;
 	}
@@ -948,42 +937,6 @@ class IEEE1588Port {
 		sync_receipt_thresh = th;
 	}
 
-    /**
-     * @brief  Sets the seqIdAsCapableThresh value
-     * @param  th value to be set
-     */
-	void setSeqIdAsCapableThresh(unsigned int th)
-	{
-		seqIdAsCapableThresh = th;
-	}
-
-    /**
-     * @brief  Gets the seqIdAsCapableThresh value
-     * @return seqIdAsCapableThresh content
-     */
-	unsigned int getSeqIdAsCapableThresh(void)
-	{
-		return seqIdAsCapableThresh;
-	}
-
-    /**
-     * @brief  Sets the lostPdelayRespThresh value
-     * @param  th value to be set
-     */
-	void setLostPdelayRespThresh(unsigned int th)
-	{
-		lostPdelayRespThresh = th;
-	}
-
-    /**
-     * @brief  Gets the lostPdelayRespThresh value
-     * @return lostPdelayRespThresh content
-     */
-	uint16_t getLostPdelayRespThresh(void)
-	{
-		return lostPdelayRespThresh;
-	}
-
 	/**
 	 * @brief  Gets the internal variabl sync_receipt_thresh, which is the
 	 * flag that monitors the amount of wrong syncs enabled before switching
@@ -1041,58 +994,6 @@ class IEEE1588Port {
 
 		return ret;
 	}
-
-    /**
-     * @brief  Set the seqIdAsCapableThreshCounter value
-     * @param  c Value to be set to.
-     * @return void
-     */
-	void setSeqIdAsCapableThreshCounter(unsigned int c)
-	{
-		seqIdAsCapableThreshCounter = c;
-	}
-
-    /**
-     * @brief  Gets the content of seqIdAsCapableThreshCounter
-     * @return seqIdAsCapableThreshCounter value
-     */
-	unsigned int getSeqIdAsCapableThreshCounter(void)
-	{
-		return seqIdAsCapableThreshCounter;
-	}
-
-    /**
-     * @brief  Increments the seqIdAsCapableThreshCounter value
-     * @param  incSeqIdAsCapableThreshCounter
-     * @return TRUE if incremented value is lower than the seqIdAsCapableThresh.
-     * FALSE otherwise.
-     */
-	bool incSeqIdAsCapableThreshCounter(void)
-	{
-		if( getAsCapable() )
-		{
-			seqIdAsCapableThreshCounter++;
-		}
-		return(seqIdAsCapableThreshCounter < getSeqIdAsCapableThresh() );
-	}
-
-    /**
-     * @brief  Stores the last seqID on port object
-     * @param  seqid Value to be set
-     */
-    void setLastSeqID(uint16_t seqid)
-    {
-        lastSeqId = seqid;
-    }
-
-    /**
-     * @brief  Gets the last SeqID from Port object
-     * @return lastSeqID
-     */
-    uint16_t getLastSeqId(void)
-    {
-        return lastSeqId;
-    }
 
     /**
      * @brief  Sets the neighbor propagation delay threshold

--- a/daemons/gptp/common/gptp_cfg.hpp
+++ b/daemons/gptp/common/gptp_cfg.hpp
@@ -169,24 +169,6 @@ class GptpIniParser
             return _config.syncReceiptThresh;
         }
 
-        /**
-         * @brief  Gets the value from seqIdAsCapableThresh from the configuration file
-         * @return seqIdAsCapableThresh content
-         */
-        unsigned int getSeqIdAsCapableThresh(void)
-        {
-            return _config.seqIdAsCapableThresh;
-        }
-
-        /**
-         * @brief  Reads the lostPdelayRespThresh from the configuration file
-         * @return lostPdelayRespThresh value from the .ini file
-         */
-        uint16_t getLostPdelayRespThresh(void)
-        {
-            return _config.lostPdelayRespThresh;
-        }
-
     private:
         int _error;
         gptp_cfg_t _config;

--- a/daemons/gptp/common/ieee1588port.cpp
+++ b/daemons/gptp/common/ieee1588port.cpp
@@ -109,10 +109,7 @@ IEEE1588Port::IEEE1588Port
 	one_way_delay = ONE_WAY_DELAY_DEFAULT;
 	neighbor_prop_delay_thresh = NEIGHBOR_PROP_DELAY_THRESH;
 	sync_receipt_thresh = DEFAULT_SYNC_RECEIPT_THRESH;
-	seqIdAsCapableThresh = DEFAULT_SEQID_ASCAPABLE_THRESHOLD;
 	wrongSeqIDCounter = 0;
-	seqIdAsCapableThreshCounter = 0;
-	lostPdelayRespThresh = DEFAULT_LOSTPDELAY_RESP_THRESH;
 
 	_peer_rate_offset = 1.0;
 
@@ -133,8 +130,6 @@ IEEE1588Port::IEEE1588Port
 
 	pdelay_count = 0;
 	sync_count = 0;
-
-	lastSeqId = 0;
 }
 
 bool IEEE1588Port::init_port(int delay[4])

--- a/daemons/gptp/common/ptp_message.cpp
+++ b/daemons/gptp/common/ptp_message.cpp
@@ -1389,11 +1389,13 @@ void PTPMessagePathDelayRespFollowUp::processMessage(IEEE1588Port * port)
 		uint16_t req_port_number;
 		resp_id.getPortNumber(&resp_port_number);
 		requestingPortIdentity->getPortNumber(&req_port_number);
+		uint16_t _cntthres = port->getSeqIdAsCapableThreshCounter() + diffLastSeqId;
 		bool isSeqIdCounterUnderThresh = port->incSeqIdAsCapableThreshCounter();
-		if( !isSeqIdCounterUnderThresh ||
-				(port->getSeqIdAsCapableThreshCounter() + diffLastSeqId) > SEQID_DIFF_THRESHOLD)
+		bool cntOverThresh = _cntthres > port->getSeqIdAsCapableThresh();
+
+		if( !isSeqIdCounterUnderThresh || cntOverThresh )
 		{
-			XPTPD_ERROR(">>> SeqID counter bigger than threshold.");
+			XPTPD_ERROR(">>> SeqID counter bigger than threshold.(%u > %u)", _cntthres, port->getSeqIdAsCapableThresh());
 			port->setAsCapable( false );
 		}
 		XPTPD_ERROR

--- a/daemons/gptp/common/ptp_message.cpp
+++ b/daemons/gptp/common/ptp_message.cpp
@@ -1361,7 +1361,7 @@ void PTPMessagePathDelayRespFollowUp::processMessage(IEEE1588Port * port)
 
 	if( req->getSequenceId() != sequenceId ) {
 		XPTPD_ERROR
-			(">>> Received PDelay FUP has different seqID than the PDleay request (%d/%d)",
+			(">>> Received PDelay FUP has different seqID than the PDelay request (%d/%d)",
 			 sequenceId, req->getSequenceId() );
 		goto abort;
 	}

--- a/daemons/gptp/common/ptp_message.cpp
+++ b/daemons/gptp/common/ptp_message.cpp
@@ -1323,7 +1323,7 @@ void PTPMessagePathDelayRespFollowUp::processMessage(IEEE1588Port * port)
 	Timestamp request_tx_timestamp(0, 0, 0);
 	Timestamp remote_req_rx_timestamp(0, 0, 0);
 	Timestamp response_rx_timestamp(0, 0, 0);
-	unsigned int diffLastSeqId;
+	uint16_t diffLastSeqId;
 
 	if (port->getPortState() == PTP_DISABLED) {
 		// Do nothing all messages should be ignored when in this state

--- a/daemons/gptp/common/ptp_message.cpp
+++ b/daemons/gptp/common/ptp_message.cpp
@@ -1391,11 +1391,11 @@ void PTPMessagePathDelayRespFollowUp::processMessage(IEEE1588Port * port)
 		requestingPortIdentity->getPortNumber(&req_port_number);
 		uint16_t _cntthres = port->getSeqIdAsCapableThreshCounter() + diffLastSeqId;
 		bool isSeqIdCounterUnderThresh = port->incSeqIdAsCapableThreshCounter();
-		bool cntOverThresh = _cntthres > port->getSeqIdAsCapableThresh();
+		bool cntOverThresh = _cntthres > SEQID_DIFF_THRESHOLD;
 
 		if( !isSeqIdCounterUnderThresh || cntOverThresh )
 		{
-			XPTPD_ERROR(">>> SeqID counter bigger than threshold.(%u > %u)", _cntthres, port->getSeqIdAsCapableThresh());
+			XPTPD_ERROR(">>> SeqID counter bigger than threshold.");
 			port->setAsCapable( false );
 		}
 		XPTPD_ERROR

--- a/daemons/gptp/gptp_cfg.ini
+++ b/daemons/gptp/gptp_cfg.ini
@@ -32,7 +32,7 @@ syncReceiptThresh = 8
 # Sequence ID AS Capable threshold
 # This flag is the the amount of wrong seqID messages that gPTP
 # is allowed to receive before it is considered not AS Capable.
-seqIdAsCapableThresh = 5
+seqIdAsCapableThresh = 4
 
 # Lost PDelay response threshold
 # A gPTP device must keep count of consecutively lost responses to Pdelay_Req

--- a/daemons/gptp/gptp_cfg.ini
+++ b/daemons/gptp/gptp_cfg.ini
@@ -29,18 +29,6 @@ neighborPropDelayThresh = 800
 # up to 1 second of wrong messages before switching
 syncReceiptThresh = 8
 
-# Sequence ID AS Capable threshold
-# This flag is the the amount of wrong seqID messages that gPTP
-# is allowed to receive before it is considered not AS Capable.
-seqIdAsCapableThresh = 4
-
-# Lost PDelay response threshold
-# A gPTP device must keep count of consecutively lost responses to Pdelay_Req
-# frames. A lost response is considered any late or invalid Pdelay_Resp or
-# Pdelay_Resp_Follow_Up. If more than 3 consecutive responses are lost,
-# then both isMeasuringDelay and asCapable must be set to FALSE.
-lostPdelayRespThresh = 3
-
 [eth]
 
 # PHY delay GB TX in nanoseconds

--- a/daemons/gptp/linux/src/daemon_cl.cpp
+++ b/daemons/gptp/linux/src/daemon_cl.cpp
@@ -320,8 +320,6 @@ int main(int argc, char **argv)
             fprintf(stdout, "phy_delay_mb_rx: %d\n", iniParser.getPhyDelayMbRx());
             fprintf(stdout, "neighborPropDelayThresh: %ld\n", iniParser.getNeighborPropDelayThresh());
             fprintf(stdout, "syncReceiptThreshold: %d\n", iniParser.getSyncReceiptThresh());
-            fprintf(stdout, "seqIdAsCapableThresh: %d\n", iniParser.getSeqIdAsCapableThresh());
-            fprintf(stdout, "lostPdelayRespThresh %d\n", iniParser.getLostPdelayRespThresh());
 
             /* If using config file, set the neighborPropDelayThresh.
              * Otherwise it will use its default value (800ns) */
@@ -331,16 +329,6 @@ int main(int argc, char **argv)
              * it will use the default value (SYNC_RECEIPT_THRESH)
              */
             port->setSyncReceiptThresh(iniParser.getSyncReceiptThresh());
-
-            /* If using config file, set the seqIdAsCapableThresh, otherwise
-             * it will use the default value (SEQID_ASCAPABLE_THRESHOLD)
-             */
-            port->setSeqIdAsCapableThresh(iniParser.getSeqIdAsCapableThresh());
-
-            /* If using config file, set the lostPdelayRespThresh, otherwise
-             * it will use the default value (LOSTPDELAY_RESP_THRESH)
-             */
-            port->setLostPdelayRespThresh(iniParser.getLostPdelayRespThresh());
 
             /*Only overwrites phy_delay default values if not input_delay switch enabled*/
             if(!input_delay)


### PR DESCRIPTION
This patch fixes Issue #138 and potentially others as well. There are other open issues that are related to handle fups/resp lost messages and making gPTP not being asCapable. The Issue #138 was fixed and I am retesting the whole thing to see if at this point nothing got broken and if there are other ones fixed as well. 

I will be posting the other results directly on the open issues if I have good news. For now I want to create the pull request (which is quite small - but required lot of investigation and testing) so people can review and we can move forward and integrate this into Avnu's repo.