### PR TITLE
Continue sending announce when priority1 is 255

### DIFF
--- a/daemons/gptp/common/ieee1588port.cpp
+++ b/daemons/gptp/common/ieee1588port.cpp
@@ -613,7 +613,6 @@ void IEEE1588Port::processEvent(Event e)
 						  (pow((double)2,getSyncInterval())*
 						   1000000000.0)));
 				}
-				return;
 			}
 			if (port_state == PTP_INITIALIZING
 			    || port_state == PTP_UNCALIBRATED
@@ -655,8 +654,10 @@ void IEEE1588Port::processEvent(Event e)
 				qualified_announce = NULL;
 
 				// Add timers for Announce and Sync, this is as close to immediately as we get
-				clock->addEventTimer
-					( this, SYNC_INTERVAL_TIMEOUT_EXPIRES, 16000000 );
+				if( clock->getPriority1() != 255) {
+					clock->addEventTimer
+						( this, SYNC_INTERVAL_TIMEOUT_EXPIRES, 16000000 );
+				}
 				startAnnounce();
 			}
 		}


### PR DESCRIPTION
If priority1 is set to 255, gPTP must not send any sync
or follow_up messages. gPTP may continue send announce
messages even when priority1 is 255, and BCMA should guarantee
that this device is not a gm.

Reference: IEEE 802.1AS Subclause 10.3.12
