### PR TITLE
AVnu automotive profile for gPTP

### DIFF
--- a/daemons/gptp/README_AVNU_AP.txt
+++ b/daemons/gptp/README_AVNU_AP.txt
@@ -1,0 +1,69 @@
+## Introduction
+This readme covers only the additional features added to the gPTP daemon 
+to support the AVnu Automotive Profile (AP). 
+
+## Automotive Profile Features Implemented
+- In general all features of the AP support for a Slave device have been 
+implemented with the following exceptions. 
+	- Windows OS platform code has not been implemented.
+- Detailed list of the AP implementation includes
+	- Configuration		
+		- Static gPTP values (AutoCDS 6.2.1)
+		- Persistent gPTP values (AutoCDS 6.2.2)
+		- Management Updated Values (AutoCDS 6.2.3)
+		- Signalling Message Configuration (AutoCDS 6.2.4)
+		- Followup TLV (AutoCDS 6.2.5)
+		- Required Values for gPTP (AutoCDS 6.2.6)
+	- Operation
+		- Disable BMCA (AutoCDS 6.3)
+		- No verification of sourcePortIdentity (AutoCDS 6.3)
+		- Sync Holdover (AutoCDS 6.3)
+		- Sync Recovery (AutoCDS 6.3)
+		- Implement Signalling Message (802.1AS 2011 10.5.4)
+		- Implement Test Mode (AutoCDS 5.3)
+	- Exception Handling	
+		- Link State Change (AutoCDS 9.2.1)
+		- Loss of Sync Messages (AutoCDS 9.3.1)
+		- Non-Continuous Sync Values (AutoCDS 9.3.2)
+		- Pdelay Response Timeout (AutoCDS 9.3.3) (Not implemented)
+		- neighborPropDelay value (AutoCDS 9.3.4)
+	- Diagnostic counters (AutoCDS 13)
+		- Abstracted with only simple dump to log upon SIGUSR2 signal.
+
+## Non-Automotive Profile Changes
+- Added fuller feature logging within gPTP
+- Updated the various logging macros and direct usage of printfs to use the new
+logging
+- IEEE1588Port class initialization changed to reduced the 14+ constructor
+parameters to a single init parameter.
+- Link up and Link down detection added.
+- Abstracted the state save functionality to allow for easier integration to
+other platforms.
+
+## New Command Line Options	
+- E enable test mode (as defined in AVnu automotive profile)
+- V enable AVnu Automotive Profile
+- GM set grandmaster for Automotive Profile
+- INITSYNC <value> initial sync interval (Log base 2. 0 = 1 sec)
+- OPERSYNC <value> operational sync interval (Log base 2. 0 = 1 sec)
+- INITPDELAY <value> initial pdelay interval (Log base 2. 0 = 1 sec)
+- OPERPDELAY <value> operational pdelay interval (Log base 2. 0 = 1 sec)
+
+## Build Related
+- There are no changes to the standard build for gPTP
+
+## Execution Related
+- Other than the new command line options there are no changes to starting gPTP
+- Example
+	- ./run_gptp.sh eth1 -M statefile -V
+		- Start with AP and a specific file name for saving state information.
+		
+## Run Time Related
+- Signals
+	- SIGHUP: writes the current gPTP state information to file.
+	- SIGUSR2: Dumps the diagnostic counters to the log
+
+## Known Issues
+- When running as slave (none -GM) there may be a SYNC rx timeout exception reported when signalling to a different SYNC rate.
+- Link down or link up may be incorrectly detected at times.
+

--- a/daemons/gptp/common/ap_message.cpp
+++ b/daemons/gptp/common/ap_message.cpp
@@ -1,0 +1,131 @@
+/*************************************************************************************************************
+Copyright (c) 2012-2016, Harman International Industries, Incorporated
+All rights reserved.
+ 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ 
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ 
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS LISTED "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS LISTED BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*************************************************************************************************************/
+
+#include <ieee1588.hpp>
+#include <avbts_clock.hpp>
+#include <avbap_message.hpp>
+#include <avbts_port.hpp>
+#include <avbts_ostimer.hpp>
+#include <gptp_log.hpp>
+
+#include <stdio.h>
+#include <string.h>
+#include <math.h>
+
+
+#define ntohll(x)    __bswap_64 (x)
+#define htonll(x)    __bswap_64 (x)
+
+
+// Octet based data 2 buffer macros
+#define OCT_D2BMEMCP(d, s) memcpy(d, s, sizeof(s)); d += sizeof(s);
+#define OCT_D2BBUFCP(d, s, len) memcpy(d, s, len); d += len;
+#define OCT_D2BHTONB(d, s) *(U8 *)(d) = s; d += sizeof(s);
+#define OCT_D2BHTONS(d, s) *(U16 *)(d) = PLAT_htons(s); d += sizeof(s);
+#define OCT_D2BHTONL(d, s) *(U32 *)(d) = PLAT_htonl(s); d += sizeof(s);
+
+// Bit based data 2 buffer macros
+#define BIT_D2BHTONB(d, s, shf) *(uint8_t *)(d) |= s << shf;
+#define BIT_D2BHTONS(d, s, shf) *(uint16_t *)(d) |= PLAT_htons((uint16_t)(s << shf));
+#define BIT_D2BHTONL(d, s, shf) *(uint32_t *)(d) |= PLAT_htonl((uint32_t)(s << shf));
+
+
+APMessageTestStatus::APMessageTestStatus()
+{
+}
+
+APMessageTestStatus::~APMessageTestStatus()
+{
+}
+
+APMessageTestStatus::APMessageTestStatus(IEEE1588Port * port)
+{
+}
+
+void APMessageTestStatus::sendPort(IEEE1588Port * port)
+{
+	static uint16_t sequenceId = 0;
+
+	uint8_t buf_t[256];
+	uint8_t *buf_ptr = buf_t + port->getPayloadOffset();
+	uint16_t tmp16;
+	uint32_t tmp32;
+	uint64_t tmp64;
+
+	memset(buf_t, 0, 256);
+
+	// Create packet in buf
+	messageLength = AP_TEST_STATUS_LENGTH;
+ 
+	BIT_D2BHTONB(buf_ptr + AP_TEST_STATUS_AVTP_SUBTYPE(AP_TEST_STATUS_OFFSET), 0xfb, 0);
+	BIT_D2BHTONB(buf_ptr + AP_TEST_STATUS_AVTP_VERSION_CONTROL(AP_TEST_STATUS_OFFSET), 0x1, 0);
+	BIT_D2BHTONS(buf_ptr + AP_TEST_STATUS_AVTP_STATUS_LENGTH(AP_TEST_STATUS_OFFSET), 148, 0);
+
+	port->getLocalAddr()->toOctetArray(buf_ptr + AP_TEST_STATUS_TARGET_ENTITY_ID(AP_TEST_STATUS_OFFSET));
+
+	tmp16 = PLAT_htons(sequenceId++);
+	memcpy(buf_ptr + AP_TEST_STATUS_SEQUENCE_ID(AP_TEST_STATUS_OFFSET), &tmp16, sizeof(tmp16));
+
+	BIT_D2BHTONS(buf_ptr + AP_TEST_STATUS_COMMAND_TYPE(AP_TEST_STATUS_OFFSET), 1, 15);
+	BIT_D2BHTONS(buf_ptr + AP_TEST_STATUS_COMMAND_TYPE(AP_TEST_STATUS_OFFSET), 0x29, 0);
+
+	tmp16 = PLAT_htons(0x09);
+	memcpy(buf_ptr + AP_TEST_STATUS_DESCRIPTOR_TYPE(AP_TEST_STATUS_OFFSET), &tmp16, sizeof(tmp16));
+	tmp16 = PLAT_htons(0x00);
+	memcpy(buf_ptr + AP_TEST_STATUS_DESCRIPTOR_INDEX(AP_TEST_STATUS_OFFSET), &tmp16, sizeof(tmp16));
+
+	tmp32 = PLAT_htonl(0x07000023);
+	memcpy(buf_ptr + AP_TEST_STATUS_COUNTERS_VALID(AP_TEST_STATUS_OFFSET), &tmp32, sizeof(tmp32));
+
+	tmp32 = PLAT_htonl(port->getLinkUpCount());
+	memcpy(buf_ptr + AP_TEST_STATUS_COUNTER_LINKUP(AP_TEST_STATUS_OFFSET), &tmp32, sizeof(tmp32));
+
+	tmp32 = PLAT_htonl(port->getLinkDownCount());
+	memcpy(buf_ptr + AP_TEST_STATUS_COUNTER_LINKDOWN(AP_TEST_STATUS_OFFSET), &tmp32, sizeof(tmp32));
+
+	Timestamp system_time;
+	Timestamp device_time;
+	uint32_t local_clock, nominal_clock_rate;
+	port->getDeviceTime(system_time, device_time, local_clock, nominal_clock_rate);
+	tmp64 = htonll(TIMESTAMP_TO_NS(system_time));
+	memcpy(buf_ptr + AP_TEST_STATUS_MESSAGE_TIMESTAMP(AP_TEST_STATUS_OFFSET), &tmp64, sizeof(tmp64));
+
+	BIT_D2BHTONB(buf_ptr + AP_TEST_STATUS_STATION_STATE(AP_TEST_STATUS_OFFSET), (uint8_t)port->getStationState(), 0);
+
+	if (port->getStationState() == STATION_STATE_ETHERNET_READY) {
+		GPTP_LOG_INFO("AVnu AP Status : STATION_STATE_ETHERNET_READY");
+	}
+	else if (port->getStationState() == STATION_STATE_AVB_SYNC) {
+		GPTP_LOG_INFO("AVnu AP Status : STATION_STATE_AVB_SYNC");
+	}
+	else if (port->getStationState() == STATION_STATE_AVB_MEDIA_READY) {
+		GPTP_LOG_INFO("AVnu AP Status : STATION_STATE_AVB_MEDIA_READY");
+	}
+
+	port->sendGeneralPort(AVTP_ETHERTYPE, buf_t, messageLength, MCAST_TEST_STATUS, NULL);
+
+	return;
+}
+

--- a/daemons/gptp/common/avbap_message.hpp
+++ b/daemons/gptp/common/avbap_message.hpp
@@ -1,0 +1,110 @@
+/*************************************************************************************************************
+Copyright (c) 2012-2016, Harman International Industries, Incorporated
+All rights reserved.
+ 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ 
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ 
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS LISTED "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS LISTED BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*************************************************************************************************************/
+
+#ifndef AVBAP_MESSAGE_HPP
+#define AVBAP_MESSAGE_HPP
+
+#include <stdint.h>
+#include <avbts_osnet.hpp>
+#include <ieee1588.hpp>
+
+#include <list>
+#include <algorithm>
+#include <avbts_message.hpp>
+
+/** @file **/
+
+#define AP_TEST_STATUS_OFFSET 0									/*!< AP Test Status offset */
+#define AP_TEST_STATUS_LENGTH 160								/*!< AP Test Status length in byte */
+#define AP_TEST_STATUS_AVTP_SUBTYPE(x) x						/*!< AVTP Subtype */
+#define AP_TEST_STATUS_AVTP_VERSION_CONTROL(x) x + 1			/*!< Version and control fields */
+#define AP_TEST_STATUS_AVTP_STATUS_LENGTH(x) x + 2				/*!< Status and content length */
+#define AP_TEST_STATUS_TARGET_ENTITY_ID(x) x + 4				/*!< Target entity ID */
+#define AP_TEST_STATUS_CONTROLLER_ENTITY_ID(x) x + 12			/*!< Controller entity ID */
+#define AP_TEST_STATUS_SEQUENCE_ID(x) x + 20					/*!< Sequence ID */
+#define AP_TEST_STATUS_COMMAND_TYPE(x) x + 22					/*!< Command type */
+#define AP_TEST_STATUS_DESCRIPTOR_TYPE(x) x + 24				/*!< Descriptor Type */
+#define AP_TEST_STATUS_DESCRIPTOR_INDEX(x) x + 26				/*!< Descriptor Index */
+#define AP_TEST_STATUS_COUNTERS_VALID(x) x + 28					/*!< Counters valid */
+#define AP_TEST_STATUS_COUNTER_LINKUP(x) x + 32					/*!< Counter Link Up */
+#define AP_TEST_STATUS_COUNTER_LINKDOWN(x) x + 36				/*!< Counter Link Down */
+#define AP_TEST_STATUS_COUNTER_FRAMES_TX(x) x + 40				/*!< Counter Frames TX */
+#define AP_TEST_STATUS_COUNTER_FRAMES_RX(x) x + 44				/*!< Counter Frames RX */
+#define AP_TEST_STATUS_COUNTER_FRAMES_RX_CRC_ERROR(x) x + 48	/*!< Counter Frames RX CRC Error */
+#define AP_TEST_STATUS_COUNTER_GM_CHANGED(x) x + 52				/*!< Counter GM Changed */
+#define AP_TEST_STATUS_COUNTER_RESERVED(x) x + 56				/*!< Reserved counters */
+#define AP_TEST_STATUS_MESSAGE_TIMESTAMP(x) x + 128				/*!< Message timestamp */
+#define AP_TEST_STATUS_STATION_STATE(x) x + 136					/*!< Station state */
+#define AP_TEST_STATUS_STATION_STATE_SPECIFIC_DATA(x) x + 137	/*!< Station state specific data */
+#define AP_TEST_STATUS_COUNTER_27(x) x + 140					/*!< Counter 27 */
+#define AP_TEST_STATUS_COUNTER_28(x) x + 144					/*!< Counter 28 */
+#define AP_TEST_STATUS_COUNTER_29(x) x + 148					/*!< Counter 29 */
+#define AP_TEST_STATUS_COUNTER_30(x) x + 152					/*!< Counter 30 */
+#define AP_TEST_STATUS_COUNTER_31(x) x + 156					/*!< Counter 31 */
+
+
+/**
+ * Automotive Profile Test Status Station State
+ */
+typedef enum {
+	STATION_STATE_RESERVED,
+	STATION_STATE_ETHERNET_READY,
+	STATION_STATE_AVB_SYNC,
+	STATION_STATE_AVB_MEDIA_READY,
+} StationState_t;
+
+
+/**
+ * Provides a class for building the ANvu Autommotive 
+ * Profile Test Status message 
+ */
+class APMessageTestStatus {
+ private:
+	uint16_t messageLength;			/*!< message length */
+
+	APMessageTestStatus();
+ public:
+	/**
+	 * @brief Default constructor. Creates APMessageTestStatus 
+	 * @param port IEEE1588Port
+	 */
+	APMessageTestStatus(IEEE1588Port * port);
+
+	/**
+	 * Destroys APMessageTestStatus interface
+	 */
+	~APMessageTestStatus();
+
+	/**
+	 * @brief  Assembles APMessageTestStatus message on the 
+	 *  	   IEEE1588Port payload
+	 * @param  port IEEE1588Port where the message will be assembled
+	 * @return void
+	 */
+	void sendPort(IEEE1588Port * port);
+};
+
+
+#endif

--- a/daemons/gptp/common/avbts_clock.hpp
+++ b/daemons/gptp/common/avbts_clock.hpp
@@ -248,7 +248,7 @@ public:
    */
   void setGrandmasterClockIdentity(ClockIdentity id) {
 	  if (id != grandmaster_clock_identity) {
-		  fprintf(stderr, "New Grandmaster \"%s\" (previous \"%s\")\n", id.getIdentityString().c_str(), grandmaster_clock_identity.getIdentityString().c_str());
+		  GPTP_LOG_INFO("New Grandmaster \"%s\" (previous \"%s\")", id.getIdentityString().c_str(), grandmaster_clock_identity.getIdentityString().c_str());
 		  grandmaster_clock_identity = id;
 	  }
   }

