### PR TITLE
Fix issue with PDelay timer not being set properly

### DIFF
--- a/daemons/gptp/common/ieee1588port.cpp
+++ b/daemons/gptp/common/ieee1588port.cpp
@@ -230,8 +230,11 @@ bool IEEE1588Port::init_port(int delay[4])
 void IEEE1588Port::startPDelay() {
 	if (automotive_profile) {
 		if (log_min_mean_pdelay_req_interval != PTPMessageSignalling::sigMsgInterval_NoSend) {
+			long long unsigned int waitTime;
+			waitTime = ((long long) (pow((double)2, log_min_mean_pdelay_req_interval) *  1000000000.0));
+			waitTime = waitTime > EVENT_TIMER_GRANULARITY ? waitTime : EVENT_TIMER_GRANULARITY;
 			pdelay_started = true;
-			startPDelayIntervalTimer(log_min_mean_pdelay_req_interval);
+			startPDelayIntervalTimer(waitTime);
 		}
 	}
 	else {


### PR DESCRIPTION
The Path Delay timer used for issuing Path Delay Request messages was not being set properly.