### PR TITLE
64 bit words network/host order conversion

### DIFF
--- a/daemons/gptp/common/ptp_message.cpp
+++ b/daemons/gptp/common/ptp_message.cpp
@@ -489,7 +489,7 @@ PTPMessageCommon *buildPTPMessage
 	memcpy(&(msg->correctionField),
 	       buf + PTP_COMMON_HDR_CORRECTION(PTP_COMMON_HDR_OFFSET),
 	       sizeof(msg->correctionField));
-	msg->correctionField = byte_swap64(msg->correctionField);	// Assume LE machine
+	msg->correctionField = PLAT_ntohll(msg->correctionField);
 	msg->sourcePortIdentity = sourcePortIdentity;
 	msg->sequenceId = sequenceId;
 	memcpy(&(msg->control),
@@ -523,7 +523,7 @@ void PTPMessageCommon::buildCommonHeader(uint8_t * buf)
      * So I am not sure why we are adding 0x10 to it
      */
 	tspec_msg_t = messageType | 0x10;
-	long long correctionField_BE = byte_swap64(correctionField);	// Assume LE machine
+	long long correctionField_BE = PLAT_htonll(correctionField);
 	uint16_t messageLength_NO = PLAT_htons(messageLength);
 
 	memcpy(buf + PTP_COMMON_HDR_TRANSSPEC_MSGTYPE(PTP_COMMON_HDR_OFFSET),

--- a/daemons/gptp/linux/src/platform.cpp
+++ b/daemons/gptp/linux/src/platform.cpp
@@ -46,3 +46,11 @@ uint16_t PLAT_ntohs( uint16_t s ) {
 uint32_t PLAT_ntohl( uint32_t l ) {
 	return ntohl( l );
 }
+uint64_t PLAT_htonll(uint64_t x)
+{
+	return ( (htonl(1) == 1) ? x : ((uint64_t)htonl((x) & 0xFFFFFFFF) << 32) | htonl((x) >> 32) );
+}
+uint64_t PLAT_ntohll(uint64_t x)
+{
+	return( (ntohl(1) == 1) ? x : ((uint64_t)ntohl((x) & 0xFFFFFFFF) << 32) | ntohl((x) >> 32) );
+}

--- a/daemons/gptp/linux/src/platform.hpp
+++ b/daemons/gptp/linux/src/platform.hpp
@@ -73,4 +73,18 @@ uint16_t PLAT_ntohs( uint16_t s );
  */
 uint32_t PLAT_ntohl( uint32_t l );
 
+/**
+ * @brief  Converts a 64-bit word from host to network order
+ * @param  x Value to be converted
+ * @return Converted value
+ */
+uint64_t PLAT_htonll(uint64_t x);
+
+/**
+ * @brief  Converts a 64 bit word from network to host order
+ * @param  x Value to be converted
+ * @return Converted value
+ */
+uint64_t PLAT_ntohll(uint64_t x);
+
 #endif

--- a/daemons/gptp/windows/daemon_cl/platform.cpp
+++ b/daemons/gptp/windows/daemon_cl/platform.cpp
@@ -53,3 +53,13 @@ uint16_t PLAT_ntohs( uint16_t s ) {
 uint32_t PLAT_ntohl( uint32_t l ) {
 	return ntohl( l );
 }
+
+uint64_t PLAT_htonll(uint64_t x)
+{
+	return ( (htonl(1) == 1) ? x : ((uint64_t)htonl((x) & 0xFFFFFFFF) << 32) | htonl((x) >> 32) );
+}
+
+uint64_t PLAT_ntohll(uint64_t x)
+{
+	return( (ntohl(1) == 1) ? x : ((uint64_t)ntohl((x) & 0xFFFFFFFF) << 32) | ntohl((x) >> 32) );
+}

--- a/daemons/gptp/windows/daemon_cl/platform.hpp
+++ b/daemons/gptp/windows/daemon_cl/platform.hpp
@@ -79,4 +79,18 @@ uint16_t PLAT_ntohs( uint16_t s );
  */
 uint32_t PLAT_ntohl( uint32_t l );
 
+/**
+ * @brief  Converts a 64-bit word from host to network order
+ * @param  x Value to be converted
+ * @return Converted value
+ */
+uint64_t PLAT_htonll(uint64_t x);
+
+/**
+ * @brief  Converts a 64 bit word from network to host order
+ * @param  x Value to be converted
+ * @return Converted value
+ */
+uint64_t PLAT_ntohll(uint64_t x);
+
 #endif


### PR DESCRIPTION
When using 64 bit words, the function byte_swap64 is used. This
function assumes the machine's endianness and because of that it is
not portable.

This patch adds two new functions to deal with the problem of converting
64 bit words between host/network order without assuming the host endianness.

Two byte_swap64 calls were replaced by these two new functions in
PTPMessageCommon::buildCommonHeader and
PTPMessageCommon::buildPTPMessage.

This commit addresses Issue #243