--- a/daemons/gptp/common/avbts_osnet.hpp
+++ b/daemons/gptp/common/avbts_osnet.hpp
@@ -272,6 +272,15 @@ class factory_name_t {
 typedef enum { net_trfail, net_fatal, net_succeed } net_result;
 
 /**
+ * Enumeration net_link_event:
+ * 	- net_linkup
+ * 	- net_linkdown
+ * 	
+ */
+typedef enum { NET_LINK_EVENT_DOWN, NET_LINK_EVENT_UP, NET_LINK_EVENT_FAIL } net_link_event;
+
+
+/**
  * Provides a generic network interface
  */
 class OSNetworkInterface {
@@ -279,13 +288,14 @@ class OSNetworkInterface {
 	 /**
 	  * @brief Sends a packet to a remote address
 	  * @param addr [in] Remote link layer address
+	  * @param etherType [in] The EtherType of the message
 	  * @param payload [in] Data buffer
 	  * @param length Size of data buffer
 	  * @param timestamp TRUE if to use the event socket with the PTP multicast address. FALSE if to use
 	  * a general socket.
 	  */
 	 virtual net_result send
-		 (LinkLayerAddress * addr, uint8_t * payload, size_t length,
+		 (LinkLayerAddress * addr, uint16_t etherType, uint8_t * payload, size_t length,
 		  bool timestamp) = 0;
 
 	 /**
@@ -306,9 +316,15 @@ class OSNetworkInterface {
 	 virtual void getLinkLayerAddress(LinkLayerAddress * addr) = 0;
 
 	 /**
+	  * @brief  Watch for net link changes.
+	  */
+	 virtual void watchNetLink(IEEE1588Port *pPort) = 0;
+
+	 /**
 	  * @brief  Provides generic method for getting the payload offset
 	  */
 	 virtual unsigned getPayloadOffset() = 0;
+
 	 /**
 	  * Native support for polimorphic destruction
 	  */

--- a/daemons/gptp/common/avbts_persist.hpp
+++ b/daemons/gptp/common/avbts_persist.hpp
@@ -1,0 +1,105 @@
+/*************************************************************************************************************
+Copyright (c) 2012-2015, Symphony Teleca Corporation, a Harman International Industries, Incorporated company
+All rights reserved.
+ 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ 
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ 
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS LISTED "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS LISTED BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+Attributions: The inih library portion of the source code is licensed from 
+Brush Technology and Ben Hoyt - Copyright (c) 2009, Brush Technology and Copyright (c) 2009, Ben Hoyt. 
+Complete license and copyright information can be found at 
+https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
+*************************************************************************************************************/
+
+#ifndef AVBTS_PERSIST_HPP
+#define AVBTS_PERSIST_HPP
+
+#include <stdint.h>
+#include <ptptypes.hpp>
+
+/**@file*/
+
+
+/**
+ * @brief  Callback function to write persistent data.
+ * @param bufPtr Buffer pointer where the restored persistent data shall be stored.
+ * @param bufSize The size of the buffer.
+ * @return True on success otherwise False
+ */
+typedef void (*gPTPPersistWriteCB_t)(char *bufPtr, uint32_t bufSize);
+
+
+
+/**
+ * Generic interface for Simple Persistence for gPTP values
+ */
+class GPTPPersist {
+public:
+	/**
+	 * @brief  Initializes the GPTP_PERSIST 
+	 * @param persistID string identifer of the persistence storage. For example a file name 
+	 * @return True on success otherwise False
+	 */
+    virtual bool initStorage(const char *persistID) = 0;
+
+	/**
+	 * @brief  Closes the GPTP_PERSIST instance
+	 * @return True on success otherwise False
+	 */
+	virtual bool closeStorage(void) = 0;
+
+	/**
+	 * @brief  Read the persistent data
+	 * @param bufPtr Buffer pointer where the restored persistent data is held.
+	 * @param bufSize The size of the restored data.
+	 * @return True on success otherwise False
+	 */
+    virtual bool readStorage(char **bufPtr, uint32_t *bufSize) = 0;
+
+	/**
+	 * @brief Register the write call back
+	 * @param writeCB Write callback from
+	 * @return none
+	 */
+	virtual void registerWriteCB(gPTPPersistWriteCB_t writeCB) = 0;
+
+	/**
+	 * @brief Set write data size
+	 * @param dataSiuze The size of data that will be written
+	 * @return none
+	 */
+	virtual void setWriteSize(uint32_t dataSize) = 0;
+
+	/**
+	 * @brief  Trigger the write callback.
+	 * @return True on success otherwise False
+	 */
+	virtual bool triggerWriteStorage(void) = 0;
+
+	/*
+	 * Destroys the GPTP_PERSIST instance
+	 */
+	virtual ~GPTPPersist() = 0;
+};
+
+inline GPTPPersist::~GPTPPersist() {}
+
+#endif  // AVBTS_PERSIST_HPP
+

--- a/daemons/gptp/common/avbts_port.hpp
+++ b/daemons/gptp/common/avbts_port.hpp
@@ -36,6 +36,7 @@
 
 #include <ieee1588.hpp>
 #include <avbts_message.hpp>
+#include <avbap_message.hpp>
 
 #include <avbts_ostimer.hpp>
 #include <avbts_oslock.hpp>
@@ -43,6 +44,7 @@
 #include <avbts_osthread.hpp>
 #include <avbts_oscondition.hpp>
 #include <ipcdef.hpp>
+#include <gptp_log.hpp>
 
 #include <stdint.h>
 
@@ -54,10 +56,13 @@
 #define GPTP_MULTICAST 0x0180C200000EULL		/*!< GPTP multicast adddress */
 #define PDELAY_MULTICAST GPTP_MULTICAST			/*!< PDELAY Multicast value */
 #define OTHER_MULTICAST GPTP_MULTICAST			/*!< OTHER multicast value */
+#define TEST_STATUS_MULTICAST 0x011BC50AC000ULL	/*!< AVnu Automotive profile test status msg Multicast value */
 
 #define PDELAY_RESP_RECEIPT_TIMEOUT_MULTIPLIER 3	/*!< PDelay timeout multiplier*/
 #define SYNC_RECEIPT_TIMEOUT_MULTIPLIER 3			/*!< Sync receipt timeout multiplier*/
 #define ANNOUNCE_RECEIPT_TIMEOUT_MULTIPLIER 3		/*!< Announce receipt timeout multiplier*/
+
+#define LOG2_INTERVAL_INVALID	-127		/* Simple out of range Log base 2 value used for Sync and PDelay msg internvals */
 
 /**
  * PortType enumeration. Selects between delay request-response (E2E) mechanism
@@ -68,6 +73,7 @@ typedef enum {
 	V2_E2E,
 	V2_P2P
 } PortType;
+
 
 /**
  * PortIdentity interface
@@ -201,12 +207,98 @@ public:
  */
 typedef std::map < PortIdentity, LinkLayerAddress > IdentityMap_t;
 
+
+/**
+ * Structure for initializing of the IEE1588 class 
+ */
+typedef struct {
+	/* clock IEEE1588Clock instance */
+	IEEE1588Clock * clock;
+
+	 /* index Interface index */
+	uint16_t index;
+
+	/* forceSlave Forces port to be slave  */
+	bool forceSlave;
+
+	 /* accelerated_sync_count If non-zero, then start 16ms sync timer */
+	int accelerated_sync_count;
+
+	/* timestamper Hardware timestamper instance */
+	HWTimestamper * timestamper;
+
+	/* offset  Initial clock offset */
+	int32_t offset;
+
+	/* net_label Network label */
+	InterfaceLabel * net_label;
+
+	/* automotive_profile set the AVnu automotive profile */
+	bool automotive_profile;
+
+	/* Set to true if the port is the grandmaster. Used for fixed GM in the the AVnu automotive profile */
+	bool isGM;
+
+	/* Set to true if the port is the grandmaster. Used for fixed GM in the the AVnu automotive profile */
+	bool testMode;
+
+	/* gPTP 10.2.4.4 */
+	char initialLogSyncInterval;
+
+	/* gPTP 11.5.2.2 */
+	char initialLogPdelayReqInterval;
+
+	/* CDS 6.2.1.5 */
+	char operLogPdelayReqInterval;
+
+	/* CDS 6.2.1.6 */
+	char operLogSyncInterval;
+
+	/* condition_factory OSConditionFactory instance */
+	OSConditionFactory * condition_factory;
+
+	/* thread_factory OSThreadFactory instance */
+	OSThreadFactory * thread_factory;
+
+	/* timer_factory OSTimerFactory instance */
+	OSTimerFactory * timer_factory;
+
+	/* lock_factory OSLockFactory instance */
+	OSLockFactory * lock_factory;
+} IEEE1588PortInit_t;
+
+
+
+/**
+ * Structure for IEE1588Port Counters
+ */
+typedef struct {
+	int32_t ieee8021AsPortStatRxSyncCount;
+	int32_t ieee8021AsPortStatRxFollowUpCount;
+	int32_t ieee8021AsPortStatRxPdelayRequest;
+	int32_t ieee8021AsPortStatRxPdelayResponse;
+	int32_t ieee8021AsPortStatRxPdelayResponseFollowUp;
+	int32_t ieee8021AsPortStatRxAnnounce;
+	int32_t ieee8021AsPortStatRxPTPPacketDiscard;
+	int32_t ieee8021AsPortStatRxSyncReceiptTimeouts;
+	int32_t ieee8021AsPortStatAnnounceReceiptTimeouts;
+	int32_t ieee8021AsPortStatPdelayAllowedLostResponsesExceeded;
+	int32_t ieee8021AsPortStatTxSyncCount;
+	int32_t ieee8021AsPortStatTxFollowUpCount;
+	int32_t ieee8021AsPortStatTxPdelayRequest;
+	int32_t ieee8021AsPortStatTxPdelayResponse;
+	int32_t ieee8021AsPortStatTxPdelayResponseFollowUp;
+	int32_t ieee8021AsPortStatTxAnnounce;
+} IEEE1588PortCounters_t;
+
+
 /**
  * Provides the IEEE 1588 port interface
  */
 class IEEE1588Port {
 	static LinkLayerAddress other_multicast;
 	static LinkLayerAddress pdelay_multicast;
+	static LinkLayerAddress test_status_multicast;
 
 	PortIdentity port_identity;
 	/* directly connected node */
@@ -240,6 +332,32 @@ class IEEE1588Port {
 
 	bool asCapable;
 
+	/* Automotive Profile : Static variables */
+	// port_state : already defined as port_state
+	bool isGM;
+	bool testMode;
+	// asCapable : already defined as asCapable
+	char initialLogPdelayReqInterval;
+	char initialLogSyncInterval;
+	char operLogPdelayReqInterval;
+	char operLogSyncInterval;
+	bool automotive_profile;
+
+	// Test Status variables
+	uint32_t linkUpCount;
+	uint32_t linkDownCount;
+	StationState_t stationState;
+
+
+	/* Automotive Profile : Persistant variables */
+	// neighborPropDelay : defined as one_way_delay ??
+	// rateRatio : Optional and didn't fine this variable. Will proceed without writing it.
+	// neighborRateRatio : defined as _peer_rate_offset ??
+
+	// Automotive Profile AVB SYNC state indicator. > 0 will inditate valid AVB SYNC state
+	uint32_t avbSyncState;
+
+
 	int32_t *rate_offset_array;
 	uint32_t rate_offset_array_size;
 	uint32_t rate_offset_count;
@@ -256,6 +374,7 @@ class IEEE1588Port {
 	PTPMessageAnnounce *qualified_announce;
 
 	uint16_t announce_sequence_id;
+	uint16_t signal_sequence_id;
 	uint16_t sync_sequence_id;
 
 	uint16_t pdelay_sequence_id;
@@ -273,10 +392,16 @@ class IEEE1588Port {
 
 	OSThread *listening_thread;
 
+	OSThread *link_thread;
+
 	OSCondition *port_ready_condition;
 
 	OSLock *pdelay_rx_lock;
 	OSLock *port_tx_lock;
+
+	OSLock *syncIntervalTimerLock;
+	OSLock *announceIntervalTimerLock;
+	OSLock *pDelayIntervalTimerLock;
 
 	OSThreadFactory *thread_factory;
 	OSTimerFactory *timer_factory;
@@ -284,7 +409,7 @@ class IEEE1588Port {
 	HWTimestamper *_hw_timestamper;
 
 	net_result port_send
-	(uint8_t * buf, int size, MulticastType mcast_type,
+	(uint16_t etherType, uint8_t * buf, int size, MulticastType mcast_type,
 	 PortIdentity * destIdentity, bool timestamp);
 
 	InterfaceLabel *net_label;
@@ -293,6 +418,12 @@ class IEEE1588Port {
 	OSConditionFactory *condition_factory;
 
 	bool pdelay_started;
+	bool sync_rate_interval_timer_started;
+
+	uint16_t lastGmTimeBaseIndicator;
+
+	IEEE1588PortCounters_t counters;
+
  public:
 	bool forceSlave;	//!< Forces port to be slave. Added for testing.
 
@@ -347,6 +478,13 @@ class IEEE1588Port {
 	void startPDelay();
 
 	/**
+	 * @brief  Starts Sync Rate Interval event timer. Used for the 
+	 *  	   Automotive Profile.
+	 * @return void
+	 */
+	void startSyncRateIntervalTimer();
+
+	/**
 	 * @brief  Starts announce event timer
 	 * @return void
 	 */
@@ -357,6 +495,30 @@ class IEEE1588Port {
 	 * @return void
 	 */
 	void syncDone() {
+		GPTP_LOG_VERBOSE("Sync complete");
+
+		if (automotive_profile && testMode && port_state == PTP_SLAVE) {
+			if (avbSyncState > 0) {
+				avbSyncState--;
+				if (avbSyncState == 0) {
+					stationState = STATION_STATE_AVB_SYNC;
+					APMessageTestStatus *testStatusMsg = new APMessageTestStatus(this);
+					if (testStatusMsg) {
+						testStatusMsg->sendPort(this);
+						delete testStatusMsg;
+					}
+				}
+			}
+		}
+
+		if (automotive_profile) {
+			if (!sync_rate_interval_timer_started) {
+				if (log_mean_sync_interval != operLogSyncInterval) {
+					startSyncRateIntervalTimer();
+				}
+			}
+		}
+
 		if( !pdelay_started ) {
 			startPDelay();
 		}
@@ -377,7 +539,7 @@ class IEEE1588Port {
 	 */
 	void setAsCapable(bool ascap) {
 		if (ascap != asCapable) {
-			fprintf(stderr, "AsCapable: %s\n",
+			GPTP_LOG_INFO("AsCapable: %s",
 					ascap == true ? "Enabled" : "Disabled");
 		}
 		if(!ascap){
@@ -393,15 +555,23 @@ class IEEE1588Port {
 	bool getAsCapable() { return( asCapable ); }
 
 	/**
+	 * @brief  Gets the AVnu automotive profile flag
+	 * @return automotive_profile flag
+	 */
+	bool getAutomotiveProfile() { return( automotive_profile ); }
+
+	/**
 	 * Destroys a IEEE1588Port
 	 */
 	~IEEE1588Port();
 
 	/**
-	 * @brief  Creates the IEEE1588Port interface.
+	 * @brief  Creates the IEEE1588Port interface. Will be 
+	 *  	   depricated when the Windows platform supports
+	 *  	   Automotive profile.
 	 * @param  clock IEEE1588Clock instance
 	 * @param  index Interface index
-	 * @param  forceSlave Forces port to be slave
+	 * @param  forceSlave Forces port to be slave 
 	 * @param  accelerated_sync_count If non-zero, then start 16ms sync timer
 	 * @param  timestamper Hardware timestamper instance
 	 * @param  offset  Initial clock offset
@@ -412,14 +582,23 @@ class IEEE1588Port {
 	 * @param  lock_factory OSLockFactory instance
 	 */
 	IEEE1588Port
-	(IEEE1588Clock * clock, uint16_t index,
-	 bool forceSlave, int accelerated_sync_count,
+	(IEEE1588Clock * clock,
+	 uint16_t index,
+	 bool forceSlave,
+	 int accelerated_sync_count,
 	 HWTimestamper * timestamper,
-	 int32_t offset, InterfaceLabel * net_label,
+	 int32_t offset,
+	 InterfaceLabel * net_label,
 	 OSConditionFactory * condition_factory,
 	 OSThreadFactory * thread_factory,
 	 OSTimerFactory * timer_factory,
 	 OSLockFactory * lock_factory);
+
+	/**
+	 * @brief  Creates the IEEE1588Port interface.
+	 * @param  init IEEE1588PortInit initialization parameters 
+	 */
+	IEEE1588Port(IEEE1588PortInit_t *portInit);
 
 	/**
 	 * @brief  Initializes the port. Creates network interface, initializes
@@ -433,6 +612,12 @@ class IEEE1588Port {
 	 * @return void
 	 */
 	void recoverPort(void);
+
+	/**
+	 * @brief Watch for link up and down events
+	 * @return Its an infinite loop. Returns NULL in case of error.
+	 */
+	void *watchNetlink(void);
 
 	/**
 	 * @brief Receives messages from the network interface
@@ -455,7 +640,7 @@ class IEEE1588Port {
 	 * @return void
 	 */
 	void sendEventPort
-	(uint8_t * buf, int len, MulticastType mcast_type,
+	(uint16_t etherType, uint8_t * buf, int len, MulticastType mcast_type,
 	 PortIdentity * destIdentity);
 
 	/**
@@ -467,7 +652,7 @@ class IEEE1588Port {
 	 * @return void
 	 */
 	void sendGeneralPort
-	(uint8_t * buf, int len, MulticastType mcast_type,
+	(uint16_t etherType, uint8_t * buf, int len, MulticastType mcast_type,
 	 PortIdentity * destIdentity);
 
 	/**
@@ -518,12 +703,45 @@ class IEEE1588Port {
 	}
 
 	/**
+	 * @brief  Gets the local_addr
+	 * @return LinkLayerAddress
+	 */
+	LinkLayerAddress *getLocalAddr(void) {
+		return &local_addr;
+	}
+
+	/**
 	 * @brief  Gets the sync interval value
 	 * @return Sync Interval
 	 */
 	char getSyncInterval(void) {
 		return log_mean_sync_interval;
 	}
+
+	/**
+	 * @brief  Sets the sync interval value
+	 * @param  val time interval
+	 * @return none
+	 */
+	void setSyncInterval(char val) {
+		log_mean_sync_interval = val;;
+	}
+
+	/**
+	 * @brief  Sets the sync interval back to initial value
+	 * @return none
+	 */
+	void setInitSyncInterval(void) {
+		log_mean_sync_interval = initialLogSyncInterval;;
+	}
+
+	/**
+	 * @brief  Start sync interval timer
+	 * @param  waitTime time interval
+	 * @return none
+	 */
+	void startSyncIntervalTimer(long long unsigned int waitTime);
+
 
 	/**
 	 * @brief  Gets the announce interval
@@ -534,12 +752,54 @@ class IEEE1588Port {
 	}
 
 	/**
+	 * @brief  Sets the announce interval
+	 * @param  val time interval
+	 * @return none
+	 */
+	void setAnnounceInterval(char val) {
+		log_mean_announce_interval = val;
+	}
+
+	/**
+	 * @brief  Start announce interval timer
+	 * @param  waitTime time interval
+	 * @return none
+	 */
+	void startAnnounceIntervalTimer(long long unsigned int waitTime);
+
+
+	/**
 	 * @brief  Gets the pDelay minimum interval
 	 * @return PDelay interval
 	 */
 	char getPDelayInterval(void) {
 		return log_min_mean_pdelay_req_interval;
 	}
+
+	/**
+	 * @brief  Sets the pDelay minimum interval
+	 * @param  val time interval
+	 * @return none
+	 */
+	void setPDelayInterval(char val) {
+		log_min_mean_pdelay_req_interval = val;
+	}
+
+	/**
+	 * @brief  Sets the pDelay minimum interval back to initial 
+	 *  	   value
+	 * @return none
+	 */
+	void setInitPDelayInterval(void) {
+		log_min_mean_pdelay_req_interval = initialLogPdelayReqInterval;
+	}
+
+	/**
+	 * @brief  Start pDelay interval timer
+	 * @param  waitTime time interval
+	 * @return none
+	 */
+	void startPDelayIntervalTimer(long long unsigned int waitTime);
 
 	/**
 	 * @brief  Gets the portState information
@@ -581,6 +841,14 @@ class IEEE1588Port {
 	 */
 	uint16_t getNextAnnounceSequenceId(void) {
 		return announce_sequence_id++;
+	}
+
+	/**
+	 * @brief  Increments signal sequence id and returns
+	 * @return Next signal sequence id.
+	 */
+	uint16_t getNextSignalSequenceId(void) {
+		return signal_sequence_id++;
 	}
 
 	/**
@@ -956,6 +1224,220 @@ class IEEE1588Port {
 	unsigned getSyncCount() {
 		return sync_count;
 	}
+
+
+	/**
+	 * @brief  Gets link up count
+	 * @return Link up  count
+	 */
+	uint32_t getLinkUpCount() {
+		return linkUpCount;
+	}
+
+	/**
+	 * @brief  Gets link down count
+	 * @return Link down count
+	 */
+	uint32_t getLinkDownCount() {
+		return linkDownCount;
+	}
+
+	/**
+	 * @brief  Gets the Station State for the Test Status 
+	 *  	   message
+	 * @return station state
+	 */
+	StationState_t getStationState() {
+		return stationState;
+	}
+
+
+	/**
+	 * @brief  Gets the lastGmTimeBaseIndicator
+	 * @return uint16 of the lastGmTimeBaseIndicator
+	 */
+	uint16_t getLastGmTimeBaseIndicator(void) {
+		return lastGmTimeBaseIndicator;
+	}
+
+	/**
+	 * @brief  Sets the lastGmTimeBaseIndicator
+	 * @param  gmTimeBaseIndicator from last Follow up message 
+	 * @return void
+	 */
+	void setLastGmTimeBaseIndicator(uint16_t gmTimeBaseIndicator) {
+		lastGmTimeBaseIndicator = gmTimeBaseIndicator;
+	}
+
+	/**
+	 * @brief  Increment IEEE Port counter: 
+	 *  	   ieee8021AsPortStatRxSyncCount
+	 * @return void
+	 */
+	void incCounter_ieee8021AsPortStatRxSyncCount(void) {
+		counters.ieee8021AsPortStatRxSyncCount++;
+	}
+
+	/**
+	 * @brief  Increment IEEE Port counter: 
+	 *  	   ieee8021AsPortStatRxFollowUpCount
+	 * @return void
+	 */
+	void incCounter_ieee8021AsPortStatRxFollowUpCount(void) {
+		counters.ieee8021AsPortStatRxFollowUpCount++;
+	}
+
+	/**
+	 * @brief  Increment IEEE Port counter: 
+	 *  	   ieee8021AsPortStatRxPdelayRequest
+	 * @return void
+	 */
+	void incCounter_ieee8021AsPortStatRxPdelayRequest(void) {
+		counters.ieee8021AsPortStatRxPdelayRequest++;
+	}
+
+	/**
+	 * @brief  Increment IEEE Port counter: 
+	 *  	   ieee8021AsPortStatRxPdelayResponse
+	 * @return void
+	 */
+	void incCounter_ieee8021AsPortStatRxPdelayResponse(void) {
+		counters.ieee8021AsPortStatRxPdelayResponse++;
+	}
+
+	/**
+	 * @brief  Increment IEEE Port counter: 
+	 *  	   ieee8021AsPortStatRxPdelayResponseFollowUp
+	 * @return void
+	 */
+	void incCounter_ieee8021AsPortStatRxPdelayResponseFollowUp(void) {
+		counters.ieee8021AsPortStatRxPdelayResponseFollowUp++;
+	}
+
+	/**
+	 * @brief  Increment IEEE Port counter: 
+	 *  	   ieee8021AsPortStatRxAnnounce
+	 * @return void
+	 */
+	void incCounter_ieee8021AsPortStatRxAnnounce(void) {
+		counters.ieee8021AsPortStatRxAnnounce++;
+	}
+
+	/**
+	 * @brief  Increment IEEE Port counter: 
+	 *  	   ieee8021AsPortStatRxPTPPacketDiscard
+	 * @return void
+	 */
+	void incCounter_ieee8021AsPortStatRxPTPPacketDiscard(void) {
+		counters.ieee8021AsPortStatRxPTPPacketDiscard++;
+	}
+
+	/**
+	 * @brief  Increment IEEE Port counter: 
+	 *  	   ieee8021AsPortStatRxSyncReceiptTimeouts
+	 * @return void
+	 */
+	void incCounter_ieee8021AsPortStatRxSyncReceiptTimeouts(void) {
+		counters.ieee8021AsPortStatRxSyncReceiptTimeouts++;
+	}
+
+	/**
+	 * @brief  Increment IEEE Port counter: 
+	 *  	   ieee8021AsPortStatAnnounceReceiptTimeouts
+	 * @return void
+	 */
+	void incCounter_ieee8021AsPortStatAnnounceReceiptTimeouts(void) {
+		counters.ieee8021AsPortStatAnnounceReceiptTimeouts++;
+	}
+
+
+	/**
+	 * @brief  Increment IEEE Port counter: 
+	 *  	   ieee8021AsPortStatPdelayAllowedLostResponsesExceeded
+	 * @return void
+	 */
+	// TODO: Not called
+	void incCounter_ieee8021AsPortStatPdelayAllowedLostResponsesExceeded(void) {
+		counters.ieee8021AsPortStatPdelayAllowedLostResponsesExceeded++;
+	}
+
+	/**
+	 * @brief  Increment IEEE Port counter: 
+	 *  	   ieee8021AsPortStatTxSyncCount
+	 * @return void
+	 */
+	void incCounter_ieee8021AsPortStatTxSyncCount(void) {
+		counters.ieee8021AsPortStatTxSyncCount++;
+	}
+
+	/**
+	 * @brief  Increment IEEE Port counter: 
+	 *  	   ieee8021AsPortStatTxFollowUpCount
+	 * @return void
+	 */
+	void incCounter_ieee8021AsPortStatTxFollowUpCount(void) {
+		counters.ieee8021AsPortStatTxFollowUpCount++;
+	}
+
+	/**
+	 * @brief  Increment IEEE Port counter: 
+	 *  	   ieee8021AsPortStatTxPdelayRequest
+	 * @return void
+	 */
+	void incCounter_ieee8021AsPortStatTxPdelayRequest(void) {
+		counters.ieee8021AsPortStatTxPdelayRequest++;
+	}
+
+	/**
+	 * @brief  Increment IEEE Port counter: 
+	 *  	   ieee8021AsPortStatTxPdelayResponse
+	 * @return void
+	 */
+	void incCounter_ieee8021AsPortStatTxPdelayResponse(void) {
+		counters.ieee8021AsPortStatTxPdelayResponse++;
+	}
+
+	/**
+	 * @brief  Increment IEEE Port counter: 
+	 *  	   ieee8021AsPortStatTxPdelayResponseFollowUp
+	 * @return void
+	 */
+	void incCounter_ieee8021AsPortStatTxPdelayResponseFollowUp(void) {
+		counters.ieee8021AsPortStatTxPdelayResponseFollowUp++;
+	}
+
+	/**
+	 * @brief  Increment IEEE Port counter: 
+	 *  	   ieee8021AsPortStatTxAnnounce
+	 * @return void
+	 */
+	void incCounter_ieee8021AsPortStatTxAnnounce(void) {
+		counters.ieee8021AsPortStatTxAnnounce++;
+	}
+
+	/**
+	 * @brief  Logs port counters
+	 * @return void
+	 */
+	void logIEEEPortCounters(void) {
+		GPTP_LOG_STATUS("IEEE Port Counter ieee8021AsPortStatRxSyncCount : %u", counters.ieee8021AsPortStatRxSyncCount);
+		GPTP_LOG_STATUS("IEEE Port Counter ieee8021AsPortStatRxFollowUpCount : %u", counters.ieee8021AsPortStatRxFollowUpCount);
+		GPTP_LOG_STATUS("IEEE Port Counter ieee8021AsPortStatRxPdelayRequest : %u", counters.ieee8021AsPortStatRxPdelayRequest);
+		GPTP_LOG_STATUS("IEEE Port Counter ieee8021AsPortStatRxPdelayResponse : %u", counters.ieee8021AsPortStatRxPdelayResponse);
+		GPTP_LOG_STATUS("IEEE Port Counter ieee8021AsPortStatRxPdelayResponseFollowUp : %u", counters.ieee8021AsPortStatRxPdelayResponseFollowUp);
+		GPTP_LOG_STATUS("IEEE Port Counter ieee8021AsPortStatRxAnnounce : %u", counters.ieee8021AsPortStatRxAnnounce);
+		GPTP_LOG_STATUS("IEEE Port Counter ieee8021AsPortStatRxPTPPacketDiscard : %u", counters.ieee8021AsPortStatRxPTPPacketDiscard);
+		GPTP_LOG_STATUS("IEEE Port Counter ieee8021AsPortStatRxSyncReceiptTimeouts : %u", counters.ieee8021AsPortStatRxSyncReceiptTimeouts);
+		GPTP_LOG_STATUS("IEEE Port Counter ieee8021AsPortStatAnnounceReceiptTimeouts : %u", counters.ieee8021AsPortStatAnnounceReceiptTimeouts);
+		GPTP_LOG_STATUS("IEEE Port Counter ieee8021AsPortStatPdelayAllowedLostResponsesExceeded : %u", counters.ieee8021AsPortStatPdelayAllowedLostResponsesExceeded);
+		GPTP_LOG_STATUS("IEEE Port Counter ieee8021AsPortStatTxSyncCount : %u", counters.ieee8021AsPortStatTxSyncCount);
+		GPTP_LOG_STATUS("IEEE Port Counter ieee8021AsPortStatTxFollowUpCount : %u", counters.ieee8021AsPortStatTxFollowUpCount);
+		GPTP_LOG_STATUS("IEEE Port Counter ieee8021AsPortStatTxPdelayRequest : %u", counters.ieee8021AsPortStatTxPdelayRequest);
+		GPTP_LOG_STATUS("IEEE Port Counter ieee8021AsPortStatTxPdelayResponse : %u", counters.ieee8021AsPortStatTxPdelayResponse);
+		GPTP_LOG_STATUS("IEEE Port Counter ieee8021AsPortStatTxPdelayResponseFollowUp : %u", counters.ieee8021AsPortStatTxPdelayResponseFollowUp);
+		GPTP_LOG_STATUS("IEEE Port Counter ieee8021AsPortStatTxAnnounce : %u", counters.ieee8021AsPortStatTxAnnounce);
+	}
+
 };
 
 #endif

--- a/daemons/gptp/common/debugout.hpp
+++ b/daemons/gptp/common/debugout.hpp
@@ -38,6 +38,9 @@
 
 #include <stdio.h>
 
+// TODO_HARMAN - TEST
+// #define PTP_DEBUG 1
+
 #define XPTPD_ERROR(fmt,...) fprintf( stderr, "ERROR at %u in %s: " fmt "\n", __LINE__, __FILE__ ,## __VA_ARGS__)	/*!< Prints errors at stderr output*/
 #ifdef PTP_DEBUG
 #define XPTPD_INFO(fmt,...) fprintf( stderr, "DEBUG at %u in %s: " fmt "\n", __LINE__, __FILE__ ,## __VA_ARGS__) /*!< Prints debugs at stderr output */

--- a/daemons/gptp/common/gptp_log.cpp
+++ b/daemons/gptp/common/gptp_log.cpp
@@ -1,0 +1,60 @@
+/*************************************************************************************************************
+Copyright (c) 2012-2016, Harman International Industries, Incorporated
+All rights reserved.
+ 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ 
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ 
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS LISTED "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS LISTED BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*************************************************************************************************************/
+
+#include <gptp_log.hpp>
+
+#include <stdio.h>
+#include <stdarg.h>
+#include <time.h>
+
+void gptpLog(const char *tag, const char *path, int line, const char *fmt, ...)
+{
+	char msg[1024];
+
+	va_list args;
+	va_start(args, fmt);
+	vsprintf(msg, fmt, args);
+
+	time_t tNow = time(NULL);
+	struct tm tmNow;
+	localtime_r(&tNow, &tmNow);
+
+	struct timespec ts;
+	clock_gettime(CLOCK_REALTIME, &ts);
+
+	if (path) {
+		fprintf(stderr, "%s: GPTP [%2.2d:%2.2d:%2.2d:%3.3ld] [%s:%u] %s\n",
+			   tag, tmNow.tm_hour, tmNow.tm_min, tmNow.tm_sec, ts.tv_nsec / 1000000, path, line, msg);
+	}
+	else {
+		fprintf(stderr, "%s: GPTP [%2.2d:%2.2d:%2.2d:%3.3ld] %s\n",
+			   tag, tmNow.tm_hour, tmNow.tm_min, tmNow.tm_sec, ts.tv_nsec / 1000000, msg);
+	}
+}
+
+
+
+
+

--- a/daemons/gptp/common/gptp_log.hpp
+++ b/daemons/gptp/common/gptp_log.hpp
@@ -1,0 +1,94 @@
+/*************************************************************************************************************
+Copyright (c) 2012-2016, Harman International Industries, Incorporated
+All rights reserved.
+ 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ 
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ 
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS LISTED "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS LISTED BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*************************************************************************************************************/
+
+#ifndef GPTP_LOG_HPP
+#define GPTP_LOG_HPP
+
+/**@file*/
+
+#include <stdio.h>
+#include <stdarg.h>
+#include <time.h>
+
+#define GPTP_LOG_CRITICAL_ON 		1
+#define GPTP_LOG_ERROR_ON 			1
+#define GPTP_LOG_EXCEPTION_ON 		1
+#define GPTP_LOG_INFO_ON 			1
+#define GPTP_LOG_STATUS_ON			1
+//#define GPTP_LOG_DEBUG_ON			1
+//#define GPTP_LOG_VERBOSE_ON		1
+
+
+void gptpLog(const char *tag, const char *path, int line, const char *fmt, ...);
+
+#ifdef GPTP_LOG_CRITICAL_ON
+#define GPTP_LOG_CRITICAL(fmt,...) gptpLog("CRITICAL ", NULL, 0, fmt, ## __VA_ARGS__)
+#else
+#define GPTP_LOG_CRITICAL(fmt,...)
+#endif  
+
+#ifdef GPTP_LOG_ERROR_ON
+#define GPTP_LOG_ERROR(fmt,...) gptpLog("ERROR    ", NULL, 0, fmt, ## __VA_ARGS__)
+#else
+#define GPTP_LOG_ERROR(fmt,...)
+#endif  
+
+#ifdef GPTP_LOG_EXCEPTION_ON
+#define GPTP_LOG_EXCEPTION(fmt,...) gptpLog("EXCEPTION", NULL, 0, fmt, ## __VA_ARGS__)
+#else
+#define GPTP_LOG_EXCEPTION(fmt,...)
+#endif  
+
+#ifdef GPTP_LOG_WARNING_ON
+#define GPTP_LOG_WARNING(fmt,...) gptpLog("WARNING  ", NULL, 0, fmt, ## __VA_ARGS__)
+#else
+#define GPTP_LOG_WARNING(fmt,...)
+#endif  
+
+#ifdef GPTP_LOG_INFO_ON
+#define GPTP_LOG_INFO(fmt,...) gptpLog("INFO     ", NULL, 0, fmt, ## __VA_ARGS__)
+#else
+#define GPTP_LOG_INFO(fmt,...)
+#endif  
+
+#ifdef GPTP_LOG_STATUS_ON
+#define GPTP_LOG_STATUS(fmt,...) gptpLog("STATUS   ", NULL, 0, fmt, ## __VA_ARGS__)
+#else
+#define GPTP_LOG_STATUS(fmt,...)
+#endif  
+
+#ifdef GPTP_LOG_DEBUG_ON
+#define GPTP_LOG_DEBUG(fmt,...) gptpLog("DEBUG    ", __FILE__, __LINE__, fmt, ## __VA_ARGS__)
+#else
+#define GPTP_LOG_DEBUG(fmt,...)
+#endif  
+
+#ifdef GPTP_LOG_VERBOSE_ON
+#define GPTP_LOG_VERBOSE(fmt,...) gptpLog("VERBOSE  ", __FILE__, __LINE__, fmt, ## __VA_ARGS__)
+#else
+#define GPTP_LOG_VERBOSE(fmt,...)
+#endif  
+
+#endif

--- a/daemons/gptp/common/ieee1588.hpp
+++ b/daemons/gptp/common/ieee1588.hpp
@@ -48,6 +48,8 @@
 #include <ptptypes.hpp>
 
 #include <debugout.hpp>
+#include <gptp_log.hpp>
+
 
 #define MAX_PORTS 32	/*!< Maximum number of IEEE1588Port instances */
 
@@ -75,6 +77,8 @@ typedef enum {
 	NULL_EVENT = 0,						//!< Null Event. Used to initialize events.
 	POWERUP = 5,						//!< Power Up. Initialize state machines.
 	INITIALIZE,							//!< Same as POWERUP.
+	LINKUP,								//!< Triggered when link comes up
+	LINKDOWN,							//!< Triggered when link goes down
 	STATE_CHANGE_EVENT,					//!< Signalizes that something has changed. Recalculates best master.
 	SYNC_INTERVAL_TIMEOUT_EXPIRES,		//!< Sync interval expired. Its time to send a sync message.
 	PDELAY_INTERVAL_TIMEOUT_EXPIRES,	//!< PDELAY interval expired. Its time to send pdelay_req message
@@ -85,6 +89,7 @@ typedef enum {
 	FAULT_DETECTED,						//!< A fault was detected.
 	PDELAY_DEFERRED_PROCESSING,			//!< Defers pdelay processing
 	PDELAY_RESP_RECEIPT_TIMEOUT_EXPIRES,	//!< Pdelay response message timeout
+	SYNC_RATE_INTERVAL_TIMEOUT_EXPIRED,	//!< Sync rate signal timeout for the Automotive Profile
 } Event;
 
 /**
@@ -214,7 +219,7 @@ class ClockIdentity {
 	 * @return void
 	 */
 	void print(const char *str) {
-		XPTPD_INFO
+		GPTP_LOG_VERBOSE
 			( "Clock Identity(%s): %02hhx %02hhx %02hhx %02hhx %02hhx %02hhx %02hhx %02hhx\n",
 			  str, id[0], id[1], id[2], id[3], id[4], id[5], id[6], id[7] );
 	}

--- a/daemons/gptp/common/ieee1588clock.cpp
+++ b/daemons/gptp/common/ieee1588clock.cpp
@@ -264,7 +264,7 @@ FrequencyRatio IEEE1588Clock::calcLocalSystemClockRateDifference( Timestamp loca
 	unsigned long long inter_local_time;
 	FrequencyRatio ppt_offset;
 
-	XPTPD_INFO( "Calculated local to system clock rate difference" );
+	GPTP_LOG_VERBOSE( "Calculated local to system clock rate difference" );
 
 	if( !_local_system_freq_offset_init ) {
 		_prev_system_time = system_time;
@@ -299,7 +299,7 @@ FrequencyRatio IEEE1588Clock::calcMasterLocalClockRateDifference( Timestamp mast
 	unsigned long long inter_master_time;
 	FrequencyRatio ppt_offset;
 	
-	XPTPD_INFO( "Calculated master to local clock rate difference" );
+	GPTP_LOG_VERBOSE( "Calculated master to local clock rate difference" );
 
 	if( !_master_local_freq_offset_init ) {
 		_prev_sync_time = sync_time;
@@ -367,7 +367,7 @@ void IEEE1588Clock::setMasterOffset
 		if( _ppm > UPPER_FREQ_LIMIT ) _ppm = UPPER_FREQ_LIMIT;
 		if( _timestamper ) {
 			if( !_timestamper->HWTimestamper_adjclockrate( _ppm )) {
-				XPTPD_ERROR( "Failed to adjust clock rate" );
+				GPTP_LOG_ERROR( "Failed to adjust clock rate" );
 			}
 		}
 	}

--- a/daemons/gptp/common/ieee1588port.cpp
+++ b/daemons/gptp/common/ieee1588port.cpp
@@ -1,31 +1,31 @@
 /******************************************************************************
 
-  Copyright (c) 2009-2012, Intel Corporation
+  Copyright (c) 2009-2012, Intel Corporation 
   All rights reserved.
-
-  Redistribution and use in source and binary forms, with or without
+  
+  Redistribution and use in source and binary forms, with or without 
   modification, are permitted provided that the following conditions are met:
-
-   1. Redistributions of source code must retain the above copyright notice,
+  
+   1. Redistributions of source code must retain the above copyright notice, 
       this list of conditions and the following disclaimer.
-
-   2. Redistributions in binary form must reproduce the above copyright
-      notice, this list of conditions and the following disclaimer in the
+  
+   2. Redistributions in binary form must reproduce the above copyright 
+      notice, this list of conditions and the following disclaimer in the 
       documentation and/or other materials provided with the distribution.
-
-   3. Neither the name of the Intel Corporation nor the names of its
-      contributors may be used to endorse or promote products derived from
+  
+   3. Neither the name of the Intel Corporation nor the names of its 
+      contributors may be used to endorse or promote products derived from 
       this software without specific prior written permission.
-
+  
   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
   POSSIBILITY OF SUCH DAMAGE.
 
@@ -41,14 +41,29 @@
 #include <avbts_osnet.hpp>
 #include <avbts_oscondition.hpp>
 
+#include <gptp_log.hpp>
+
 #include <stdio.h>
-
 #include <math.h>
-
 #include <stdlib.h>
+#include <stdint.h>
+
 
 LinkLayerAddress IEEE1588Port::other_multicast(OTHER_MULTICAST);
 LinkLayerAddress IEEE1588Port::pdelay_multicast(PDELAY_MULTICAST);
+LinkLayerAddress IEEE1588Port::test_status_multicast(TEST_STATUS_MULTICAST);
+
+
+OSThreadExitCode watchNetLinkWrapper(void *arg)
+{
+	IEEE1588Port *port;
+
+	port = (IEEE1588Port *) arg;
+	if (port->watchNetlink() == NULL)
+		return osthread_ok;
+	else
+		return osthread_error;
+}
 
 OSThreadExitCode openPortWrapper(void *arg)
 {
@@ -68,42 +83,63 @@ IEEE1588Port::~IEEE1588Port()
 	if( qualified_announce != NULL ) delete qualified_announce;
 }
 
-IEEE1588Port::IEEE1588Port
-(IEEE1588Clock * clock, uint16_t index, bool forceSlave,
- int accelerated_sync_count, HWTimestamper * timestamper, int32_t offset,
- InterfaceLabel * net_label, OSConditionFactory * condition_factory,
- OSThreadFactory * thread_factory, OSTimerFactory * timer_factory,
- OSLockFactory * lock_factory)
+
+IEEE1588Port::IEEE1588Port(IEEE1588PortInit_t *portInit)
 {
 	sync_sequence_id = 0;
 
-	clock->registerPort(this, index);
-	this->clock = clock;
-	ifindex = index;
+	clock = portInit->clock;
+	ifindex = portInit->index;
+	clock->registerPort(this, ifindex);
 
-	this->forceSlave = forceSlave;
+	forceSlave = portInit->forceSlave;
 	port_state = PTP_INITIALIZING;
 
-	asCapable = false;
+	automotive_profile = portInit->automotive_profile;
+	isGM = portInit->isGM;
+	testMode = portInit->testMode;
+	initialLogSyncInterval = portInit->initialLogSyncInterval;
+	initialLogPdelayReqInterval = portInit->initialLogPdelayReqInterval;
+	operLogPdelayReqInterval = portInit->operLogPdelayReqInterval;
+	operLogSyncInterval = portInit->operLogSyncInterval;
+
+	if (automotive_profile) {
+		asCapable = true;
+
+		initialLogSyncInterval = -5;		// 31.25 ms
+		initialLogPdelayReqInterval = -3;	// 125 ms
+		operLogPdelayReqInterval = 0;		// 1 second	
+		operLogSyncInterval = 0;			// 1 second
+	}
+	else {
+		asCapable = false;
+
+		initialLogSyncInterval = -3;		// 125 ms
+		initialLogPdelayReqInterval = -3;	// 125 ms
+		operLogPdelayReqInterval = 0;		// 1 second	
+		operLogSyncInterval = 0;			// 1 second
+	}
 
 	announce_sequence_id = 0;
+	signal_sequence_id = 0;
 	sync_sequence_id = 0;
 	pdelay_sequence_id = 0;
 
 	sync_sequence_id = 0;
 
 	pdelay_started = false;
+	sync_rate_interval_timer_started = false;
 
-	log_mean_sync_interval = -3;
-	_accelerated_sync_count = accelerated_sync_count;
+	log_mean_sync_interval = initialLogSyncInterval;
+	_accelerated_sync_count = portInit->accelerated_sync_count;
 	log_mean_announce_interval = 0;
-	log_min_mean_pdelay_req_interval = 0;
+	log_min_mean_pdelay_req_interval = initialLogPdelayReqInterval;
 
-	_current_clock_offset = _initial_clock_offset = offset;
+	_current_clock_offset = _initial_clock_offset = portInit->offset;
 
 	rate_offset_array = NULL;
 
-	_hw_timestamper = timestamper;
+	_hw_timestamper = portInit->timestamper;
 
 	one_way_delay = 3600000000000;
 
@@ -116,17 +152,31 @@ IEEE1588Port::IEEE1588Port
 
 	qualified_announce = NULL;
 
-	this->net_label = net_label;
+	this->net_label = portInit->net_label;
 
-	this->timer_factory = timer_factory;
-	this->thread_factory = thread_factory;
+	this->timer_factory = portInit->timer_factory;
+	this->thread_factory = portInit->thread_factory;
 
-	this->condition_factory = condition_factory;
-	this->lock_factory = lock_factory;
+	this->condition_factory = portInit->condition_factory;
+	this->lock_factory = portInit->lock_factory;
 
 	pdelay_count = 0;
 	sync_count = 0;
+
+	if (testMode) {
+		if (isGM) {
+			avbSyncState = 1;
+		}
+		else {
+			avbSyncState = 2;
+		}
+		linkUpCount = 1;		// TODO : really should check the current linkup status http://stackoverflow.com/questions/15723061/how-to-check-if-interface-is-up
+		linkDownCount = 0;
+		stationState = STATION_STATE_RESERVED;
+	}
 }
+
+
 
 bool IEEE1588Port::init_port(int delay[4])
 {
@@ -140,7 +190,7 @@ bool IEEE1588Port::init_port(int delay[4])
 
 	if( _hw_timestamper != NULL ) {
 		if( !_hw_timestamper->HWTimestamper_init( net_label, net_iface )) {
-			XPTPD_ERROR
+			GPTP_LOG_ERROR
 				( "Failed to initialize hardware timestamper, "
 				  "falling back to software timestamping" );
 			_hw_timestamper = NULL;
@@ -150,6 +200,10 @@ bool IEEE1588Port::init_port(int delay[4])
 
 	pdelay_rx_lock = lock_factory->createLock(oslock_recursive);
 	port_tx_lock = lock_factory->createLock(oslock_recursive);
+
+	syncIntervalTimerLock = lock_factory->createLock(oslock_recursive);
+	announceIntervalTimerLock = lock_factory->createLock(oslock_recursive);
+	pDelayIntervalTimerLock = lock_factory->createLock(oslock_recursive);
 
 	port_identity.setClockIdentity(clock->getClockIdentity());
 	port_identity.setPortNumber(&ifindex);
@@ -161,11 +215,29 @@ bool IEEE1588Port::init_port(int delay[4])
 
 void IEEE1588Port::startPDelay() {
 	pdelay_started = true;
-	clock->addEventTimer( this, PDELAY_INTERVAL_TIMEOUT_EXPIRES, 32000000 );
+	startPDelayIntervalTimer(32000000);
+}
+
+void IEEE1588Port::startSyncRateIntervalTimer() {
+	if (automotive_profile) {
+		sync_rate_interval_timer_started = true;
+		if (isGM) {
+			// GM will wait up to 8  seconds for signaling rate
+			// TODO: This isn't according to spec but set because it is believed that some slave devices aren't signalling
+			//  to reduce the rate
+			clock->addEventTimer( this, SYNC_RATE_INTERVAL_TIMEOUT_EXPIRED, 8000000000 );
+		}
+		else {
+			// Slave will time out after 4 seconds
+			clock->addEventTimer( this, SYNC_RATE_INTERVAL_TIMEOUT_EXPIRED, 4000000000 );
+		}
+	}
 }
 
 void IEEE1588Port::startAnnounce() {
-	clock->addEventTimer( this, ANNOUNCE_INTERVAL_TIMEOUT_EXPIRES, 16000000 );
+	if (!automotive_profile) {
+		startAnnounceIntervalTimer(16000000);
+	}
 }
 
 bool IEEE1588Port::serializeState( void *buf, off_t *count ) {
@@ -237,7 +309,7 @@ bool IEEE1588Port::serializeState( void *buf, off_t *count ) {
 
 bool IEEE1588Port::restoreSerializedState( void *buf, off_t *count ) {
   bool ret = true;
-
+  
   /* asCapable */
   if( ret && *count >= (off_t) sizeof( asCapable )) {
     memcpy( &asCapable, buf, sizeof( asCapable ));
@@ -289,6 +361,14 @@ bool IEEE1588Port::restoreSerializedState( void *buf, off_t *count ) {
   return ret;
 }
 
+void *IEEE1588Port::watchNetlink(void)
+{
+	// Should never return
+	net_iface->watchNetLink(this);
+
+	return NULL;
+}
+
 void *IEEE1588Port::openPort(IEEE1588Port *port)
 {
 	port_ready_condition->signal();
@@ -303,20 +383,20 @@ void *IEEE1588Port::openPort(IEEE1588Port *port)
 		size_t length = sizeof(buf);
 
 		if ((rrecv = net_iface->nrecv(&remote, buf, length,&get_delay)) == net_succeed) {
-			XPTPD_INFO("Processing network buffer");
+			GPTP_LOG_VERBOSE("Processing network buffer");
 			msg = buildPTPMessage((char *)buf, (int)length, &remote,
 					    this);
 			if (msg != NULL) {
-				XPTPD_INFO("Processing message");
+				GPTP_LOG_VERBOSE("Processing message");
 				msg->processMessage(this);
 				if (msg->garbage()) {
 					delete msg;
 				}
 			} else {
-				XPTPD_ERROR("Discarding invalid message");
+				GPTP_LOG_ERROR("Discarding invalid message");
 			}
 		} else if (rrecv == net_fatal) {
-			XPTPD_ERROR("read from network interface failed");
+			GPTP_LOG_ERROR("read from network interface failed");
 			this->processEvent(FAULT_DETECTED);
 			break;
 		}
@@ -325,7 +405,7 @@ void *IEEE1588Port::openPort(IEEE1588Port *port)
 	return NULL;
 }
 
-net_result IEEE1588Port::port_send(uint8_t * buf, int size,
+net_result IEEE1588Port::port_send(uint16_t etherType, uint8_t * buf, int size,
 				   MulticastType mcast_type,
 				   PortIdentity * destIdentity, bool timestamp)
 {
@@ -334,14 +414,18 @@ net_result IEEE1588Port::port_send(uint8_t * buf, int size,
 	if (mcast_type != MCAST_NONE) {
 		if (mcast_type == MCAST_PDELAY) {
 			dest = pdelay_multicast;
-		} else {
+		} 
+		else if (mcast_type == MCAST_TEST_STATUS) {
+			dest = test_status_multicast;
+		}
+		else {
 			dest = other_multicast;
 		}
 	} else {
 		mapSocketAddr(destIdentity, &dest);
 	}
 
-	return net_iface->send(&dest, (uint8_t *) buf, size, timestamp);
+	return net_iface->send(&dest, etherType, (uint8_t *) buf, size, timestamp);
 }
 
 unsigned IEEE1588Port::getPayloadOffset()
@@ -349,25 +433,25 @@ unsigned IEEE1588Port::getPayloadOffset()
 	return net_iface->getPayloadOffset();
 }
 
-void IEEE1588Port::sendEventPort(uint8_t * buf, int size,
+void IEEE1588Port::sendEventPort(uint16_t etherType, uint8_t * buf, int size,
 				 MulticastType mcast_type,
 				 PortIdentity * destIdentity)
 {
-	net_result rtx = port_send(buf, size, mcast_type, destIdentity, true);
+	net_result rtx = port_send(etherType, buf, size, mcast_type, destIdentity, true);
 	if (rtx != net_succeed) {
-		XPTPD_ERROR("sendEventPort(): failure");
+		GPTP_LOG_ERROR("sendEventPort(): failure");
 	}
 
 	return;
 }
 
-void IEEE1588Port::sendGeneralPort(uint8_t * buf, int size,
+void IEEE1588Port::sendGeneralPort(uint16_t etherType, uint8_t * buf, int size,
 				   MulticastType mcast_type,
 				   PortIdentity * destIdentity)
 {
-	net_result rtx = port_send(buf, size, mcast_type, destIdentity, false);
+	net_result rtx = port_send(etherType, buf, size, mcast_type, destIdentity, false);
 	if (rtx != net_succeed) {
-		XPTPD_ERROR("sendGeneralPort(): failure");
+		GPTP_LOG_ERROR("sendGeneralPort(): failure");
 	}
 
 	return;
@@ -381,7 +465,7 @@ void IEEE1588Port::processEvent(Event e)
 	switch (e) {
 	case POWERUP:
 	case INITIALIZE:
-		XPTPD_INFO("Received POWERUP/INITIALIZE event");
+		GPTP_LOG_VERBOSE("Received POWERUP/INITIALIZE event");
 		clock->getTimerQLock();
 
 		{
@@ -393,9 +477,14 @@ void IEEE1588Port::processEvent(Event e)
 			if( port_state != PTP_MASTER ) {
 				_accelerated_sync_count = -1;
 			}
-
-			if( port_state != PTP_SLAVE && port_state != PTP_MASTER ) {
-				fprintf( stderr, "Starting PDelay\n" );
+			
+			if (!automotive_profile) {
+				if( port_state != PTP_SLAVE && port_state != PTP_MASTER ) {
+					GPTP_LOG_INFO("Starting PDelay");
+					startPDelay();
+				}
+			}
+			else {
 				startPDelay();
 			}
 
@@ -413,13 +502,21 @@ void IEEE1588Port::processEvent(Event e)
 					(ANNOUNCE_RECEIPT_TIMEOUT_MULTIPLIER*
 					 pow((double)2,getAnnounceInterval())*1000000000.0);
 			}
-
+      
 			port_ready_condition->wait_prelock();
+
+			link_thread = thread_factory->createThread();
+			if (!link_thread->start(watchNetLinkWrapper, (void *)this))
+			{
+				GPTP_LOG_ERROR("Error creating port link thread");
+				return;
+			}
+
 			listening_thread = thread_factory->createThread();
 			if (!listening_thread->
 				start (openPortWrapper, (void *)this))
 			{
-				XPTPD_ERROR("Error creating port thread");
+				GPTP_LOG_ERROR("Error creating port listener thread");
 				return;
 			}
 			port_ready_condition->wait();
@@ -432,110 +529,187 @@ void IEEE1588Port::processEvent(Event e)
 
 		clock->putTimerQLock();
 
-		break;
-	case STATE_CHANGE_EVENT:
-		if ( clock->getPriority1() != 255 ) {
-			int number_ports, j;
-			PTPMessageAnnounce *EBest = NULL;
-			char EBestClockIdentity[PTP_CLOCK_IDENTITY_LENGTH];
-
-			IEEE1588Port **ports;
-			clock->getPortList(number_ports, ports);
-
-
-
-			/* Find EBest for all ports */
-			j = 0;
-			for (int i = 0; i < number_ports; ++i) {
-				while (ports[j] == NULL)
-					++j;
-				if (ports[j]->port_state == PTP_DISABLED
-				    || ports[j]->port_state == PTP_FAULTY) {
-					continue;
+		if (automotive_profile) {
+			if (testMode) {
+				stationState = STATION_STATE_ETHERNET_READY;
+				APMessageTestStatus *testStatusMsg = new APMessageTestStatus(this);
+				if (testStatusMsg) {
+					testStatusMsg->sendPort(this);
+					delete testStatusMsg;
 				}
-				if (EBest == NULL) {
-					EBest = ports[j]->calculateERBest();
-				} else {
-					if (ports[j]->calculateERBest()->isBetterThan(EBest)) {
+			}
+
+			if (!isGM) {
+				// Send an initial signalling message
+				PTPMessageSignalling *sigMsg = new PTPMessageSignalling(this);
+				if (sigMsg) {
+					sigMsg->setintervals(log_min_mean_pdelay_req_interval, log_mean_sync_interval, PTPMessageSignalling::sigMsgInterval_NoSend);
+					
+					sigMsg->sendPort(this, NULL);
+					delete sigMsg;
+				}
+			}
+		}
+
+		break;
+
+	case LINKUP:
+		GPTP_LOG_EXCEPTION("LINK UP");
+
+		if (automotive_profile) {
+			asCapable = true;
+
+			if (testMode) {
+				stationState = STATION_STATE_ETHERNET_READY;
+				APMessageTestStatus *testStatusMsg = new APMessageTestStatus(this);
+				if (testStatusMsg) {
+					testStatusMsg->sendPort(this);
+					delete testStatusMsg;
+				}
+			}
+
+			log_mean_sync_interval = initialLogSyncInterval;
+			log_mean_announce_interval = 0;
+			log_min_mean_pdelay_req_interval = initialLogPdelayReqInterval;
+
+			if (!isGM) {
+				// Send an initial signalling message
+				PTPMessageSignalling *sigMsg = new PTPMessageSignalling(this);
+				if (sigMsg) {
+					sigMsg->setintervals(log_min_mean_pdelay_req_interval, log_mean_sync_interval, PTPMessageSignalling::sigMsgInterval_NoSend);
+
+					sigMsg->sendPort(this, NULL);
+					delete sigMsg;
+				}
+			}
+
+			// Start AVB SYNC at 2. It will decrement after each sync. When it reaches 0 the Test Status message 
+			//  can be sent
+			if (testMode) {
+				linkUpCount++;
+				if (isGM) {
+					avbSyncState = 1;
+				}
+				else {
+					avbSyncState = 2;
+				}
+			}
+		}
+
+		break;
+
+	case LINKDOWN:
+		// TODO : The determination of link down may not be reliable. It has been observed on one system routine LINKDOWN
+		//  events without any matching LINKUP events yet network traffic continues.
+		GPTP_LOG_EXCEPTION("LINK DOWN (maybe)");
+		if (testMode) {
+			linkDownCount++;
+		}
+		break;
+
+	case STATE_CHANGE_EVENT:
+		if (!automotive_profile) {		// BMCA is not active with Automotive Profile
+			if ( clock->getPriority1() != 255 ) {
+				int number_ports, j;
+				PTPMessageAnnounce *EBest = NULL;
+				char EBestClockIdentity[PTP_CLOCK_IDENTITY_LENGTH];
+
+				IEEE1588Port **ports;
+				clock->getPortList(number_ports, ports);
+
+				/* Find EBest for all ports */
+				j = 0;
+				for (int i = 0; i < number_ports; ++i) {
+					while (ports[j] == NULL)
+						++j;
+					if (ports[j]->port_state == PTP_DISABLED
+						|| ports[j]->port_state == PTP_FAULTY) {
+						continue;
+					}
+					if (EBest == NULL) {
 						EBest = ports[j]->calculateERBest();
+					} else {
+						if (ports[j]->calculateERBest()->isBetterThan(EBest)) {
+							EBest = ports[j]->calculateERBest();
+						}
 					}
 				}
-			}
 
-			/* Check if we've changed */
-			{
-
-			  uint8_t LastEBestClockIdentity[PTP_CLOCK_IDENTITY_LENGTH];
-			  clock->getLastEBestIdentity().
-				  getIdentityString( LastEBestClockIdentity );
-			  EBest->getGrandmasterIdentity( EBestClockIdentity );
-			  if( memcmp
-				  ( EBestClockIdentity, LastEBestClockIdentity,
-					PTP_CLOCK_IDENTITY_LENGTH ) != 0 )
-			  {
-				  ClockIdentity newGM;
-				  changed_external_master = true;
-				  newGM.set((uint8_t *) EBestClockIdentity );
-				  clock->setLastEBestIdentity( newGM );
-			  } else {
-				  changed_external_master = false;
-			  }
-			}
-
-			if( clock->isBetterThan( EBest )) {
-				// We're Grandmaster, set grandmaster info to me
-				ClockIdentity clock_identity;
-				unsigned char priority1;
-				unsigned char priority2;
-				ClockQuality clock_quality;
-
-				clock_identity = getClock()->getClockIdentity();
-				getClock()->setGrandmasterClockIdentity( clock_identity );
-				priority1 = getClock()->getPriority1();
-				getClock()->setGrandmasterPriority1( priority1 );
-				priority2 = getClock()->getPriority2();
-				getClock()->setGrandmasterPriority2( priority2 );
-				clock_quality = getClock()->getClockQuality();
-				getClock()->setGrandmasterClockQuality( clock_quality );
-			}
-
-			j = 0;
-			for (int i = 0; i < number_ports; ++i) {
-				while (ports[j] == NULL)
-					++j;
-				if (ports[j]->port_state == PTP_DISABLED
-				    || ports[j]->port_state == PTP_FAULTY) {
-					continue;
-				}
-				if (clock->isBetterThan(EBest)) {
-					// We are the GrandMaster, all ports are master
-					EBest = NULL;	// EBest == NULL : we were grandmaster
-					ports[j]->recommendState(PTP_MASTER,
-								 changed_external_master);
+				/* Check if we've changed */
+				{
+				  
+				  uint8_t LastEBestClockIdentity[PTP_CLOCK_IDENTITY_LENGTH];
+				  clock->getLastEBestIdentity().
+					  getIdentityString( LastEBestClockIdentity );
+				  EBest->getGrandmasterIdentity( EBestClockIdentity );
+				  if( memcmp
+					  ( EBestClockIdentity, LastEBestClockIdentity,
+						PTP_CLOCK_IDENTITY_LENGTH ) != 0 )
+				  {
+					  ClockIdentity newGM;
+					  changed_external_master = true;
+					  newGM.set((uint8_t *) EBestClockIdentity );
+					  clock->setLastEBestIdentity( newGM );
 				} else {
-					if( EBest == ports[j]->calculateERBest() ) {
-						// The "best" Announce was recieved on this port
-						ClockIdentity clock_identity;
-						unsigned char priority1;
-						unsigned char priority2;
-						ClockQuality *clock_quality;
+					  changed_external_master = false;
+				  }
+				}
+				
+				if (clock->isBetterThan(EBest)) {
+					// We're Grandmaster, set grandmaster info to me
+					ClockIdentity clock_identity;
+					unsigned char priority1;
+					unsigned char priority2;
+					ClockQuality clock_quality;
+				  
+					clock_identity = getClock()->getClockIdentity();
+					getClock()->setGrandmasterClockIdentity( clock_identity );
+					priority1 = getClock()->getPriority1();
+					getClock()->setGrandmasterPriority1( priority1 );
+					priority2 = getClock()->getPriority2();
+					getClock()->setGrandmasterPriority2( priority2 );
+					clock_quality = getClock()->getClockQuality();
+					getClock()->setGrandmasterClockQuality( clock_quality );
+				}
 
-						ports[j]->recommendState
-							( PTP_SLAVE, changed_external_master );
-
-						clock_identity = EBest->getGrandmasterClockIdentity();
-						getClock()->setGrandmasterClockIdentity(clock_identity);
-						priority1 = EBest->getGrandmasterPriority1();
-						getClock()->setGrandmasterPriority1( priority1 );
-						priority2 = EBest->getGrandmasterPriority2();
-						getClock()->setGrandmasterPriority2( priority2 );
-						clock_quality = EBest->getGrandmasterClockQuality();
-						getClock()->setGrandmasterClockQuality(*clock_quality);
+				j = 0;
+				for (int i = 0; i < number_ports; ++i) {
+					while (ports[j] == NULL)
+						++j;
+					if (ports[j]->port_state == PTP_DISABLED
+						|| ports[j]->port_state == PTP_FAULTY) {
+						continue;
+					}
+					if (clock->isBetterThan(EBest)) {
+						// We are the GrandMaster, all ports are master
+						EBest = NULL;	// EBest == NULL : we were grandmaster
+						ports[j]->recommendState(PTP_MASTER,
+									 changed_external_master);
 					} else {
-						/* Otherwise we are the master because we have
-						   sync'd to a better clock */
-						ports[j]->recommendState
-							(PTP_MASTER, changed_external_master);
+						if( EBest == ports[j]->calculateERBest() ) {
+							// The "best" Announce was recieved on this port
+							ClockIdentity clock_identity;
+							unsigned char priority1;
+							unsigned char priority2;
+							ClockQuality *clock_quality;
+							
+							ports[j]->recommendState
+								( PTP_SLAVE, changed_external_master );
+							
+							clock_identity = EBest->getGrandmasterClockIdentity();
+							getClock()->setGrandmasterClockIdentity(clock_identity);
+							priority1 = EBest->getGrandmasterPriority1();
+							getClock()->setGrandmasterPriority1( priority1 );
+							priority2 = EBest->getGrandmasterPriority2();
+							getClock()->setGrandmasterPriority2( priority2 );
+							clock_quality = EBest->getGrandmasterClockQuality();
+							getClock()->setGrandmasterClockQuality(*clock_quality);
+						} else {
+							/* Otherwise we are the master because we have 
+							   sync'd to a better clock */
+							ports[j]->recommendState
+								(PTP_MASTER, changed_external_master);
+						}
 					}
 				}
 			}
@@ -544,76 +718,88 @@ void IEEE1588Port::processEvent(Event e)
 	case ANNOUNCE_RECEIPT_TIMEOUT_EXPIRES:
 	case SYNC_RECEIPT_TIMEOUT_EXPIRES:
 		{
-			if( clock->getPriority1() == 255 ) {
-				// Restart timer
-				if( e == ANNOUNCE_RECEIPT_TIMEOUT_EXPIRES ) {
-					clock->addEventTimer
-						(this, ANNOUNCE_RECEIPT_TIMEOUT_EXPIRES,
-						 (ANNOUNCE_RECEIPT_TIMEOUT_MULTIPLIER*
-						  (unsigned long long)
-						  (pow((double)2,getAnnounceInterval())*
-						   1000000000.0)));
-				} else {
-					clock->addEventTimer
-						(this, SYNC_RECEIPT_TIMEOUT_EXPIRES,
-						 (SYNC_RECEIPT_TIMEOUT_MULTIPLIER*
-						  (unsigned long long)
-						  (pow((double)2,getSyncInterval())*
-						   1000000000.0)));
-				}
-				return;
+			if (e == ANNOUNCE_RECEIPT_TIMEOUT_EXPIRES) {
+				incCounter_ieee8021AsPortStatAnnounceReceiptTimeouts();
 			}
-			if (port_state == PTP_INITIALIZING
-			    || port_state == PTP_UNCALIBRATED
-			    || port_state == PTP_SLAVE
-			    || port_state == PTP_PRE_MASTER) {
-				fprintf
-					(stderr,
-					 "*** %s Timeout Expired - Becoming Master\n",
-					 e == ANNOUNCE_RECEIPT_TIMEOUT_EXPIRES ? "Announce" :
-					 "Sync" );
-				{
-				  // We're Grandmaster, set grandmaster info to me
-				  ClockIdentity clock_identity;
-				  unsigned char priority1;
-				  unsigned char priority2;
-				  ClockQuality clock_quality;
+			else if (e == SYNC_RECEIPT_TIMEOUT_EXPIRES) {
+				incCounter_ieee8021AsPortStatRxSyncReceiptTimeouts();
+			}
 
-				  clock_identity = getClock()->getClockIdentity();
-				  getClock()->setGrandmasterClockIdentity( clock_identity );
-				  priority1 = getClock()->getPriority1();
-				  getClock()->setGrandmasterPriority1( priority1 );
-				  priority2 = getClock()->getPriority2();
-				  getClock()->setGrandmasterPriority2( priority2 );
-				  clock_quality = getClock()->getClockQuality();
-				  getClock()->setGrandmasterClockQuality( clock_quality );
+			if (!automotive_profile) {
+				if( clock->getPriority1() == 255 ) {
+					// Restart timer
+					if( e == ANNOUNCE_RECEIPT_TIMEOUT_EXPIRES ) {
+						clock->addEventTimer
+							(this, ANNOUNCE_RECEIPT_TIMEOUT_EXPIRES,
+							 (ANNOUNCE_RECEIPT_TIMEOUT_MULTIPLIER*
+							  (unsigned long long)
+							  (pow((double)2,getAnnounceInterval())*
+							   1000000000.0)));
+					} else {
+						clock->addEventTimer
+							(this, SYNC_RECEIPT_TIMEOUT_EXPIRES,
+							 (SYNC_RECEIPT_TIMEOUT_MULTIPLIER*
+							  (unsigned long long)
+							  (pow((double)2,getSyncInterval())*
+							   1000000000.0)));
+					}
+					return;
 				}
-				port_state = PTP_MASTER;
-				Timestamp system_time;
-				Timestamp device_time;
+				if (port_state == PTP_INITIALIZING
+					|| port_state == PTP_UNCALIBRATED
+					|| port_state == PTP_SLAVE
+					|| port_state == PTP_PRE_MASTER) {
+					GPTP_LOG_INFO
+						("*** %s Timeout Expired - Becoming Master", 
+						 e == ANNOUNCE_RECEIPT_TIMEOUT_EXPIRES ? "Announce" :
+						 "Sync" );
+					{
+					  // We're Grandmaster, set grandmaster info to me
+					  ClockIdentity clock_identity;
+					  unsigned char priority1;
+					  unsigned char priority2;
+					  ClockQuality clock_quality;
+					  
+					  clock_identity = getClock()->getClockIdentity();
+					  getClock()->setGrandmasterClockIdentity( clock_identity );
+					  priority1 = getClock()->getPriority1();
+					  getClock()->setGrandmasterPriority1( priority1 );
+					  priority2 = getClock()->getPriority2();
+					  getClock()->setGrandmasterPriority2( priority2 );
+					  clock_quality = getClock()->getClockQuality();
+					  getClock()->setGrandmasterClockQuality( clock_quality );
+					}
+					port_state = PTP_MASTER;
+					Timestamp system_time;
+					Timestamp device_time;
 
-				uint32_t local_clock, nominal_clock_rate;
+					uint32_t local_clock, nominal_clock_rate;
 
-				getDeviceTime(system_time, device_time,
-					      local_clock, nominal_clock_rate);
+					getDeviceTime(system_time, device_time,
+							  local_clock, nominal_clock_rate);
 
-				(void) clock->calcLocalSystemClockRateDifference
-				  ( device_time, system_time );
+					(void) clock->calcLocalSystemClockRateDifference
+					  ( device_time, system_time );
 
-				delete qualified_announce;
-				qualified_announce = NULL;
+					delete qualified_announce;
+					qualified_announce = NULL;
 
-				// Add timers for Announce and Sync, this is as close to immediately as we get
-				clock->addEventTimer
-					( this, SYNC_INTERVAL_TIMEOUT_EXPIRES, 16000000 );
-				startAnnounce();
-					//
+					// Add timers for Announce and Sync, this is as close to immediately as we get
+					startSyncIntervalTimer(16000000);
+
+					startAnnounce();
+						// 
+				}
+			}
+			else {
+				// Automotive Profile
+				GPTP_LOG_EXCEPTION("SYNC receipt timeout");
 			}
 		}
 
 		break;
 	case PDELAY_INTERVAL_TIMEOUT_EXPIRES:
-			XPTPD_INFO("PDELAY_INTERVAL_TIMEOUT_EXPIRES occured");
+			GPTP_LOG_VERBOSE("PDELAY_INTERVAL_TIMEOUT_EXPIRES occured");
 			{
 				int ts_good;
 				Timestamp req_timestamp;
@@ -641,7 +827,7 @@ void IEEE1588Port::processEvent(Event e)
 
 				getTxLock();
 				pdelay_req->sendPort(this, NULL);
-				XPTPD_INFO("Sent PDelay Request");
+				GPTP_LOG_VERBOSE("Sent PDelay Request");
 
 				ts_good =
 				    getTxTimestamp
@@ -651,10 +837,9 @@ void IEEE1588Port::processEvent(Event e)
 					timer->sleep(req);
 					wait_time += req;
 					if (ts_good != -72 && iter < 1)
-						fprintf
-							(stderr,
-							 "Error (TX) timestamping PDelay request "
-							 "(Retrying-%d), error=%d\n", iter, ts_good);
+						GPTP_LOG_ERROR
+							("Error (TX) timestamping PDelay request "
+							 "(Retrying-%d), error=%d", iter, ts_good);
 					ts_good =
 					    getTxTimestamp
 						(pdelay_req, req_timestamp,
@@ -668,25 +853,25 @@ void IEEE1588Port::processEvent(Event e)
 				} else {
 				  Timestamp failed = INVALID_TIMESTAMP;
 				  pdelay_req->setTimestamp(failed);
-				  fprintf( stderr, "Invalid TX\n" );
+				  GPTP_LOG_ERROR("Invalid TX");
 				}
 
 				if (ts_good != 0) {
 					char msg
 					    [HWTIMESTAMPER_EXTENDED_MESSAGE_SIZE];
 					getExtendedError(msg);
-					XPTPD_ERROR(
+					GPTP_LOG_ERROR(
 						"Error (TX) timestamping PDelay request, error=%d\t%s",
 						ts_good, msg);
 				}
 #ifdef DEBUG
 				if (ts_good == 0) {
-					XPTPD_INFO
+					GPTP_LOG_VERBOSE
 					    ("Successful PDelay Req timestamp, %u,%u",
 					     req_timestamp.seconds_ls,
 					     req_timestamp.nanoseconds);
 				} else {
-					XPTPD_INFO
+					GPTP_LOG_VERBOSE
 					    ("*** Unsuccessful PDelay Req timestamp");
 				}
 #endif
@@ -704,19 +889,18 @@ void IEEE1588Port::processEvent(Event e)
 					clock->addEventTimer
 						(this, PDELAY_RESP_RECEIPT_TIMEOUT_EXPIRES, timeout );
 
-					interval =
+					interval = 
 						((long long)
 						 (pow((double)2,getPDelayInterval())*1000000000.0)) -
 						wait_time*1000;
 					interval = interval > EVENT_TIMER_GRANULARITY ?
 						interval : EVENT_TIMER_GRANULARITY;
-					clock->addEventTimer
-						(this, PDELAY_INTERVAL_TIMEOUT_EXPIRES, interval );
+					startPDelayIntervalTimer(interval);
 				}
 			}
 			break;
 	case SYNC_INTERVAL_TIMEOUT_EXPIRES:
-			XPTPD_INFO("SYNC_INTERVAL_TIMEOUT_EXPIRES occured");
+			GPTP_LOG_WARNING("SYNC_INTERVAL_TIMEOUT_EXPIRES occured");
 			{
 				/* Set offset from master to zero, update device vs
 				   system time offset */
@@ -736,8 +920,23 @@ void IEEE1588Port::processEvent(Event e)
 					sync->setPortIdentity(&dest_id);
 					getTxLock();
 					sync->sendPort(this, NULL);
-					XPTPD_INFO("Sent SYNC message");
+					GPTP_LOG_VERBOSE("Sent SYNC message");
 
+					if (automotive_profile && testMode && port_state == PTP_MASTER) {
+						if (avbSyncState > 0) {
+							avbSyncState--;
+							if (avbSyncState == 0) {
+								// Send an initial signalling message
+								stationState = STATION_STATE_AVB_SYNC;
+								APMessageTestStatus *testStatusMsg = new APMessageTestStatus(this);
+								if (testStatusMsg) {
+									testStatusMsg->sendPort(this);
+									delete testStatusMsg;
+								}
+							}
+						}
+					}
+					
 					int ts_good;
 					Timestamp sync_timestamp;
 					unsigned sync_timestamp_counter_value;
@@ -752,12 +951,12 @@ void IEEE1588Port::processEvent(Event e)
 						wait_time += req;
 
 						if (ts_good != -72 && iter < 1)
-							XPTPD_ERROR(
+							GPTP_LOG_ERROR(
 								"Error (TX) timestamping Sync (Retrying), "
 								"error=%d", ts_good);
 						ts_good =
 							getTxTimestamp
-							(sync, sync_timestamp,
+							(sync, sync_timestamp, 
 							 sync_timestamp_counter_value, iter == 0);
 						req *= 2;
 					}
@@ -767,21 +966,20 @@ void IEEE1588Port::processEvent(Event e)
 						char msg
 							[HWTIMESTAMPER_EXTENDED_MESSAGE_SIZE];
 						getExtendedError(msg);
-						fprintf
-							(stderr,
-							 "Error (TX) timestamping Sync, error="
+						GPTP_LOG_ERROR
+							("Error (TX) timestamping Sync, error="
 							 "%d\n%s",
 							 ts_good, msg );
  					}
 
 					if (ts_good == 0) {
-						XPTPD_INFO("Successful Sync timestamp");
-						XPTPD_INFO("Seconds: %u",
+						GPTP_LOG_VERBOSE("Successful Sync timestamp");
+						GPTP_LOG_VERBOSE("Seconds: %u",
 								   sync_timestamp.seconds_ls);
-						XPTPD_INFO("Nanoseconds: %u",
+						GPTP_LOG_VERBOSE("Nanoseconds: %u",
 								   sync_timestamp.nanoseconds);
 					} else {
-						XPTPD_INFO
+						GPTP_LOG_WARNING
 							("*** Unsuccessful Sync timestamp");
 					}
 
@@ -804,8 +1002,8 @@ void IEEE1588Port::processEvent(Event e)
 				   causing an update to local/system timestamp */
 				getDeviceTime
 					(system_time, device_time, local_clock, nominal_clock_rate);
-
-				XPTPD_INFO
+				
+				GPTP_LOG_VERBOSE
 					("port::processEvent(): System time: %u,%u Device Time: %u,%u",
 					 system_time.seconds_ls, system_time.nanoseconds,
 					 device_time.seconds_ls, device_time.nanoseconds);
@@ -821,28 +1019,37 @@ void IEEE1588Port::processEvent(Event e)
 				   system_time, local_system_freq_offset, sync_count,
 				   pdelay_count, port_state );
 
-			  /* If accelerated_sync is non-zero then start 16 ms sync
-				 timer, subtract 1, for last one start PDelay also */
-			  if( _accelerated_sync_count > 0 ) {
-				  clock->addEventTimer
-					  ( this, SYNC_INTERVAL_TIMEOUT_EXPIRES, 8000000 );
-				  --_accelerated_sync_count;
-			  } else {
-				  syncDone();
-				  if( _accelerated_sync_count == 0 ) {
-					  --_accelerated_sync_count;
-				  }
-				  wait_time *= 1000; // to ns
-				  wait_time =
-					  ((long long)
-					   (pow((double)2,getSyncInterval())*1000000000.0)) -
-					  wait_time;
-				  wait_time = wait_time > EVENT_TIMER_GRANULARITY ? wait_time :
-					  EVENT_TIMER_GRANULARITY;
-				  clock->addEventTimer
-					  ( this, SYNC_INTERVAL_TIMEOUT_EXPIRES, wait_time );
-			  }
+			  if (!automotive_profile) {
+				  /* If accelerated_sync is non-zero then start 16 ms sync
+					 timer, subtract 1, for last one start PDelay also */
+				  if( _accelerated_sync_count > 0 ) {
 
+					  startSyncIntervalTimer(8000000);
+					  --_accelerated_sync_count;
+				  } else {
+					  syncDone();
+					  if( _accelerated_sync_count == 0 ) {
+						  --_accelerated_sync_count;
+					  }
+					  wait_time *= 1000; // to ns
+					  wait_time =
+						  ((long long)
+						   (pow((double)2,getSyncInterval())*1000000000.0)) -
+						  wait_time;
+					  wait_time = wait_time > EVENT_TIMER_GRANULARITY ? wait_time :
+						  EVENT_TIMER_GRANULARITY;
+					  startSyncIntervalTimer(wait_time);
+				  }
+			  }
+			  else {
+				  // Automotive Profile
+				  syncDone();
+
+				  wait_time = ((long long) (pow((double)2, getSyncInterval()) *  1000000000.0));
+				  wait_time = wait_time > EVENT_TIMER_GRANULARITY ? wait_time : EVENT_TIMER_GRANULARITY;
+				  startSyncIntervalTimer(wait_time);
+			  }
+			  
 			}
 			break;
 	case ANNOUNCE_INTERVAL_TIMEOUT_EXPIRES:
@@ -858,18 +1065,16 @@ void IEEE1588Port::processEvent(Event e)
 			annc->sendPort(this, NULL);
 			delete annc;
 		}
-		clock->addEventTimer
-			(this, ANNOUNCE_INTERVAL_TIMEOUT_EXPIRES,
-			 (unsigned)
-			 (pow ((double)2, getAnnounceInterval()) * 1000000000.0));
+		startAnnounceIntervalTimer(pow ((double)2, getAnnounceInterval()) * 1000000000.0);
+
 		break;
 	case FAULT_DETECTED:
-		XPTPD_INFO("Received FAULT_DETECTED event");
+		GPTP_LOG_WARNING("Received FAULT_DETECTED event");
 		break;
 	case PDELAY_DEFERRED_PROCESSING:
 		pdelay_rx_lock->lock();
 		if (last_pdelay_resp_fwup == NULL) {
-			fprintf(stderr, "PDelay Response Followup is NULL!\n");
+			GPTP_LOG_WARNING("PDelay Response Followup is NULL!");
 			abort();
 		}
 		last_pdelay_resp_fwup->processMessage(this);
@@ -880,11 +1085,46 @@ void IEEE1588Port::processEvent(Event e)
 		pdelay_rx_lock->unlock();
 		break;
 	case PDELAY_RESP_RECEIPT_TIMEOUT_EXPIRES:
-		setAsCapable(false);
+		if (!automotive_profile) {
+			setAsCapable(false);
+		}
 		pdelay_count = 0;
 		break;
+
+	case SYNC_RATE_INTERVAL_TIMEOUT_EXPIRED:
+		{
+			GPTP_LOG_WARNING("SYNC_RATE_INTERVAL_TIMEOUT_EXPIRES occured");
+
+			sync_rate_interval_timer_started = false;
+
+			bool sendSignalMessage = false;
+			if (log_mean_sync_interval != operLogSyncInterval) {
+				log_mean_sync_interval = operLogSyncInterval;
+				sendSignalMessage = true;
+			}
+
+			if (log_min_mean_pdelay_req_interval != operLogPdelayReqInterval) {
+				log_min_mean_pdelay_req_interval = operLogPdelayReqInterval;
+				sendSignalMessage = true;
+			}
+
+			if (sendSignalMessage) {
+				if (!isGM) {
+					// Send operational signalling message
+					PTPMessageSignalling *sigMsg = new PTPMessageSignalling(this);
+					if (sigMsg) {
+						sigMsg->setintervals(log_min_mean_pdelay_req_interval, log_mean_sync_interval, PTPMessageSignalling::sigMsgInterval_NoChange);
+						sigMsg->sendPort(this, NULL);
+						delete sigMsg;
+					}
+				}
+			}
+		}
+
+		break;
+
 	default:
-		XPTPD_INFO
+		GPTP_LOG_WARNING
 		    ("Unhandled event type in IEEE1588Port::processEvent(), %d",
 		     e);
 		break;
@@ -932,8 +1172,8 @@ void IEEE1588Port::becomeMaster( bool annc ) {
   if( annc ) {
     startAnnounce();
   }
-  clock->addEventTimer( this, SYNC_INTERVAL_TIMEOUT_EXPIRES, 16000000 );
-  fprintf( stderr, "Switching to Master\n" );
+  startSyncIntervalTimer(16000000);
+  GPTP_LOG_INFO("Switching to Master");
 
   return;
 }
@@ -953,9 +1193,9 @@ void IEEE1588Port::becomeSlave( bool restart_syntonization ) {
 	   (ANNOUNCE_RECEIPT_TIMEOUT_MULTIPLIER*
 		(unsigned long long)
 		(pow((double)2,getAnnounceInterval())*1000000000.0)));
-  fprintf( stderr, "Switching to Slave\n" );
+  GPTP_LOG_INFO("Switching to Slave");
   if( restart_syntonization ) clock->newSyntonizationSetPoint();
-
+  
   return;
 }
 
@@ -979,14 +1219,14 @@ void IEEE1588Port::recommendState
 			reset_sync = true;
 		} else {
 		  if( changed_external_master ) {
-		    fprintf( stderr, "Changed master!\n" );
+		    GPTP_LOG_INFO("Changed master!");
 		    clock->newSyntonizationSetPoint();
 			reset_sync = true;
 		  }
 		}
 		break;
 	default:
-		XPTPD_INFO
+		GPTP_LOG_WARNING
 		    ("Invalid state change requested by call to "
 			 "1588Port::recommendState()");
 		break;
@@ -1053,3 +1293,25 @@ int IEEE1588Port::getRxTimestamp(PortIdentity * sourcePortIdentity,
 	timestamp = clock->getSystemTime();
 	return 0;
 }
+
+void IEEE1588Port::startSyncIntervalTimer(long long unsigned int waitTime) {
+	syncIntervalTimerLock->lock();
+	clock->deleteEventTimer(this, SYNC_INTERVAL_TIMEOUT_EXPIRES);
+	clock->addEventTimer(this, SYNC_INTERVAL_TIMEOUT_EXPIRES, waitTime);
+	syncIntervalTimerLock->unlock();
+}
+
+void IEEE1588Port::startAnnounceIntervalTimer(long long unsigned int waitTime) {
+	announceIntervalTimerLock->lock();
+	clock->deleteEventTimer(this, ANNOUNCE_INTERVAL_TIMEOUT_EXPIRES);
+	clock->addEventTimer(this, ANNOUNCE_INTERVAL_TIMEOUT_EXPIRES, waitTime);
+	announceIntervalTimerLock->unlock();
+}
+
+void IEEE1588Port::startPDelayIntervalTimer(long long unsigned int waitTime) {
+	pDelayIntervalTimerLock->lock();
+	clock->deleteEventTimer(this, PDELAY_INTERVAL_TIMEOUT_EXPIRES);
+	clock->addEventTimer(this, PDELAY_INTERVAL_TIMEOUT_EXPIRES, waitTime);
+	pDelayIntervalTimerLock->unlock();
+}
+

--- a/daemons/gptp/common/ieee1588port.cpp
+++ b/daemons/gptp/common/ieee1588port.cpp
@@ -106,18 +106,32 @@ IEEE1588Port::IEEE1588Port(IEEE1588PortInit_t *portInit)
 	if (automotive_profile) {
 		asCapable = true;
 
-		initialLogSyncInterval = -5;		// 31.25 ms
-		initialLogPdelayReqInterval = -3;	// 125 ms
-		operLogPdelayReqInterval = 0;		// 1 second	
-		operLogSyncInterval = 0;			// 1 second
+		if (initialLogSyncInterval == LOG2_INTERVAL_INVALID)
+			initialLogSyncInterval = -5;		// 31.25 ms
+
+		if (initialLogPdelayReqInterval == LOG2_INTERVAL_INVALID)
+			initialLogPdelayReqInterval = -3;	// 125 ms
+											
+		if (operLogPdelayReqInterval == LOG2_INTERVAL_INVALID)
+			operLogPdelayReqInterval = 0;		// 1 second	
+			
+		if (operLogSyncInterval == LOG2_INTERVAL_INVALID)
+			 operLogSyncInterval = 0;			// 1 second
 	}
 	else {
 		asCapable = false;
 
-		initialLogSyncInterval = -3;		// 125 ms
-		initialLogPdelayReqInterval = -3;	// 125 ms
-		operLogPdelayReqInterval = 0;		// 1 second	
-		operLogSyncInterval = 0;			// 1 second
+		if (initialLogSyncInterval == LOG2_INTERVAL_INVALID)
+			initialLogSyncInterval = -3;		// 125 ms
+
+		if (initialLogPdelayReqInterval == LOG2_INTERVAL_INVALID)
+			initialLogPdelayReqInterval = -3;	// 125 ms
+
+		if (operLogPdelayReqInterval == LOG2_INTERVAL_INVALID)
+			operLogPdelayReqInterval = 0;		// 1 second	
+
+		if (operLogSyncInterval == LOG2_INTERVAL_INVALID)
+			 operLogSyncInterval = 0;			// 1 second
 	}
 
 	announce_sequence_id = 0;
@@ -214,8 +228,16 @@ bool IEEE1588Port::init_port(int delay[4])
 }
 
 void IEEE1588Port::startPDelay() {
-	pdelay_started = true;
-	startPDelayIntervalTimer(32000000);
+	if (automotive_profile) {
+		if (log_min_mean_pdelay_req_interval != PTPMessageSignalling::sigMsgInterval_NoSend) {
+			pdelay_started = true;
+			startPDelayIntervalTimer(log_min_mean_pdelay_req_interval);
+		}
+	}
+	else {
+		pdelay_started = true;
+		startPDelayIntervalTimer(32000000);
+	}
 }
 
 void IEEE1588Port::startSyncRateIntervalTimer() {

--- a/daemons/gptp/common/ptptypes.hpp
+++ b/daemons/gptp/common/ptptypes.hpp
@@ -41,6 +41,7 @@ typedef long double FrequencyRatio; /*!< Frequency Ratio */
 #define ETHER_ADDR_OCTETS	6		/*!< Number of octets in a link layer address*/
 #define IP_ADDR_OCTETS		4		/*!< Number of octets in a ip address*/
 #define PTP_ETHERTYPE 0x88F7		/*!< PTP ethertype */
+#define AVTP_ETHERTYPE 0x22F0		/*!< AVTP ethertype used for Test Status Message */
 
 /**
  * PortState enumeration

--- a/daemons/gptp/linux/build/Makefile
+++ b/daemons/gptp/linux/build/Makefile
@@ -40,10 +40,13 @@ SRC_DIR = ../src
 OBJ_DIR = obj
 
 OBJ_FILES = $(OBJ_DIR)/ptp_message.o\
+		 $(OBJ_DIR)/ap_message.o\
 		 $(OBJ_DIR)/avbts_osnet.o\
 		 $(OBJ_DIR)/ieee1588port.o\
 		 $(OBJ_DIR)/ieee1588clock.o \
 		 $(OBJ_DIR)/linux_hal_common.o \
+		 $(OBJ_DIR)/linux_hal_persist_file.o \
+		 $(OBJ_DIR)/gptp_log.o \
 		 $(OBJ_DIR)/platform.o
 
 HEADER_FILES = $(COMMON_DIR)/avbts_port.hpp\
@@ -55,9 +58,13 @@ HEADER_FILES = $(COMMON_DIR)/avbts_port.hpp\
 		$(COMMON_DIR)/avbts_osipc.hpp\
 		$(COMMON_DIR)/avbts_oscondition.hpp\
 		$(COMMON_DIR)/avbts_message.hpp\
+		$(COMMON_DIR)/avbap_message.hpp\
 		$(COMMON_DIR)/avbts_clock.hpp\
+		$(COMMON_DIR)/avbts_persist.hpp\
 		$(COMMON_DIR)/ieee1588.hpp\
+		$(COMMON_DIR)/gptp_log.hpp\
 		$(SRC_DIR)/linux_hal_common.hpp\
+		$(SRC_DIR)/linux_hal_persist_file.hpp\
 		$(SRC_DIR)/platform.hpp
 
 ifeq ($(ARCH),I210)
@@ -121,8 +128,17 @@ $(OBJ_DIR)/ieee1588clock.o: $(COMMON_DIR)/ieee1588clock.cpp $(HEADER_FILES)
 $(OBJ_DIR)/ptp_message.o: $(COMMON_DIR)/ptp_message.cpp $(HEADER_FILES)
 	$(CXX) $(CFLAGS) $(CXXFLAGS) -c $(COMMON_DIR)/ptp_message.cpp -o $(OBJ_DIR)/ptp_message.o
 
+$(OBJ_DIR)/ap_message.o: $(COMMON_DIR)/ap_message.cpp $(HEADER_FILES)
+	$(CXX) $(CFLAGS) $(CXXFLAGS) -c $(COMMON_DIR)/ap_message.cpp -o $(OBJ_DIR)/ap_message.o
+
 $(OBJ_DIR)/avbts_osnet.o: $(COMMON_DIR)/avbts_osnet.cpp $(HEADER_FILES)
 	$(CXX) $(CFLAGS) $(CXXFLAGS) -c $(COMMON_DIR)/avbts_osnet.cpp -o $(OBJ_DIR)/avbts_osnet.o
+
+$(OBJ_DIR)/linux_hal_persist_file.o: $(SRC_DIR)/linux_hal_persist_file.cpp $(HEADER_FILES)
+	$(CXX) $(CFLAGS) $(CXXFLAGS) -c $(SRC_DIR)/linux_hal_persist_file.cpp -o $(OBJ_DIR)/linux_hal_persist_file.o
+
+$(OBJ_DIR)/gptp_log.o: $(COMMON_DIR)/gptp_log.cpp $(HEADER_FILES)
+	$(CXX) $(CFLAGS) $(CXXFLAGS) -c $(COMMON_DIR)/gptp_log.cpp -o $(OBJ_DIR)/gptp_log.o
 
 clean:
 	$(RM) *~ $(OBJ_DIR)/*.o  $(OBJ_DIR)/daemon_cl 

--- a/daemons/gptp/linux/src/daemon_cl.cpp
+++ b/daemons/gptp/linux/src/daemon_cl.cpp
@@ -360,7 +360,7 @@ int main(int argc, char **argv) {
 	if( restoredataptr != NULL ) {
 		if (!restorefailed) {
 			restorefailed = !pPort->restoreSerializedState(restoredataptr, &restoredatacount);
-			GPTP_LOG_INFO("Persistent port data restored: asCapable:%d, port_state:%d, one_way_delay:%" PRId64, pPort->getAsCapable(), pPort->getPortState(), pPort->getLinkDelay());
+			GPTP_LOG_INFO("Persistent port data restored: asCapable:%d, port_state:%d, one_way_delay:%lld", pPort->getAsCapable(), pPort->getPortState(), pPort->getLinkDelay());
 		}
 		restoredataptr = ((char *)restoredata) + (restoredatalength - restoredatacount);
 	}

--- a/daemons/gptp/linux/src/daemon_cl.cpp
+++ b/daemons/gptp/linux/src/daemon_cl.cpp
@@ -1,31 +1,31 @@
 /******************************************************************************
 
-  Copyright (c) 2012 Intel Corporation
+  Copyright (c) 2012 Intel Corporation 
   All rights reserved.
-
-  Redistribution and use in source and binary forms, with or without
+  
+  Redistribution and use in source and binary forms, with or without 
   modification, are permitted provided that the following conditions are met:
-
-   1. Redistributions of source code must retain the above copyright notice,
-      this list of conditions and the following disclaimer.
-
-   2. Redistributions in binary form must reproduce the above copyright
-      notice, this list of conditions and the following disclaimer in the
-      documentation and/or other materials provided with the distribution.
-
-   3. Neither the name of the Intel Corporation nor the names of its
-      contributors may be used to endorse or promote products derived from
-      this software without specific prior written permission.
-
+  
+   1. Redistributions of source code must retain the above copyright notice, 
+	  this list of conditions and the following disclaimer.
+  
+   2. Redistributions in binary form must reproduce the above copyright 
+	  notice, this list of conditions and the following disclaimer in the 
+	  documentation and/or other materials provided with the distribution.
+  
+   3. Neither the name of the Intel Corporation nor the names of its 
+	  contributors may be used to endorse or promote products derived from 
+	  this software without specific prior written permission.
+  
   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
   POSSIBILITY OF SUCH DAMAGE.
 
@@ -35,12 +35,15 @@
 #include "avbts_clock.hpp"
 #include "avbts_osnet.hpp"
 #include "avbts_oslock.hpp"
+#include "avbts_persist.hpp"
 #ifdef ARCH_INTELCE
 #include "linux_hal_intelce.hpp"
 #else
 #include "linux_hal_generic.hpp"
 #endif
+#include "linux_hal_persist_file.hpp"
 #include <ctype.h>
+#include <inttypes.h>
 #include <signal.h>
 #include <fcntl.h>
 #include <sys/mman.h>
@@ -48,28 +51,52 @@
 #include <errno.h>
 #include <sys/stat.h>
 #include <unistd.h>
+
 #define PHY_DELAY_GB_TX_I20 184 //1G delay
 #define PHY_DELAY_GB_RX_I20 382 //1G delay
 #define PHY_DELAY_MB_TX_I20 1044//100M delay
 #define PHY_DELAY_MB_RX_I20 2133//100M delay
 
+void gPTPPersistWriteCB(char *bufPtr, uint32_t bufSize);
+
 void print_usage( char *arg0 ) {
-  fprintf( stderr,
-	   "%s <network interface> [-S] [-P] [-M <filename>] "
-	   "[-A <count>] [-G <group>] [-R <priority 1>] [-D <gb_tx_delay,gb_rx_delay,mb_tx_delay,mb_rx_delay>]\n",
-	   arg0 );
-  fprintf
+	fprintf(stderr,
+			"%s <network interface> [-S] [-P] [-V] [-M <filename>] "
+			"[-A <count>] [-G <group>] [-R <priority 1>] "
+			"[-D <gb_tx_delay,gb_rx_delay,mb_tx_delay,mb_rx_delay>] "
+			"[-T] [-L] [-E] [-GM] [-INITSYNC <value>] [-OPERSYNC <value>] "
+			"[-INITPDELAY <value>] [-OPERPDELAY <value>]"
+			"\n",
+			arg0);
+	fprintf
 	  ( stderr,
-		"\t-S start syntonization\n\t-P pulse per second\n"
+		"\t-S start syntonization\n"
+		"\t-P pulse per second\n"
 		"\t-M <filename> save/restore state\n"
 		"\t-A <count> initial accelerated sync count\n"
 		"\t-G <group> group id for shared memory\n"
-		"\t-R <priority 1> priority 1 value\n"
-		"\t-T force master\n\t-L force slave\n" );
+		"\t-R <priority 1> priority 1 value\n" 
+		"\t-D Phy Delay <gb_tx_delay,gb_rx_delay,mb_tx_delay,mb_rx_delay>\n" 
+		"\t-T force master (ignored when Automotive Profile set)\n"
+		"\t-L force slave (ignored when Automotive Profile set)\n"
+		"\t-E enable test mode (as defined in AVnu automotive profile)\n"
+		"\t-V enable AVnu Automotive Profile\n"
+		"\t-GM set grandmaster for Automotive Profile\n"
+		"\t-INITSYNC <value> initial sync interval (Log base 2. 0 = 1 sec)\n"
+		"\t-OPERSYNC <value> operational sync interval (Log base 2. 0 = 1 sec)\n"
+		"\t-INITPDELAY <value> initial pdelay interval (Log base 2. 0 = 1 sec)\n"
+		"\t-OPERPDELAY <value> operational pdelay interval (Log base 2. 0 = 1 sec)\n"
+		);
 }
 
-int main(int argc, char **argv)
-{
+static 	IEEE1588Clock *pClock = NULL;
+static 	IEEE1588Port *pPort = NULL;
+
+int main(int argc, char **argv) {
+	GPTP_LOG_INFO("gPTP starting");
+
+	IEEE1588PortInit_t portInit;
+
 	sigset_t set;
 	InterfaceName *ifname;
 	int sig;
@@ -81,15 +108,36 @@ int main(int argc, char **argv)
 	bool override_portstate = false;
 	PortState port_state;
 
-	int restorefd = -1;
-	void *restoredata = ((void *) -1);
+	//void *restoredata = ((void *)-1);
+	char *restoredata = NULL;
 	char *restoredataptr = NULL;
 	off_t restoredatalength = 0;
-	off_t restoredatacount;
+	off_t restoredatacount = 0;
 	bool restorefailed = false;
 	LinuxIPCArg *ipc_arg = NULL;
 
 	int accelerated_sync_count = 0;
+
+	GPTPPersist *pGPTPPersist = NULL;
+
+	portInit.clock = NULL;
+	portInit.index = 0;
+	portInit.forceSlave = false;
+	portInit.accelerated_sync_count = 0;
+	portInit.timestamper = NULL;
+	portInit.offset = 0;
+	portInit.net_label = NULL;
+	portInit.automotive_profile = false;
+	portInit.isGM = false;
+	portInit.testMode = false;
+	portInit.initialLogSyncInterval = LOG2_INTERVAL_INVALID;
+	portInit.initialLogPdelayReqInterval = LOG2_INTERVAL_INVALID;
+	portInit.operLogPdelayReqInterval = LOG2_INTERVAL_INVALID;
+	portInit.operLogSyncInterval = LOG2_INTERVAL_INVALID;
+	portInit.condition_factory = NULL;
+	portInit.thread_factory = NULL;
+	portInit.timer_factory = NULL;
+	portInit.lock_factory = NULL;
 
 	// Block SIGUSR1
 	{
@@ -101,15 +149,15 @@ int main(int argc, char **argv)
 			return -1;
 		}
 	}
-
+    
 	int phy_delay[4]={0,0,0,0};
 	bool input_delay=false;
 
 
 	LinuxNetworkInterfaceFactory *default_factory =
-		new LinuxNetworkInterfaceFactory;
+	   new LinuxNetworkInterfaceFactory;
 	OSNetworkInterfaceFactory::registerFactory
-		(factory_name_t("default"), default_factory);
+	   (factory_name_t("default"), default_factory);
 	LinuxThreadFactory *thread_factory = new LinuxThreadFactory();
 	LinuxTimerQueueFactory *timerq_factory = new LinuxTimerQueueFactory();
 	LinuxLockFactory *lock_factory = new LinuxLockFactory();
@@ -122,72 +170,78 @@ int main(int argc, char **argv)
 		print_usage( argv[0] );
 		return -1;
 	}
-	ifname = new InterfaceName( argv[1], strlen(argv[1]) );
+	ifname = new InterfaceName( argv[1], strlen(argv[1]) ); 
 
 	/* Process optional arguments */
 	for( i = 2; i < argc; ++i ) {
+
 		if( argv[i][0] == '-' ) {
-			if( toupper( argv[i][1] ) == 'S' ) {
+			if (strcmp(argv[i] + 1, "S") == 0) {
 				// Get syntonize directive from command line
 				syntonize = true;
 			}
-			else if( toupper( argv[i][1] ) == 'T' ) {
+			else if (strcmp(argv[i] + 1, "T") == 0) {
 				override_portstate = true;
 				port_state = PTP_MASTER;
 			}
-			else if( toupper( argv[i][1] ) == 'L' ) {
+			else if (strcmp(argv[i] + 1, "L") == 0) {
 				override_portstate = true;
 				port_state = PTP_SLAVE;
 			}
-			else if( toupper( argv[i][1] ) == 'M' ) {
+			else if (strcmp(argv[i] + 1, "M") == 0) {
 				// Open file
 				if( i+1 < argc ) {
-					restorefd = open
-						( argv[i+1], O_RDWR|O_CREAT, S_IRUSR|S_IWUSR ); ++i;
-					if( restorefd == -1 ) printf
-						( "Failed to open restore file\n" );
-				} else {
+					pGPTPPersist = makeLinuxGPTPPersistFile();
+					if (pGPTPPersist) {
+						pGPTPPersist->initStorage(argv[i + 1]);
+					}
+				}
+				else {
 					printf( "Restore file must be specified on "
-							"command line\n" );
+						   "command line\n");
 				}
 			}
-			else if( toupper( argv[i][1] ) == 'A' ) {
+			else if (strcmp(argv[i] + 1, "A") == 0) {
 				if( i+1 < argc ) {
 					accelerated_sync_count = atoi( argv[++i] );
-				} else {
+				}
+				else {
 					printf( "Accelerated sync count must be specified on the "
-							"command line with A option\n" );
+						   "command line with A option\n");
 				}
 			}
-			else if( toupper( argv[i][1] ) == 'G' ) {
+			else if (strcmp(argv[i] + 1, "G") == 0) {
 				if( i+1 < argc ) {
 					ipc_arg = new LinuxIPCArg(argv[++i]);
-				} else {
+				}
+				else {
 					printf( "Must specify group name on the command line\n" );
 				}
 			}
-			else if( toupper( argv[i][1] ) == 'P' ) {
+			else if (strcmp(argv[i] + 1, "P") == 0) {
 				pps = true;
 			}
-			else if( toupper( argv[i][1] ) == 'H' ) {
+			else if (strcmp(argv[i] + 1, "H") == 0) {
 				print_usage( argv[0] );
 				return 0;
 			}
-			else if( toupper( argv[i][1] ) == 'R' ) {
+			else if (strcmp(argv[i] + 1, "R") == 0) {
 				if( i+1 >= argc ) {
 					printf( "Priority 1 value must be specified on "
-							"command line, using default value\n" );
-				} else {
+						   "command line, using default value\n");
+				}
+				else {
 					unsigned long tmp = strtoul( argv[i+1], NULL, 0 ); ++i;
 					if( tmp == 0 ) {
 						printf( "Invalid priority 1 value, using "
-								"default value\n" );
-					} else {
+							   "default value\n");
+					}
+					else {
 						priority1 = (uint8_t) tmp;
 					}
 				}
 			}
-			else if(toupper(argv[i][1]) == 'D'){
+			else if (strcmp(argv[i] + 1, "D") == 0) {
 				input_delay=true;
 				int delay_count=0;
 				char *cli_inp_delay = strtok(argv[i+1],",");
@@ -210,6 +264,27 @@ int main(int argc, char **argv)
 					return 0;
 				}
 			}
+			else if (strcmp(argv[i] + 1, "V") == 0) {
+				portInit.automotive_profile = true;
+			}
+			else if (strcmp(argv[i] + 1, "GM") == 0) {
+				portInit.isGM = true;
+			}
+			else if (strcmp(argv[i] + 1, "E") == 0) {
+				portInit.testMode = true;
+			}
+			else if (strcmp(argv[i] + 1, "INITSYNC") == 0) {
+				portInit.initialLogSyncInterval = atoi(argv[++i]);
+			}
+			else if (strcmp(argv[i] + 1, "OPERSYNC") == 0) {
+				portInit.initialLogPdelayReqInterval = atoi(argv[++i]);
+			}
+			else if (strcmp(argv[i] + 1, "INITPDELAY") == 0) {
+				portInit.operLogSyncInterval = atoi(argv[++i]);
+			}
+			else if (strcmp(argv[i] + 1, "OPERPDELAY") == 0) {
+				portInit.operLogPdelayReqInterval = atoi(argv[++i]);
+			}
 		}
 	}
 
@@ -222,35 +297,21 @@ int main(int argc, char **argv)
 	}
 
 	if( !ipc->init( ipc_arg ) ) {
-	  delete ipc;
-	  ipc = NULL;
+		delete ipc;
+		ipc = NULL;
 	}
 	if( ipc_arg != NULL ) delete ipc_arg;
 
-	if( restorefd != -1 ) {
-		// MMAP file
-		struct stat stat0;
-		if( fstat( restorefd, &stat0 ) == -1 ) {
-			printf( "Failed to stat restore file, %s\n", strerror( errno ));
-			restoredatalength = 0;
-		} else {
-			restoredatalength = stat0.st_size;
-			if( restoredatalength != 0 ) {
-				if(( restoredata = mmap( NULL, restoredatalength,
-										 PROT_READ | PROT_WRITE, MAP_SHARED,
-										 restorefd, 0 )) == ((void *)-1) ) {
-					printf( "Failed to mmap restore file, %s\n",
-							strerror( errno ));
-				} else {
-					restoredatacount = restoredatalength;
-					restoredataptr = (char *) restoredata;
-				}
-			}
-		}
+	if (pGPTPPersist) {
+		uint32_t bufSize = 0;
+		if (!pGPTPPersist->readStorage(&restoredata, &bufSize))
+			printf( "Failed to stat restore file\n");
+		restoredatalength = bufSize; 
+		restoredatacount = restoredatalength;
+		restoredataptr = (char *)restoredata;
 	}
 
-	if (argc < 2)
-		return -1;
+	if (argc < 2) return -1;
 	ifname = new InterfaceName(argv[1], strlen(argv[1]));
 
 #ifdef ARCH_INTELCE
@@ -262,115 +323,138 @@ int main(int argc, char **argv)
 	sigemptyset(&set);
 	sigaddset(&set, SIGINT);
 	sigaddset( &set, SIGTERM );
+	sigaddset(&set, SIGHUP);
+	sigaddset(&set, SIGUSR2);
 	if (pthread_sigmask(SIG_BLOCK, &set, NULL) != 0) {
 		perror("pthread_sigmask()");
 		return -1;
 	}
 
-	IEEE1588Clock *clock =
-	  new IEEE1588Clock( false, syntonize, priority1, timestamper,
-			     timerq_factory , ipc, lock_factory );
+	pClock = new IEEE1588Clock(false, syntonize, priority1, timestamper, timerq_factory, ipc, lock_factory);
 
 	if( restoredataptr != NULL ) {
-	  if( !restorefailed )
-	    restorefailed =
-	      !clock->restoreSerializedState( restoredataptr,
-					      &restoredatacount );
-	  restoredataptr = ((char *)restoredata) +
-	    (restoredatalength - restoredatacount);
+		if (!restorefailed) 
+			restorefailed = !pClock->restoreSerializedState(restoredataptr, &restoredatacount);
+		restoredataptr = ((char *)restoredata) + (restoredatalength - restoredatacount);
 	}
 
-    IEEE1588Port *port =
-      new IEEE1588Port
-      ( clock, 1, false, accelerated_sync_count, timestamper, 0, ifname,
-	condition_factory, thread_factory, timer_factory, lock_factory );
-	if (!port->init_port(phy_delay)) {
+	// TODO: The setting of values into temporary variables should be changed to just set directly into the portInit struct.
+	portInit.clock = pClock;
+	portInit.index = 1;
+	portInit.forceSlave = false;
+	portInit.accelerated_sync_count = accelerated_sync_count;
+	portInit.timestamper = timestamper;
+	portInit.offset = 0;
+	portInit.net_label = ifname;
+	portInit.condition_factory = condition_factory;
+	portInit.thread_factory = thread_factory;
+	portInit.timer_factory = timer_factory;
+	portInit.lock_factory = lock_factory;
+
+	pPort = new IEEE1588Port(&portInit);
+	if (!pPort->init_port(phy_delay)) {
 		printf("failed to initialize port \n");
 		return -1;
 	}
 
 	if( restoredataptr != NULL ) {
-	  if( !restorefailed ) restorefailed =
-	    !port->restoreSerializedState( restoredataptr, &restoredatacount );
-	  restoredataptr = ((char *)restoredata) +
-	    (restoredatalength - restoredatacount);
+		if (!restorefailed) {
+			restorefailed = !pPort->restoreSerializedState(restoredataptr, &restoredatacount);
+			GPTP_LOG_INFO("Persistent port data restored: asCapable:%d, port_state:%d, one_way_delay:%" PRId64, pPort->getAsCapable(), pPort->getPortState(), pPort->getLinkDelay());
+		}
+		restoredataptr = ((char *)restoredata) + (restoredatalength - restoredatacount);
+	}
+
+
+	if (portInit.automotive_profile) {
+		if (portInit.isGM) {
+			port_state = PTP_MASTER;
+		}
+		else {
+			port_state = PTP_SLAVE;
+		}
+		override_portstate = true;
 	}
 
 	if( override_portstate ) {
-		port->setPortState( port_state );
+		pPort->setPortState(port_state);
 	}
 
 	// Start PPS if requested
 	if( pps ) {
-	  if( !timestamper->HWTimestamper_PPS_start()) {
-	    printf( "Failed to start pulse per second I/O\n" );
-	  }
+		if (!timestamper->HWTimestamper_PPS_start()) {
+			printf("Failed to start pulse per second I/O\n");
+		}
 	}
 
-	port->processEvent(POWERUP);
+	// Configure persistent write
+	if (pGPTPPersist) {
+		off_t len = 0;
+		restoredatacount = 0;
+		pClock->serializeState(NULL, &len);
+		restoredatacount += len;
+		pPort->serializeState(NULL, &len);
+		restoredatacount += len;
+		pGPTPPersist->setWriteSize((uint32_t)restoredatacount);
+		pGPTPPersist->registerWriteCB(gPTPPersistWriteCB);
+	}
+
+
+	pPort->processEvent(POWERUP);
 
 	do {
-	if (sigwait(&set, &sig) != 0) {
-		perror("sigwait()");
-		return -1;
+		sig = 0;
+
+		if (sigwait(&set, &sig) != 0) {
+			perror("sigwait()");
+			return -1;
+		}
+
+		if (sig == SIGHUP) {
+			if (pGPTPPersist) {
+				if (pPort->getPortState() == PTP_MASTER || pPort->getPortState() == PTP_SLAVE) {
+					pGPTPPersist->triggerWriteStorage();
+				}
+			}
+		}
+
+		if (sig == SIGUSR2) {
+			pPort->logIEEEPortCounters();
+		}
 	}
-
-	if (sig == SIGHUP) {
-	// If port is either master or slave, save clock and then port state
-	if( restorefd != -1 ) {
-	  if( port->getPortState() == PTP_MASTER ||
-	      port->getPortState() == PTP_SLAVE ) {
-	    printf( "Signal received to write restore data\n" );
-	    off_t len;
-	    restoredatacount = 0;
-	    clock->serializeState( NULL, &len );
-	    restoredatacount += len;
-	    port->serializeState( NULL, &len );
-	    restoredatacount += len;
-
-	    if( restoredatacount > restoredatalength ) {
-	      ftruncate( restorefd, restoredatacount );
-	      if( restoredata != ((void *) -1)) {
-		restoredata =
-		  mremap( restoredata, restoredatalength, restoredatacount,
-			  MREMAP_MAYMOVE );
-	      } else {
-		restoredata =
-		  mmap( NULL, restoredatacount, PROT_READ | PROT_WRITE,
-			MAP_SHARED, restorefd, 0 );
-	      }
-	      if( restoredata == ((void *) -1 )) goto remap_failed;
-	      restoredatalength = restoredatacount;
-	    }
-
-	    restoredataptr = (char *) restoredata;
-	    clock->serializeState( restoredataptr, &restoredatacount );
-	    restoredataptr = ((char *)restoredata) +
-	      (restoredatalength - restoredatacount);
-	    port->serializeState( restoredataptr, &restoredatacount );
-	    restoredataptr = ((char *)restoredata) +
-	      (restoredatalength - restoredatacount);
-	  remap_failed:
-	    ;;
-	  }
-
-
-	  if( restoredata != ((void *) -1 ))
-	    munmap( restoredata, restoredatalength );
-	}
-	}
-	} while(sig == SIGHUP);
+	while (sig == SIGHUP || sig == SIGUSR2);
 
 	fprintf(stderr, "Exiting on %d\n", sig);
 
+	if (pGPTPPersist) {
+		pGPTPPersist->closeStorage();
+	}
+
 	// Stop PPS if previously started
 	if( pps ) {
-	    if( !timestamper->HWTimestamper_PPS_stop()) {
-		printf( "Failed to stop pulse per second I/O\n" );
-	    }
+		if (!timestamper->HWTimestamper_PPS_stop()) {
+			printf("Failed to stop pulse per second I/O\n");
+		}
 	}
 
 	if( ipc ) delete ipc;
 
 	return 0;
 }
+
+
+void gPTPPersistWriteCB(char *bufPtr, uint32_t bufSize)
+{
+	printf("Signal received to write restore data\n");
+
+	off_t restoredatalength = bufSize;
+	off_t restoredatacount = restoredatalength;
+	char *restoredataptr = NULL;
+
+	restoredataptr = (char *)bufPtr;
+	pClock->serializeState(restoredataptr, &restoredatacount);
+	restoredataptr = ((char *)bufPtr) + (restoredatalength - restoredatacount);
+	pPort->serializeState(restoredataptr, &restoredatacount);
+	restoredataptr = ((char *)bufPtr) + (restoredatalength - restoredatacount);
+}
+

--- a/daemons/gptp/linux/src/daemon_cl.cpp
+++ b/daemons/gptp/linux/src/daemon_cl.cpp
@@ -277,10 +277,10 @@ int main(int argc, char **argv) {
 				portInit.initialLogSyncInterval = atoi(argv[++i]);
 			}
 			else if (strcmp(argv[i] + 1, "OPERSYNC") == 0) {
-				portInit.initialLogPdelayReqInterval = atoi(argv[++i]);
+				portInit.operLogSyncInterval = atoi(argv[++i]);
 			}
 			else if (strcmp(argv[i] + 1, "INITPDELAY") == 0) {
-				portInit.operLogSyncInterval = atoi(argv[++i]);
+				portInit.initialLogPdelayReqInterval = atoi(argv[++i]);
 			}
 			else if (strcmp(argv[i] + 1, "OPERPDELAY") == 0) {
 				portInit.operLogPdelayReqInterval = atoi(argv[++i]);

--- a/daemons/gptp/linux/src/linux_hal_common.cpp
+++ b/daemons/gptp/linux/src/linux_hal_common.cpp
@@ -55,6 +55,12 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
+#include <sys/socket.h>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+
 Timestamp tsToTimestamp(struct timespec *ts)
 {
 	Timestamp ret;
@@ -76,14 +82,15 @@ LinuxNetworkInterface::~LinuxNetworkInterface() {
 	close( sd_general );
 }
 
+
 net_result LinuxNetworkInterface::send
-( LinkLayerAddress *addr, uint8_t *payload, size_t length, bool timestamp ) {
+( LinkLayerAddress *addr, uint16_t etherType, uint8_t *payload, size_t length, bool timestamp ) {
 	sockaddr_ll *remote = NULL;
 	int err;
 	remote = new struct sockaddr_ll;
 	memset( remote, 0, sizeof( *remote ));
 	remote->sll_family = AF_PACKET;
-	remote->sll_protocol = PLAT_htons( PTP_ETHERTYPE );
+	remote->sll_protocol = PLAT_htons( etherType );
 	remote->sll_ifindex = ifindex;
 	remote->sll_halen = ETH_ALEN;
 	addr->toOctetArray( remote->sll_addr );
@@ -102,7 +109,7 @@ net_result LinuxNetworkInterface::send
   }
 	delete remote;
 	if( err == -1 ) {
-		XPTPD_ERROR( "Failed to send: %s(%d)", strerror(errno), errno );
+		GPTP_LOG_ERROR( "Failed to send: %s(%d)", strerror(errno), errno );
 		return net_fatal;
 	}
 	return net_succeed;
@@ -128,7 +135,7 @@ void LinuxNetworkInterface::disable_clear_rx_queue() {
 		( sd_event, SOL_PACKET, PACKET_DROP_MEMBERSHIP, &mr_8021as,
 		  sizeof( mr_8021as ));
 	if( err == -1 ) {
-		XPTPD_ERROR
+		GPTP_LOG_ERROR
 			( "Unable to add PTP multicast addresses to port id: %u",
 			  ifindex );
 		return;
@@ -152,7 +159,7 @@ void LinuxNetworkInterface::reenable_rx_queue() {
 		( sd_event, SOL_PACKET, PACKET_ADD_MEMBERSHIP, &mr_8021as,
 		  sizeof( mr_8021as ));
 	if( err == -1 ) {
-		XPTPD_ERROR
+		GPTP_LOG_ERROR
 			( "Unable to add PTP multicast addresses to port id: %u",
 			  ifindex );
 		return;
@@ -161,6 +168,93 @@ void LinuxNetworkInterface::reenable_rx_queue() {
 	if( !net_lock.unlock() ) {
 		fprintf( stderr, "D failed unlock rx lock, %d\n", err );
 	}
+}
+
+static void x_readEvent(int sockint, IEEE1588Port *pPort)
+{
+	int status;
+	char buf[4096];
+	struct iovec iov = { buf, sizeof buf };
+	struct sockaddr_nl snl;
+	struct msghdr msg = { (void *) &snl, sizeof snl, &iov, 1, NULL, 0, 0 };
+	struct nlmsghdr *msgHdr;
+	struct ifinfomsg *ifi;
+
+	status = recvmsg(sockint, &msg, 0);
+
+	if (status < 0) {
+		GPTP_LOG_ERROR("read_netlink: Error recvmsg: %d", status);
+		return;
+	}
+
+	if (status == 0) {
+		GPTP_LOG_ERROR("read_netlink: EOF");
+		return;
+	}
+
+	// Process the NETLINK messages
+	for (msgHdr = (struct nlmsghdr *)buf; NLMSG_OK(msgHdr, (unsigned int)status); msgHdr = NLMSG_NEXT(msgHdr, status))
+	{
+		if (msgHdr->nlmsg_type == NLMSG_DONE)
+			return;
+
+		if (msgHdr->nlmsg_type == NLMSG_ERROR) {
+			GPTP_LOG_ERROR("netlink message error");
+			return;
+		}
+
+		if (msgHdr->nlmsg_type == RTM_NEWLINK) {
+			ifi = (struct ifinfomsg *)NLMSG_DATA(msgHdr);
+			if ((ifi->ifi_flags & IFF_RUNNING)) {
+				pPort->processEvent(LINKUP);
+			}
+			else {
+				pPort->processEvent(LINKDOWN);
+			}
+		}
+	}
+	return;
+}
+
+void LinuxNetworkInterface::watchNetLink(IEEE1588Port *pPort)
+{
+	fd_set netLinkFD;
+	int netLinkSocket;
+
+	struct sockaddr_nl addr;
+
+	netLinkSocket = socket (AF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
+	if (netLinkSocket < 0) {
+		GPTP_LOG_ERROR("NETLINK socket open error");
+		return;
+	}
+
+	memset((void *) &addr, 0, sizeof (addr));
+
+	addr.nl_family = AF_NETLINK;
+	addr.nl_pid = getpid ();
+	addr.nl_groups = RTMGRP_LINK;
+
+	if (bind (netLinkSocket, (struct sockaddr *) &addr, sizeof (addr)) < 0) {
+		GPTP_LOG_ERROR("Socket bind failed");
+		return;
+	}
+
+	while (1) {
+		FD_ZERO(&netLinkFD);
+		FD_CLR(netLinkSocket, &netLinkFD);
+		FD_SET(netLinkSocket, &netLinkFD);
+
+		// Wait forever for a net link event
+		int retval = select(FD_SETSIZE, &netLinkFD, NULL, NULL, NULL);
+		if (retval == -1)
+			; // Error on select. We will ignore and keep going
+		else if (retval) {
+			x_readEvent(netLinkSocket, pPort);
+		}
+		else
+			; // Would be timeout but Won't happen because we wait forever
+	  }
 }
 
 struct LinuxTimerQueuePrivate {
@@ -285,7 +379,7 @@ bool LinuxTimerQueue::addEvent
 		if ( timer_create
 			 (CLOCK_MONOTONIC, &outer_arg->sevp, &outer_arg->timer_handle)
 			 == -1) {
-			XPTPD_ERROR("timer_create failed - %s", strerror(errno));
+			GPTP_LOG_ERROR("timer_create failed - %s", strerror(errno));
 			return false;
 		}
 		timerQueueMap[key] = outer_arg;
@@ -468,7 +562,7 @@ bool LinuxLock::initialize( OSLockType type ) {
 		pthread_mutexattr_settype(&_private->mta, PTHREAD_MUTEX_RECURSIVE);
 	lock_c = pthread_mutex_init(&_private->mutex,&_private->mta);
 	if(lock_c != 0) {
-		XPTPD_ERROR("Mutex initialization failed - %s\n",strerror(errno));
+		GPTP_LOG_ERROR("Mutex initialization failed - %s\n",strerror(errno));
 		return oslock_fail;
 	}
 	return oslock_ok;
@@ -571,7 +665,7 @@ bool LinuxThread::start(OSThreadFunction function, void *arg) {
 	sigaddset(&set, SIGALRM);
 	err = pthread_sigmask(SIG_BLOCK, &set, &oset);
 	if (err != 0) {
-		XPTPD_ERROR
+		GPTP_LOG_ERROR
 			("Add timer pthread_sigmask( SIG_BLOCK ... )");
 		return false;
 	}
@@ -582,7 +676,7 @@ bool LinuxThread::start(OSThreadFunction function, void *arg) {
 	sigdelset(&oset, SIGALRM);
 	err = pthread_sigmask(SIG_SETMASK, &oset, NULL);
 	if (err != 0) {
-		XPTPD_ERROR
+		GPTP_LOG_ERROR
 			("Add timer pthread_sigmask( SIG_SETMASK ... )");
 		return false;
 	}
@@ -625,7 +719,7 @@ bool LinuxSharedMemoryIPC::init( OS_IPC_ARG *barg ) {
 	} else {
 		arg = dynamic_cast<LinuxIPCArg *> (barg);
 		if( arg == NULL ) {
-			XPTPD_ERROR( "Wrong IPC init arg type" );
+			GPTP_LOG_ERROR( "Wrong IPC init arg type" );
 			goto exit_error;
 		} else {
 			group_name = arg->group_name;
@@ -633,33 +727,33 @@ bool LinuxSharedMemoryIPC::init( OS_IPC_ARG *barg ) {
 	}
 	grp = getgrnam( group_name );
 	if( grp == NULL ) {
-		XPTPD_ERROR( "Group %s not found, will try root (0) instead", group_name );
+		GPTP_LOG_ERROR( "Group %s not found, will try root (0) instead", group_name );
 	}
 
 	shm_fd = shm_open( SHM_NAME, O_RDWR | O_CREAT, 0660 );
 	if( shm_fd == -1 ) {
-		XPTPD_ERROR( "shm_open(): %s", strerror(errno) );
+		GPTP_LOG_ERROR( "shm_open(): %s", strerror(errno) );
 		goto exit_error;
 	}
 	(void) umask(oldumask);
 	if (fchown(shm_fd, -1, grp != NULL ? grp->gr_gid : 0) < 0) {
-		XPTPD_ERROR("shm_open(): Failed to set ownership");
+		GPTP_LOG_ERROR("shm_open(): Failed to set ownership");
 	}
 	if( ftruncate( shm_fd, SHM_SIZE ) == -1 ) {
-		XPTPD_ERROR( "ftruncate()" );
+		GPTP_LOG_ERROR( "ftruncate()" );
 		goto exit_unlink;
 	}
 	master_offset_buffer = (char *) mmap
 		( NULL, SHM_SIZE, PROT_READ | PROT_WRITE, MAP_LOCKED | MAP_SHARED,
 		  shm_fd, 0 );
 	if( master_offset_buffer == (char *) -1 ) {
-		XPTPD_ERROR( "mmap()" );
+		GPTP_LOG_ERROR( "mmap()" );
 		goto exit_unlink;
 	}
 	/*create mutex attr */
 	err = pthread_mutexattr_init(&shared);
 	if(err != 0) {
-		XPTPD_ERROR
+		GPTP_LOG_ERROR
 			("mutex attr initialization failed - %s\n",
 			 strerror(errno));
 		goto exit_unlink;
@@ -668,7 +762,7 @@ bool LinuxSharedMemoryIPC::init( OS_IPC_ARG *barg ) {
 	/*create a mutex */
 	err = pthread_mutex_init((pthread_mutex_t *) master_offset_buffer, &shared);
 	if(err != 0) {
-		XPTPD_ERROR
+		GPTP_LOG_ERROR
 			("sharedmem - Mutex initialization failed - %s\n",
 			 strerror(errno));
 		goto exit_unlink;
@@ -728,24 +822,24 @@ bool LinuxNetworkInterfaceFactory::createInterface
 	LinuxNetworkInterface *net_iface_l = new LinuxNetworkInterface();
 
 	if( !net_iface_l->net_lock.init()) {
-		XPTPD_ERROR( "Failed to initialize network lock");
+		GPTP_LOG_ERROR( "Failed to initialize network lock");
 		return false;
 	}
 
 	InterfaceName *ifname = dynamic_cast<InterfaceName *>(label);
 	if( ifname == NULL ){
-		XPTPD_ERROR( "ifname == NULL");
+		GPTP_LOG_ERROR( "ifname == NULL");
 		return false;
 	}
 
 	net_iface_l->sd_general = socket( PF_PACKET, SOCK_DGRAM, 0 );
 	if( net_iface_l->sd_general == -1 ) {
-		XPTPD_ERROR( "failed to open general socket: %s", strerror(errno));
+		GPTP_LOG_ERROR( "failed to open general socket: %s", strerror(errno));
 		return false;
 	}
 	net_iface_l->sd_event = socket( PF_PACKET, SOCK_DGRAM, 0 );
 	if( net_iface_l->sd_event == -1 ) {
-		XPTPD_ERROR
+		GPTP_LOG_ERROR
 			( "failed to open event socket: %s \n", strerror(errno));
 		return false;
 	}
@@ -754,7 +848,7 @@ bool LinuxNetworkInterfaceFactory::createInterface
 	ifname->toString( device.ifr_name, IFNAMSIZ );
 	err = ioctl( net_iface_l->sd_event, SIOCGIFHWADDR, &device );
 	if( err == -1 ) {
-		XPTPD_ERROR
+		GPTP_LOG_ERROR
 			( "Failed to get interface address: %s", strerror( errno ));
 		return false;
 	}
@@ -763,7 +857,7 @@ bool LinuxNetworkInterfaceFactory::createInterface
 	net_iface_l->local_addr = addr;
 	err = ioctl( net_iface_l->sd_event, SIOCGIFINDEX, &device );
 	if( err == -1 ) {
-		XPTPD_ERROR
+		GPTP_LOG_ERROR
 			( "Failed to get interface index: %s", strerror( errno ));
 		return false;
 	}
@@ -778,7 +872,7 @@ bool LinuxNetworkInterfaceFactory::createInterface
 		( net_iface_l->sd_event, SOL_PACKET, PACKET_ADD_MEMBERSHIP,
 		  &mr_8021as, sizeof( mr_8021as ));
 	if( err == -1 ) {
-		XPTPD_ERROR
+		GPTP_LOG_ERROR
 			( "Unable to add PTP multicast addresses to port id: %u",
 			  ifindex );
 		return false;
@@ -792,19 +886,19 @@ bool LinuxNetworkInterfaceFactory::createInterface
 		( net_iface_l->sd_event, (sockaddr *) &ifsock_addr,
 		  sizeof( ifsock_addr ));
 	if( err == -1 ) {
-		XPTPD_ERROR( "Call to bind() failed: %s", strerror(errno) );
+		GPTP_LOG_ERROR( "Call to bind() failed: %s", strerror(errno) );
 		return false;
 	}
 
 	net_iface_l->timestamper =
 		dynamic_cast <LinuxTimestamper *>(timestamper);
 	if(net_iface_l->timestamper == NULL) {
-		XPTPD_ERROR( "timestamper == NULL\n" );
+		GPTP_LOG_ERROR( "timestamper == NULL\n" );
 		return false;
 	}
 	if( !net_iface_l->timestamper->post_init
 		( ifindex, net_iface_l->sd_event, &net_iface_l->net_lock )) {
-		XPTPD_ERROR( "post_init failed\n" );
+		GPTP_LOG_ERROR( "post_init failed\n" );
 		return false;
 	}
 	*net_iface = net_iface_l;

--- a/daemons/gptp/linux/src/linux_hal_common.hpp
+++ b/daemons/gptp/linux/src/linux_hal_common.hpp
@@ -156,7 +156,8 @@ private:
 public:
 	/**
 	 * @brief Sends a packet to a remote address
-	 * @param addr [in] Remote link layer address
+	 * @param addr [in] Remote link layer address 
+	 * @param etherType [in] The EtherType of the message
 	 * @param payload [in] Data buffer
 	 * @param length Size of data buffer
 	 * @param timestamp TRUE if to use the event socket with the PTP multicast address. FALSE if to use
@@ -164,7 +165,7 @@ public:
 	 * @return net_fatal if error, net_success if success
 	 */
 	virtual net_result send
-	( LinkLayerAddress *addr, uint8_t *payload, size_t length,
+	( LinkLayerAddress *addr, uint16_t etherType, uint8_t *payload, size_t length,
 	  bool timestamp );
 
 	/**
@@ -198,6 +199,12 @@ public:
 	virtual void getLinkLayerAddress( LinkLayerAddress *addr ) {
 		*addr = local_addr;
 	}
+
+	/**
+	 * @brief  Watch for net link changes.
+	 */
+	virtual void watchNetLink(IEEE1588Port *pPort);
+
 
 	/**
 	 *  @brief Gets the payload offset

--- a/daemons/gptp/linux/src/linux_hal_generic.cpp
+++ b/daemons/gptp/linux/src/linux_hal_generic.cpp
@@ -88,11 +88,11 @@ net_result LinuxNetworkInterface::nrecv
 	} else if( err == -1 ) {
 		if( err == EINTR ) {
 			// Caught signal
-			XPTPD_ERROR( "select() recv signal" );
+			GPTP_LOG_ERROR( "select() recv signal" );
 			ret = net_trfail;
 			goto done;
 		} else {
-			XPTPD_ERROR( "select() failed" );
+			GPTP_LOG_ERROR( "select() failed" );
 			ret = net_fatal;
 			goto done;
     }
@@ -122,7 +122,7 @@ net_result LinuxNetworkInterface::nrecv
 			ret = net_trfail;
 			goto done;
 		}
-		XPTPD_ERROR( "recvmsg() failed: %s", strerror(errno) );
+		GPTP_LOG_ERROR( "recvmsg() failed: %s", strerror(errno) );
 		ret = net_fatal;
 		goto done;
 	}
@@ -211,7 +211,7 @@ LinuxTimestamperGeneric::LinuxTimestamperGeneric() {
 
 bool LinuxTimestamperGeneric::Adjust( void *tmx ) {
 	if( syscall(__NR_clock_adjtime, _private->clockid, tmx ) != 0 ) {
-		XPTPD_ERROR( "Failed to adjust PTP clock rate" );
+		GPTP_LOG_ERROR( "Failed to adjust PTP clock rate" );
 		return false;
 	}
 	return true;
@@ -237,7 +237,7 @@ bool LinuxTimestamperGeneric::HWTimestamper_init
 	snprintf
 		( ptp_device+PTP_DEVICE_IDX_OFFS,
 		  sizeof(ptp_device)-PTP_DEVICE_IDX_OFFS, "%d", phc_index );
-	fprintf( stderr, "Using clock device: %s\n", ptp_device );
+	GPTP_LOG_INFO("Using clock device: %s", ptp_device);
 	phc_fd = open( ptp_device, O_RDWR );
 	if( phc_fd == -1 || (_private->clockid = FD_TO_CLOCKID(phc_fd)) == -1 ) {
 		fprintf( stderr, "Failed to open PTP clock device\n" );
@@ -245,7 +245,7 @@ bool LinuxTimestamperGeneric::HWTimestamper_init
 	}
 
 	if( !resetFrequencyAdjustment() ) {
-		XPTPD_ERROR( "Failed to reset (zero) frequency adjustment" );
+		GPTP_LOG_ERROR( "Failed to reset (zero) frequency adjustment" );
 		return false;
 	}
 
@@ -346,7 +346,7 @@ bool LinuxTimestamperGeneric::post_init( int ifindex, int sd, TicketingLock *loc
 	device.ifr_ifindex = ifindex;
 	err = ioctl( sd, SIOCGIFNAME, &device );
 	if( err == -1 ) {
-		XPTPD_ERROR
+		GPTP_LOG_ERROR
 			( "Failed to get interface name: %s", strerror( errno ));
 		return false;
 	}
@@ -357,7 +357,7 @@ bool LinuxTimestamperGeneric::post_init( int ifindex, int sd, TicketingLock *loc
 	hwconfig.tx_type = HWTSTAMP_TX_ON;
 	err = ioctl( sd, SIOCSHWTSTAMP, &device );
 	if( err == -1 ) {
-		XPTPD_ERROR
+		GPTP_LOG_ERROR
 			( "Failed to configure timestamping: %s", strerror( errno ));
 		return false;
 	}
@@ -370,7 +370,7 @@ bool LinuxTimestamperGeneric::post_init( int ifindex, int sd, TicketingLock *loc
 		( sd, SOL_SOCKET, SO_TIMESTAMPING, &timestamp_flags,
 		  sizeof(timestamp_flags) );
 	if( err == -1 ) {
-		XPTPD_ERROR
+		GPTP_LOG_ERROR
 			( "Failed to configure timestamping on socket: %s",
 			  strerror( errno ));
 		return false;

--- a/daemons/gptp/linux/src/linux_hal_intelce.cpp
+++ b/daemons/gptp/linux/src/linux_hal_intelce.cpp
@@ -196,7 +196,7 @@ net_result LinuxNetworkInterface::nrecv
 	struct timeval timeout = { 0, 16000 }; // 16 ms
 
 	if( !net_lock.lock( &got_net_lock ) || !got_net_lock ) {
-		XPTPD_ERROR( "A Failed to lock mutex" );
+		GPTP_LOG_ERROR( "A Failed to lock mutex" );
 		return net_fatal;
 	}
 
@@ -210,11 +210,11 @@ net_result LinuxNetworkInterface::nrecv
 	} else if( err == -1 ) {
 		if( err == EINTR ) {
 			// Caught signal
-			XPTPD_ERROR( "select() recv signal" );
+			GPTP_LOG_ERROR( "select() recv signal" );
 			ret = net_trfail;
 			goto done;
 		} else {
-			XPTPD_ERROR( "select() failed" );
+			GPTP_LOG_ERROR( "select() failed" );
 			ret = net_fatal;
 			goto done;
 		}
@@ -225,7 +225,7 @@ net_result LinuxNetworkInterface::nrecv
   
 	err = recv( sd_event, payload, length, 0 );
 	if( err < 0 ) {
-		XPTPD_ERROR( "recvmsg() failed: %s", strerror(errno) );
+		GPTP_LOG_ERROR( "recvmsg() failed: %s", strerror(errno) );
 		ret = net_fatal;
 		goto done;
 	}
@@ -235,7 +235,7 @@ net_result LinuxNetworkInterface::nrecv
 
  done:
 	if( !net_lock.unlock()) {
-		XPTPD_ERROR( "A Failed to unlock, %d\n", err );
+		GPTP_LOG_ERROR( "A Failed to unlock, %d\n", err );
 		return net_fatal;
 	}
 

--- a/daemons/gptp/linux/src/linux_hal_persist_file.cpp
+++ b/daemons/gptp/linux/src/linux_hal_persist_file.cpp
@@ -1,0 +1,152 @@
+/*************************************************************************************************************
+Copyright (c) 2012-2016, Harman International Industries, Incorporated
+All rights reserved.
+ 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ 
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ 
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS LISTED "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS LISTED BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*************************************************************************************************************/
+
+#include <stdio.h>
+#include <string>
+#include <string.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <ctype.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <errno.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+
+#include "linux_hal_persist_file.hpp"
+
+class LinuxGPTPPersistFile : public GPTPPersist {
+private:
+	std::string persistIDStr;
+	gPTPPersistWriteCB_t writeCB;
+
+	int persistFD;
+	void *restoredata;
+	off_t storedDataLength;
+	off_t memoryDataLength;
+
+public:
+	LinuxGPTPPersistFile() {
+		persistFD = -1;
+		restoredata = ((void *)-1);
+		storedDataLength = 0;
+		memoryDataLength = 0;
+	}
+
+	~LinuxGPTPPersistFile() {} ;
+
+	bool initStorage(const char *persistID) {
+		persistIDStr = persistID;
+
+		persistFD = open(persistID, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
+		if (persistFD == -1) {
+			printf("Failed to open restore file\n");
+			return false;
+		}
+		return true;
+	}
+
+	bool closeStorage(void) {
+		if (persistFD != -1) {
+			if (restoredata != ((void *) -1))
+				munmap(restoredata, storedDataLength);
+			close(persistFD);
+		}
+		return true;
+	}
+
+	bool readStorage(char **bufPtr, uint32_t *bufSize) {
+		bool result = false;
+		if (persistFD != -1) {
+			// MMAP file
+			struct stat stat0;
+			if (fstat(persistFD, &stat0) == -1) {
+				printf("Failed to stat restore file, %s\n", strerror(errno));
+				storedDataLength = 0;
+			}
+			else {
+				storedDataLength = stat0.st_size;
+				if (storedDataLength != 0) {
+					if ((restoredata = mmap(NULL, storedDataLength, PROT_READ | PROT_WRITE, MAP_SHARED, persistFD, 0)) == ((void *)-1)) {
+						printf("Failed to mmap restore file, %s\n", strerror(errno));
+					}
+					else {
+						*bufSize = storedDataLength;
+						*bufPtr = (char *)restoredata;
+						result = true;
+					}
+				}
+			}
+		}
+
+		return result;
+	}
+
+	void registerWriteCB(gPTPPersistWriteCB_t writeCB)
+	{
+		this->writeCB = writeCB;
+	}
+
+	void setWriteSize(uint32_t dataSize)
+	{
+		memoryDataLength = dataSize;
+	}
+
+	bool triggerWriteStorage(void)
+	{
+		if (!writeCB) {
+			printf("Persistent write callback not registered\n");
+		}
+
+		bool result = false;
+		if (memoryDataLength > storedDataLength) {
+			ftruncate(persistFD, memoryDataLength);
+			if (restoredata != ((void *)-1)) {
+				restoredata = mremap(restoredata, storedDataLength, memoryDataLength, MREMAP_MAYMOVE);
+			}
+			else {
+				restoredata = mmap(NULL, memoryDataLength, PROT_READ | PROT_WRITE, MAP_SHARED, persistFD, 0);
+			}
+			if (restoredata == ((void *)-1)) {
+
+			}
+			else {
+				storedDataLength = memoryDataLength;
+				result = true;
+			}
+		}
+
+		writeCB((char *)restoredata, storedDataLength);
+		return result;
+	}
+};
+
+
+
+GPTPPersist* makeLinuxGPTPPersistFile() {
+	return new LinuxGPTPPersistFile();
+}
+

--- a/daemons/gptp/linux/src/linux_hal_persist_file.hpp
+++ b/daemons/gptp/linux/src/linux_hal_persist_file.hpp
@@ -1,0 +1,42 @@
+/*************************************************************************************************************
+Copyright (c) 2012-2016, Harman International Industries, Incorporated
+All rights reserved.
+ 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ 
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ 
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS LISTED "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS LISTED BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*************************************************************************************************************/
+
+
+#ifndef LINUX_HAL_PERSIST_FILE_HPP
+#define LINUX_HAL_PERSIST_FILE_HPP
+
+#include "avbts_persist.hpp"
+
+
+/**@file*/
+
+/**
+ * @brief  Creates an instance of a GPTPPersist
+ * @return Pointer to the GPTPPersist instance or NULL on failure
+ */
+GPTPPersist *makeLinuxGPTPPersistFile();
+
+
+#endif	/* LINUX_HAL_PERSIST_FILE_HPP */

--- a/daemons/gptp/windows/daemon_cl/IPCListener.cpp
+++ b/daemons/gptp/windows/daemon_cl/IPCListener.cpp
@@ -68,7 +68,7 @@ DWORD WINAPI IPCListener::IPCListenerLoop( IPCSharedData *arg ) {
 			pipe = CreateNamedPipe( pipename, PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED, PIPE_TYPE_BYTE | PIPE_READMODE_BYTE , PIPE_UNLIMITED_INSTANCES,
 				OUTSTANDING_MESSAGES*NPIPE_MAX_SERVER_MSG_SZ, OUTSTANDING_MESSAGES*NPIPE_MAX_MSG_SZ, 0, NULL );
 			if( pipe == INVALID_HANDLE_VALUE ) {
-				XPTPD_ERROR( "Open pipe error (%s): %d", pipename, GetLastError() );
+				GPTP_LOG_ERROR( "Open pipe error (%s): %d", pipename, GetLastError() );
 				goto do_error;
 			}
 			pipe_state = PIPE_UNCONNECT;
@@ -85,7 +85,7 @@ DWORD WINAPI IPCListener::IPCListenerLoop( IPCSharedData *arg ) {
 					err = GetLastError();
 					switch( err ) {
 					default:
-						XPTPD_ERROR( "Attempt to connect on Pipe failed, %d", err );
+						GPTP_LOG_ERROR( "Attempt to connect on Pipe failed, %d", err );
 						goto do_error;
 					case ERROR_PIPE_CONNECTED:
 						pipe_state = PIPE_CONNECT;
@@ -115,7 +115,7 @@ DWORD WINAPI IPCListener::IPCListenerLoop( IPCSharedData *arg ) {
 					err = GetLastError();
 					switch( err ) {
 					default:
-						XPTPD_ERROR( "Failed to read from pipe @%u,%d", __LINE__, err );
+						GPTP_LOG_ERROR( "Failed to read from pipe @%u,%d", __LINE__, err );
 						goto do_error;
 					case ERROR_BROKEN_PIPE:
 						pipe_state = PIPE_CLOSED;
@@ -140,30 +140,30 @@ DWORD WINAPI IPCListener::IPCListenerLoop( IPCSharedData *arg ) {
 						pipe_state = PIPE_CLOSED;
 						continue;
 					}
-					XPTPD_ERROR( "Failed to read from pipe @%u,%d", __LINE__, err );
+					GPTP_LOG_ERROR( "Failed to read from pipe @%u,%d", __LINE__, err );
 					goto do_error;
 				}
 				switch( ((WindowsNPipeMessage *)tmp)->getType() ) {
 				case CTRL_MSG:
 					((WinNPipeCtrlMessage *)tmp)->init();
 					if(( readlen = ((WinNPipeCtrlMessage *)tmp)->read( pipe, readlen )) == -1 ) {
-						XPTPD_ERROR( "Failed to read from pipe @%u", __LINE__ );
+						GPTP_LOG_ERROR( "Failed to read from pipe @%u", __LINE__ );
 						goto do_error;
 					}
 					//readlen may not be set properly ??
 					// Attempt to add or remove from the list
 					switch( ((WinNPipeCtrlMessage *)tmp)->getCtrlWhich() ) {
 					default:
-						XPTPD_ERROR( "Recvd CTRL cmd specifying illegal operation @%u", __LINE__ );
+						GPTP_LOG_ERROR( "Recvd CTRL cmd specifying illegal operation @%u", __LINE__ );
 						goto do_error;
 					case ADD_PEER:
 						if( !list->IsReady() || !list->add( ((WinNPipeCtrlMessage *)tmp)->getPeerAddr() ) ) {
-							XPTPD_ERROR( "Failed to add peer @%u", __LINE__ );
+							GPTP_LOG_ERROR( "Failed to add peer @%u", __LINE__ );
 						}
 						break;
 					case REMOVE_PEER:
 						if( !list->IsReady() || !list->remove( ((WinNPipeCtrlMessage *)tmp)->getPeerAddr() ) ) {
-							XPTPD_ERROR( "Failed to remove peer @%u", __LINE__ );
+							GPTP_LOG_ERROR( "Failed to remove peer @%u", __LINE__ );
 						}
 						break;
 					}
@@ -171,7 +171,7 @@ DWORD WINAPI IPCListener::IPCListenerLoop( IPCSharedData *arg ) {
 				case OFFSET_MSG:
 					((WinNPipeQueryMessage *)tmp)->init();
 					if(( readlen = ((WinNPipeQueryMessage *)tmp)->read( pipe, readlen )) == -1 ) {
-						XPTPD_ERROR( "Failed to read from pipe @%u", __LINE__ );
+						GPTP_LOG_ERROR( "Failed to read from pipe @%u", __LINE__ );
 						goto do_error;
 					}
 					// Create an offset message and send it
@@ -182,7 +182,7 @@ DWORD WINAPI IPCListener::IPCListenerLoop( IPCSharedData *arg ) {
 					((WinNPipeOffsetUpdateMessage *)tmp)->write(pipe);
 					break;
 				default:
-					XPTPD_ERROR( "Recvd Unknown Message" );
+					GPTP_LOG_ERROR( "Recvd Unknown Message" );
 					// Is this recoverable?
 					goto do_error;
 				}

--- a/daemons/gptp/windows/daemon_cl/Stoppable.hpp
+++ b/daemons/gptp/windows/daemon_cl/Stoppable.hpp
@@ -60,7 +60,7 @@ public:
 		exit_waiting = true;
 		if( WaitForSingleObject( thread, INFINITE ) == WAIT_FAILED ) {
 			char *errstr;
-			XPTPD_ERROR( "Wait for thread exit failed %s", errstr );
+			GPTP_LOG_ERROR( "Wait for thread exit failed %s", errstr );
 			delete errstr;
 		}
 		exit_waiting = false;

--- a/daemons/gptp/windows/daemon_cl/daemon_cl.cpp
+++ b/daemons/gptp/windows/daemon_cl/daemon_cl.cpp
@@ -140,7 +140,7 @@ int _tmain(int argc, _TCHAR* argv[])
 	// Create Port Object linked to clock and low level
 	IEEE1588Port *port = new IEEE1588Port( clock, 1, false, 0, timestamper, 0, &local_addr,
 		condition_factory, thread_factory, timer_factory, lock_factory );
-	if( !port->init_port() ) {
+	if( !port->init_port(phy_delay) ) {
 		printf( "Failed to initialize port\n" );
 		return -1;
 	}

--- a/daemons/gptp/windows/daemon_cl/ipcdef.hpp
+++ b/daemons/gptp/windows/daemon_cl/ipcdef.hpp
@@ -105,7 +105,7 @@ public:
         if( last_error == ERROR_SUCCESS || last_error == ERROR_PIPE_LISTENING ) {
             return true;
         }
-		XPTPD_ERROR( "Failed to write to named pipe: %u", last_error );
+		GPTP_LOG_ERROR( "Failed to write to named pipe: %u", last_error );
 		return false;
     }
 	/**
@@ -132,7 +132,7 @@ public:
 		if( ReadFile( pipe, ((char *)this)+offs, ol_read_req, &bytes_read, lol ) == 0 ) {
 			int err = GetLastError();
 			if( err != ERROR_IO_PENDING ) {
-				XPTPD_ERROR( "Failed to read %d bytes from named pipe: %u", ol_read_req, err );
+				GPTP_LOG_ERROR( "Failed to read %d bytes from named pipe: %u", ol_read_req, err );
 			}
 			return err == ERROR_IO_PENDING ? 0 : -1;
 		}

--- a/daemons/gptp/windows/daemon_cl/windows_hal.cpp
+++ b/daemons/gptp/windows/daemon_cl/windows_hal.cpp
@@ -117,10 +117,10 @@ bool WindowsNamedPipeIPC::init(OS_IPC_ARG *arg) {
 	ipclistener = new IPCListener();
 	// Start IPC listen thread
 	if (!ipclistener->start(ipcdata)) {
-		XPTPD_ERROR("Starting IPC listener thread failed");
+		GPTP_LOG_ERROR("Starting IPC listener thread failed");
 	}
 	else {
-		XPTPD_INFO("Starting IPC listener thread succeeded");
+		GPTP_LOG_VERBOSE("Starting IPC listener thread succeeded");
 	}
 
 	return true;

--- a/run_gptp.sh
+++ b/run_gptp.sh
@@ -8,4 +8,4 @@ if [ "$#" -eq "0" ]; then
 fi
 
 groupadd ptp
-daemons/gptp/linux/build/obj/daemon_cl $1
+daemons/gptp/linux/build/obj/daemon_cl $1 $2 $3 $4 $5 $6 $7 $8


### PR DESCRIPTION
A fairly large set of changes to gPTP to support the AVnu Automotiive Profile. Details of the readme are:

## Introduction
This readme covers only the additional features added to the gPTP daemon 
to support the AVnu Automotive Profile (AP). 

## Automotive Profile Features Implemented
- In general all features of the AP support for a Slave device have been 
implemented with the following exceptions. 
	- Windows OS platform code has not been implemented.
- Detailed list of the AP implementation includes
	- Configuration		
		- Static gPTP values (AutoCDS 6.2.1)
		- Persistent gPTP values (AutoCDS 6.2.2)
		- Management Updated Values (AutoCDS 6.2.3)
		- Signalling Message Configuration (AutoCDS 6.2.4)
		- Followup TLV (AutoCDS 6.2.5)
		- Required Values for gPTP (AutoCDS 6.2.6)
	- Operation
		- Disable BMCA (AutoCDS 6.3)
		- No verification of sourcePortIdentity (AutoCDS 6.3)
		- Sync Holdover (AutoCDS 6.3)
		- Sync Recovery (AutoCDS 6.3)
		- Implement Signalling Message (802.1AS 2011 10.5.4)
		- Implement Test Mode (AutoCDS 5.3)
	- Exception Handling	
		- Link State Change (AutoCDS 9.2.1)
		- Loss of Sync Messages (AutoCDS 9.3.1)
		- Non-Continuous Sync Values (AutoCDS 9.3.2)
		- Pdelay Response Timeout (AutoCDS 9.3.3) (Not implemented)
		- neighborPropDelay value (AutoCDS 9.3.4)
	- Diagnostic counters (AutoCDS 13)
		- Abstracted with only simple dump to log upon SIGUSR2 signal.

## Non-Automotive Profile Changes
- Added fuller feature logging within gPTP
- Updated the various logging macros and direct usage of printfs to use the new
logging
- IEEE1588Port class initialization changed to reduced the 14+ constructor
parameters to a single init parameter.
- Link up and Link down detection added.
- Abstracted the state save functionality to allow for easier integration to
other platforms.

## New Command Line Options	
- E enable test mode (as defined in AVnu automotive profile)
- V enable AVnu Automotive Profile
- GM set grandmaster for Automotive Profile
- INITSYNC <value> initial sync interval (Log base 2. 0 = 1 sec)
- OPERSYNC <value> operational sync interval (Log base 2. 0 = 1 sec)
- INITPDELAY <value> initial pdelay interval (Log base 2. 0 = 1 sec)
- OPERPDELAY <value> operational pdelay interval (Log base 2. 0 = 1 sec)

## Build Related
- There are no changes to the standard build for gPTP

## Execution Related
- Other than the new command line options there are no changes to starting gPTP
- Example
	- ./run_gptp.sh eth1 -M statefile -V
		- Start with AP and a specific file name for saving state information.
		
## Run Time Related
- Signals
	- SIGHUP: writes the current gPTP state information to file.
	- SIGUSR2: Dumps the diagnostic counters to the log

## Known Issues
- When running as slave (none -GM) there may be a SYNC rx timeout exception reported when signalling to a different SYNC rate.
- Link down or link up may be incorrectly detected at times.
