### PR TITLE
Fix TLV parse offset

### DIFF
--- a/daemons/gptp/common/ptp_message.cpp
+++ b/daemons/gptp/common/ptp_message.cpp
@@ -223,7 +223,9 @@ PTPMessageCommon *buildPTPMessage
 			    PLAT_ntohl(followup_msg->
 				       preciseOriginTimestamp.nanoseconds);
 
-			memcpy( &(followup_msg->tlv), buf+PTP_FOLLOWUP_LENGTH, sizeof(followup_msg->tlv) );
+			memcpy( &(followup_msg->tlv),
+				buf+PTP_FOLLOWUP_OFFSET+PTP_FOLLOWUP_LENGTH,
+				sizeof(followup_msg->tlv) );
 
 			msg = followup_msg;
         }


### PR DESCRIPTION
Previously followup TLV offset was incorrect in the code - the PTP header
length was missing

This patch adds in the length of the PTP header