### PR TITLE
Memory leak in buildPTPMessage()

### DIFF
--- a/daemons/gptp/common/ptp_message.cpp
+++ b/daemons/gptp/common/ptp_message.cpp
@@ -98,6 +98,11 @@ PTPMessageCommon *buildPTPMessage
 	messageType = (MessageType) (tspec_msg_t & 0xF);
 	transportSpecific = (tspec_msg_t >> 4) & 0x0F;
 
+	if (transportSpecific!=1) {
+		GPTP_LOG_EXCEPTION("*** Received message with unsupported transportSpecific type=%d",transportSpecific);
+		goto done;
+	}
+
 	sourcePortIdentity = new PortIdentity
 		((uint8_t *)
 		 (buf + PTP_COMMON_HDR_SOURCE_CLOCK_ID
@@ -148,12 +153,7 @@ PTPMessageCommon *buildPTPMessage
 		}
 
 	}
-
-	if (transportSpecific!=1) {
-		GPTP_LOG_EXCEPTION("*** Received message with unsupported transportSpecific type=%d",transportSpecific);
-		return NULL;
-	}
-
+ 
 	switch (messageType) {
 	case SYNC_MESSAGE:
 

--- a/daemons/gptp/common/ptp_message.cpp
+++ b/daemons/gptp/common/ptp_message.cpp
@@ -98,8 +98,8 @@ PTPMessageCommon *buildPTPMessage
 	messageType = (MessageType) (tspec_msg_t & 0xF);
 	transportSpecific = (tspec_msg_t >> 4) & 0x0F;
 
-	if (transportSpecific!=1) {
-		GPTP_LOG_EXCEPTION("*** Received message with unsupported transportSpecific type=%d",transportSpecific);
+	if (1 != transportSpecific) {
+		GPTP_LOG_EXCEPTION("*** Received message with unsupported transportSpecific type=%d", transportSpecific);
 		goto done;
 	}
 


### PR DESCRIPTION
Hello,

this patch fixes a memory leak in `buildPTPMessage()`:
When a message with unset transport_specific flag is received, `buildPTPMessage()` will immediately return NULL, without freeing any previously allocated resources.
This patch changes the function so that the check is performed before a PortIdentity is allocated, and instead of returning NULL immediately, jumps to the cleanup code at the end of the function (which is also used in case of other error conditions).

To verify the memory leak and the fix, the attached source can be used (the code will send 1,000,000 announce message with unset transport_specific flag).
[unspecific_memory_leak.zip](https://github.com/AVnu/Open-AVB/files/302053/unspecific_memory_leak.zip)
