### PR TITLE
Handle link up/down events

### DIFF
--- a/daemons/gptp/common/avbts_osnet.hpp
+++ b/daemons/gptp/common/avbts_osnet.hpp
@@ -282,6 +282,14 @@ class factory_name_t {
  */
 typedef enum { net_trfail, net_fatal, net_succeed } net_result;
 
+
+/**
+ * Enumeration net_link_event:
+ * 	- net_linkup
+ * 	- net_linkdown
+ */
+typedef enum { NET_LINK_EVENT_DOWN, NET_LINK_EVENT_UP, NET_LINK_EVENT_FAIL } net_link_event;
+
 /**
  * Provides a generic network interface
  */
@@ -317,9 +325,15 @@ class OSNetworkInterface {
 	 virtual void getLinkLayerAddress(LinkLayerAddress * addr) = 0;
 
 	 /**
+	  * @brief Watch for netlink changes.
+	  */
+	 virtual void watchNetLink(IEEE1588Port *pPort) = 0;
+
+	 /**
 	  * @brief  Provides generic method for getting the payload offset
 	  */
 	 virtual unsigned getPayloadOffset() = 0;
+
 	 /**
 	  * Native support for polimorphic destruction
 	  */

--- a/daemons/gptp/common/avbts_port.hpp
+++ b/daemons/gptp/common/avbts_port.hpp
@@ -214,6 +214,7 @@ class IEEE1588Port {
 
 	OSNetworkInterface *net_iface;
 	LinkLayerAddress local_addr;
+	int link_delay[4];
 
 	/* Port Status */
 	unsigned sync_count;  // 0 for master, ++ for each sync receive as slave
@@ -287,6 +288,8 @@ class IEEE1588Port {
 	PTPMessageSync *last_sync;
 
 	OSThread *listening_thread;
+
+	OSThread *link_thread;
 
 	OSCondition *port_ready_condition;
 
@@ -473,6 +476,12 @@ class IEEE1588Port {
 	 * @return void
 	 */
 	void recoverPort(void);
+
+	/**
+	 * @brief Watch for link up and down events.
+	 * @return Its an infinite loop. Returns NULL in case of error.
+	 */
+	void *watchNetLink(void);
 
 	/**
 	 * @brief Receives messages from the network interface
@@ -850,6 +859,11 @@ class IEEE1588Port {
 			*msg = '\0';
 		}
 	}
+
+	/**
+	 * @brief Initializes the hwtimestamper
+	 */
+	void timestamper_init(void);
 
 	/**
 	 * @brief  Gets RX timestamp based on port identity

--- a/daemons/gptp/common/ieee1588.hpp
+++ b/daemons/gptp/common/ieee1588.hpp
@@ -84,6 +84,8 @@ typedef enum {
 	NULL_EVENT = 0,						//!< Null Event. Used to initialize events.
 	POWERUP = 5,						//!< Power Up. Initialize state machines.
 	INITIALIZE,							//!< Same as POWERUP.
+	LINKUP,								//!< Triggered when link comes up.
+	LINKDOWN,							//!< Triggered when link goes down.
 	STATE_CHANGE_EVENT,					//!< Signalizes that something has changed. Recalculates best master.
 	SYNC_INTERVAL_TIMEOUT_EXPIRES,		//!< Sync interval expired. Its time to send a sync message.
 	PDELAY_INTERVAL_TIMEOUT_EXPIRES,	//!< PDELAY interval expired. Its time to send pdelay_req message

--- a/daemons/gptp/common/ieee1588clock.cpp
+++ b/daemons/gptp/common/ieee1588clock.cpp
@@ -216,6 +216,14 @@ bool IEEE1588Clock::restoreSerializedState( void *buf, off_t *count ) {
   return ret;
 }
 
+void *IEEE1588Port::watchNetLink(void)
+{
+	// Should never return
+	net_iface->watchNetLink(this);
+
+	return NULL;
+}
+
 Timestamp IEEE1588Clock::getSystemTime(void)
 {
 	return (Timestamp(0, 0, 0));

--- a/daemons/gptp/common/ieee1588port.cpp
+++ b/daemons/gptp/common/ieee1588port.cpp
@@ -145,7 +145,7 @@ IEEE1588Port::IEEE1588Port
 
 	pdelay_count = 0;
 	sync_count = 0;
-	bzero(link_delay, 4);
+	memset(link_delay, 0, sizeof(link_delay));
 }
 
 void IEEE1588Port::timestamper_init(void)
@@ -171,7 +171,7 @@ bool IEEE1588Port::init_port(int delay[4])
 	this->net_iface = net_iface;
 	this->net_iface->getLinkLayerAddress(&local_addr);
 	clock->setClockIdentity(&local_addr);
-	memcpy(this->link_delay, delay, 4);
+	memcpy(this->link_delay, delay, sizeof(this->link_delay));
 
 	this->timestamper_init();
 

--- a/daemons/gptp/linux/src/linux_hal_common.hpp
+++ b/daemons/gptp/linux/src/linux_hal_common.hpp
@@ -200,6 +200,11 @@ public:
 	}
 
 	/**
+	 * @brief Watch for net link changes.
+	 */
+	virtual void watchNetLink(IEEE1588Port *pPort);
+
+	/**
 	 *  @brief Gets the payload offset
 	 *  @return payload offset
 	 */


### PR DESCRIPTION
Created a link_thread to monitor the NIC status;
Created two extra events on IEEEPort::processEvents to
handle the link up/down state transitions;
On link up, the HWTimestamper init is called. On link down, it is
just being logged the state transition.

This commit is based on the automotive-profile branch and fixes Issue #254.