### PR TITLE
Change all doxygen-style comments to have a @brief

### DIFF
--- a/daemons/gptp/common/avbap_message.hpp
+++ b/daemons/gptp/common/avbap_message.hpp
@@ -66,7 +66,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 /**
- * Automotive Profile Test Status Station State
+ * @brief Automotive Profile Test Status Station State
  */
 typedef enum {
 	STATION_STATE_RESERVED,
@@ -77,7 +77,7 @@ typedef enum {
 
 
 /**
- * Provides a class for building the ANvu Automotive
+ * @brief Provides a class for building the ANvu Automotive
  * Profile Test Status message
  */
 class APMessageTestStatus {
@@ -93,7 +93,7 @@ class APMessageTestStatus {
 	APMessageTestStatus(IEEE1588Port * port);
 
 	/**
-	 * Destroys APMessageTestStatus interface
+	 * @brief Destroys APMessageTestStatus interface
 	 */
 	~APMessageTestStatus();
 

--- a/daemons/gptp/common/avbts_clock.hpp
+++ b/daemons/gptp/common/avbts_clock.hpp
@@ -50,7 +50,7 @@
 #define LOWER_FREQ_LIMIT -250.0		/*!< Lower frequency limit */
 
 /**
- * Provides the clock quality abstraction.
+ * @brief Provides the clock quality abstraction.
  * Represents the quality of the clock
  * Defined at IEEE 802.1AS-2011
  * Clause 6.3.3.8
@@ -72,7 +72,7 @@ struct ClockQuality {
 };
 
 /**
- * Provides the 1588 clock interface
+ * @brief Provides the 1588 clock interface
  */
 class IEEE1588Clock {
 private:
@@ -131,7 +131,7 @@ private:
 	FrequencyRatio _local_system_freq_offset;
 
     /**
-     * fup info stores information of the last time
+     * @brief fup info stores information of the last time
      * the base time has changed. When that happens
      * the information from fup_status is copied over
      * fup_info. The follow-up sendPort method is
@@ -141,7 +141,7 @@ private:
     FollowUpTLV *fup_info;
 
     /**
-     * fup status has the instantaneous info
+     * @brief fup status has the instantaneous info
      */
     FollowUpTLV *fup_status;
 

--- a/daemons/gptp/common/avbts_message.hpp
+++ b/daemons/gptp/common/avbts_message.hpp
@@ -128,7 +128,7 @@
 #define TX_TIMEOUT_ITER 6		/*!< Number of timeout iteractions for sending/receiving messages*/
 
 /**
- * Enumeration message type. IEEE 1588-2008 Clause 13.3.2.2
+ * @brief Enumeration message type. IEEE 1588-2008 Clause 13.3.2.2
  */
 enum MessageType {
 	SYNC_MESSAGE = 0,
@@ -144,7 +144,7 @@ enum MessageType {
 };
 
 /**
- * Enumeration legacy message type
+ * @brief Enumeration legacy message type
  */
 enum LegacyMessageType {
 	SYNC,
@@ -156,7 +156,7 @@ enum LegacyMessageType {
 };
 
 /**
- * Enumeration multicast type.
+ * @brief Enumeration multicast type.
  */
 enum MulticastType {
 	MCAST_NONE,
@@ -166,7 +166,7 @@ enum MulticastType {
 };
 
 /**
- * Provides the PTPMessage common interface used during building of
+ * @brief Provides the PTPMessage common interface used during building of
  * PTP messages.
  */
 class PTPMessageCommon {
@@ -191,7 +191,7 @@ protected:
 	bool _gc;	/*!< Garbage collection flag */
 
 	/**
-	 * Default constructor
+	 * @brief Default constructor
 	 */
 	PTPMessageCommon(void) { };
  public:
@@ -201,7 +201,7 @@ protected:
 	 */
 	PTPMessageCommon(IEEE1588Port * port);
 	/**
-	 * Destroys PTPMessageCommon interface
+	 * @brief Destroys PTPMessageCommon interface
 	 */
 	virtual ~PTPMessageCommon(void);
 
@@ -337,7 +337,7 @@ protected:
 									  as PATH_TRACE, whose value is 0x8. */
 
 /**
- * Provides the PathTraceTLV interface
+ * @brief Provides the PathTraceTLV interface
  * The fields of the path TLV shall be as specified in Table 10-8 and in
  * 10.5.4.3.2 through 10.5.4.3.9 from IEEE 802.1AS. This TLV,
  * and its use, are defined in IEEE Std 1588-2008 (see 16.2 and Table 34 of IEEE Std 1588-2008).
@@ -349,7 +349,7 @@ class PathTraceTLV {
 	IdentityList identityList;
  public:
 	/**
-	 * Creates the PathTraceTLV interface.
+	 * @brief Creates the PathTraceTLV interface.
 	 * Sets tlvType to PATH_TRACE_TLV_TYPE using network byte order
 	 */
 	PathTraceTLV() {
@@ -436,7 +436,7 @@ class PathTraceTLV {
 #pragma pack(pop)
 
 /**
- * Provides the PTPMessageAnnounce interface
+ * @brief Provides the PTPMessageAnnounce interface
  * The PTPMessageAnnounce class is used to create
  * announce messages on the 802.1AS format when building
  * the ptp messages.
@@ -458,12 +458,12 @@ class PTPMessageAnnounce:public PTPMessageCommon {
 	 PTPMessageAnnounce(void);
  public:
 	 /**
-	  * Creates the PTPMessageAnnounce interface
+	  * @brief Creates the PTPMessageAnnounce interface
 	  */
 	 PTPMessageAnnounce(IEEE1588Port * port);
 
 	 /**
-	  * Destroys the PTPMessageAnnounce interface
+	  * @brief Destroys the PTPMessageAnnounce interface
 	  */
 	~PTPMessageAnnounce();
 
@@ -547,7 +547,7 @@ class PTPMessageAnnounce:public PTPMessageCommon {
 };
 
 /**
- * Provides a class for building the PTP Sync message
+ * @brief Provides a class for building the PTP Sync message
  */
 class PTPMessageSync : public PTPMessageCommon {
  private:
@@ -562,7 +562,7 @@ class PTPMessageSync : public PTPMessageCommon {
 	PTPMessageSync(IEEE1588Port * port);
 
 	/**
-	 * Destroys PTPMessageSync interface
+	 * @brief Destroys PTPMessageSync interface
 	 */
 	~PTPMessageSync();
 
@@ -597,7 +597,7 @@ class PTPMessageSync : public PTPMessageCommon {
 #pragma pack(push,1)
 
 /**
- * Provides a scaledNs interface
+ * @brief Provides a scaledNs interface
  * The scaledNs type represents signed values of time and time interval in units of 2e-16 ns.
  */
 class scaledNs {
@@ -606,7 +606,7 @@ class scaledNs {
 	uint64_t ls;
  public:
 	/**
-	 * Builds scaledNs interface
+	 * @brief Builds scaledNs interface
 	 */
 	scaledNs() {
 		ms = 0;
@@ -657,7 +657,7 @@ class scaledNs {
 };
 
 /**
- * Provides a follow-up TLV interface back to the previous packing mode
+ * @brief Provides a follow-up TLV interface back to the previous packing mode
  */
 class FollowUpTLV {
  private:
@@ -672,7 +672,7 @@ class FollowUpTLV {
 	int32_t scaledLastGmFreqChange;
  public:
 	/**
-	 * Builds the FollowUpTLV interface
+	 * @brief Builds the FollowUpTLV interface
 	 */
 	FollowUpTLV() {
 		tlvType = PLAT_htons(0x3);
@@ -783,7 +783,7 @@ class FollowUpTLV {
 #pragma pack(pop)
 
 /**
- * Provides a class for a class for building a PTP follow up message
+ * @brief Provides a class for a class for building a PTP follow up message
  */
 class PTPMessageFollowUp:public PTPMessageCommon {
 private:
@@ -794,7 +794,7 @@ private:
 	PTPMessageFollowUp(void) { }
 public:
 	/**
-	 * Builds the PTPMessageFollowUP object
+	 * @brief Builds the PTPMessageFollowUP object
 	 */
 	PTPMessageFollowUp(IEEE1588Port * port);
 
@@ -846,7 +846,7 @@ public:
 };
 
 /**
- * Provides a class for building the PTP Path Delay Request message
+ * @brief Provides a class for building the PTP Path Delay Request message
  */
 class PTPMessagePathDelayReq : public PTPMessageCommon {
  private:
@@ -857,13 +857,13 @@ class PTPMessagePathDelayReq : public PTPMessageCommon {
 	}
  public:
 	/**
-	 * Destroys the PTPMessagePathDelayReq object
+	 * @brief Destroys the PTPMessagePathDelayReq object
 	 */
 	~PTPMessagePathDelayReq() {
 	}
 
 	/**
-	 * Builds the PTPMessagePathDelayReq message
+	 * @brief Builds the PTPMessagePathDelayReq message
 	 */
 	PTPMessagePathDelayReq(IEEE1588Port * port);
 
@@ -895,7 +895,7 @@ class PTPMessagePathDelayReq : public PTPMessageCommon {
 };
 
 /**
- * Provides a class for building the PTP Path Delay Response message.
+ * @brief Provides a class for building the PTP Path Delay Response message.
  */
 class PTPMessagePathDelayResp:public PTPMessageCommon {
 private:
@@ -906,11 +906,11 @@ private:
 	}
 public:
 	/**
-	 * Destroys the PTPMessagePathDelayResp object
+	 * @brief Destroys the PTPMessagePathDelayResp object
 	 */
 	~PTPMessagePathDelayResp();
 	/**
-	 * Builds the PTPMessagePathDelayResp object
+	 * @brief Builds the PTPMessagePathDelayResp object
 	 */
 	PTPMessagePathDelayResp(IEEE1588Port * port);
 
@@ -964,7 +964,7 @@ public:
 };
 
 /**
- * Provides a class for building the PTP Path Delay Response follow up message.
+ * @brief Provides a class for building the PTP Path Delay Response follow up message.
  */
 class PTPMessagePathDelayRespFollowUp:public PTPMessageCommon {
  private:
@@ -975,12 +975,12 @@ class PTPMessagePathDelayRespFollowUp:public PTPMessageCommon {
 
 public:
 	/**
-	 * Builds the PTPMessagePathDelayRespFollowUp object
+	 * @brief Builds the PTPMessagePathDelayRespFollowUp object
 	 */
 	PTPMessagePathDelayRespFollowUp(IEEE1588Port * port);
 
 	/**
-	 * Destroys the PTPMessagePathDelayRespFollowUp object
+	 * @brief Destroys the PTPMessagePathDelayRespFollowUp object
 	 */
 	~PTPMessagePathDelayRespFollowUp();
 
@@ -1038,7 +1038,7 @@ public:
 
 
 /**
- * Provides a Signalling Msg Interval Request TLV interface back to the previous
+ * @brief Provides a Signalling Msg Interval Request TLV interface back to the previous
  * packing mode
  */
 class SignallingTLV {
@@ -1055,7 +1055,7 @@ class SignallingTLV {
 	uint16_t reserved;
  public:
 	/**
-	 * Builds the Signalling Msg Interval Request TLV interface
+	 * @brief Builds the Signalling Msg Interval Request TLV interface
 	 */
 	SignallingTLV() {
 		tlvType = PLAT_htons(0x3);
@@ -1137,7 +1137,7 @@ class SignallingTLV {
 #pragma pack(pop)
 
 /**
- * Provides a class for building a PTP signalling message
+ * @brief Provides a class for building a PTP signalling message
  */
 class PTPMessageSignalling:public PTPMessageCommon {
 private:
@@ -1151,17 +1151,17 @@ public:
 	static const int8_t sigMsgInterval_NoChange =  -128;
 
 	/**
-	 * Builds the PTPMessageSignalling object
+	 * @brief Builds the PTPMessageSignalling object
 	 */
 	PTPMessageSignalling(IEEE1588Port * port);
 
 	/**
-	 * Destroys the PTPMessageSignalling object
+	 * @brief Destroys the PTPMessageSignalling object
 	 */
 	~PTPMessageSignalling();
 
 	/**
-	 *@brief Sets the signalling intervals
+	 * @brief Sets the signalling intervals
 	 * @param  linkDelayInterval link delay interval
 	 * @param  timeSyncInterval Sync interval
 	 * @param  announceInterval Announce interval

--- a/daemons/gptp/common/avbts_oscondition.hpp
+++ b/daemons/gptp/common/avbts_oscondition.hpp
@@ -37,7 +37,7 @@
 /**@file*/
 
 /**
- * Provides a generic interface for OS's locking condition
+ * @brief Provides a generic interface for OS's locking condition
  */
 class OSCondition {
 private:
@@ -62,12 +62,12 @@ public:
 	virtual bool signal() = 0;
 
 	/**
-	 * Deletes previously declared flags
+	 * @brief Deletes previously declared flags
 	 */
 	virtual ~OSCondition() = 0;
 protected:
 	/**
-	 * Default constructor. Initializes internal variables
+	 * @brief Default constructor. Initializes internal variables
 	 */
 	OSCondition() {
 		wait_count = 0;
@@ -101,7 +101,7 @@ protected:
 inline OSCondition::~OSCondition() { }
 
 /**
- * Provides factory design patter for OS Condition class
+ * @brief Provides factory design patter for OS Condition class
  */
 class OSConditionFactory {
 public:
@@ -112,7 +112,7 @@ public:
 	virtual OSCondition * createCondition() = 0;
 
 	/**
-	 * Destroys OSCondition objects
+	 * @brief Destroys OSCondition objects
 	 */
 	virtual ~OSConditionFactory() = 0;
 };

--- a/daemons/gptp/common/avbts_osipc.hpp
+++ b/daemons/gptp/common/avbts_osipc.hpp
@@ -41,7 +41,7 @@
 /**@file*/
 
 /**
- * Generic interface for Inter Process Communication arguments
+ * @brief Generic interface for Inter Process Communication arguments
  */
 class OS_IPC_ARG {
 public:
@@ -51,7 +51,7 @@ public:
 inline OS_IPC_ARG::~OS_IPC_ARG () { }
 
 /**
- * Generic interface for Inter Process Communication
+ * @brief Generic interface for Inter Process Communication
  */
 class OS_IPC {
 public:

--- a/daemons/gptp/common/avbts_oslock.hpp
+++ b/daemons/gptp/common/avbts_oslock.hpp
@@ -37,13 +37,13 @@
 /**@file*/
 
 /**
- * Lock type enumeration. The possible values are:
+ * @brief Lock type enumeration. The possible values are:
  * 	- oslock_recursive;
  * 	- oslock_nonrecursive;
  */
 typedef enum { oslock_recursive, oslock_nonrecursive } OSLockType;
 /**
- * Lock result enumeration. The possible values are:
+ * @brief Lock result enumeration. The possible values are:
  * 	- oslock_ok;
  * 	- oslock_self;
  * 	- oslock_held;
@@ -52,7 +52,7 @@ typedef enum { oslock_recursive, oslock_nonrecursive } OSLockType;
 typedef enum { oslock_ok, oslock_self, oslock_held, oslock_fail } OSLockResult;
 
 /**
- * Provides a generic mechanism for locking critical sections.
+ * @brief Provides a generic mechanism for locking critical sections.
  */
 class OSLock {
 	public:
@@ -75,7 +75,7 @@ class OSLock {
 		virtual OSLockResult trylock() = 0;
 	protected:
 		/**
-		 * Default constructor
+		 * @brief Default constructor
 		 */
 		OSLock() { }
 
@@ -93,7 +93,7 @@ class OSLock {
 inline OSLock::~OSLock() {}
 
 /**
- * Provides a factory pattern for OSLock
+ * @brief Provides a factory pattern for OSLock
  */
 class OSLockFactory {
 	public:

--- a/daemons/gptp/common/avbts_osnet.hpp
+++ b/daemons/gptp/common/avbts_osnet.hpp
@@ -46,7 +46,7 @@
 #define DEFAULT_TIMEOUT 1			/*!< Default timeout in milliseconds*/
 
 /**
- * LinkLayerAddress Class
+ * @brief LinkLayerAddress Class
  * Provides methods for initializing and comparing ethernet addresses.
  */
 class LinkLayerAddress:public InterfaceLabel {
@@ -55,38 +55,37 @@ class LinkLayerAddress:public InterfaceLabel {
 	uint8_t addr[ETHER_ADDR_OCTETS];
  public:
 	/**
-	 * Default constructor
+	 * @brief Default constructor
 	 */
 	LinkLayerAddress() {
 	};
 
 	/**
-	 * Receives a 64bit scalar
-	 * address and initializes its internal octet array with
-	 * the first 48 bits.
+	 * @brief Receives a 64bit scalar address and initializes its internal octet
+	 * array with the first 48 bits.
 	 * @param address_scalar 64 bit address
 	 */
 	LinkLayerAddress(uint64_t address_scalar) {
 		uint8_t *ptr;
 		address_scalar <<= 16;
-        if(addr == NULL)
-            return;
+		if(addr == NULL)
+			return;
 
-        for (ptr = addr; ptr < addr + ETHER_ADDR_OCTETS; ++ptr) {
+		for (ptr = addr; ptr < addr + ETHER_ADDR_OCTETS; ++ptr) {
 			*ptr = (address_scalar & 0xFF00000000000000ULL) >> 56;
 			address_scalar <<= 8;
 		}
 	}
 
 	/**
-	 * Receives an address as an array of octets
+	 * @brief Receives an address as an array of octets
 	 * and copies the first 6 over the internal ethernet address.
 	 * @param address_octet_array Array of octets containing the address
 	 */
 	LinkLayerAddress(uint8_t * address_octet_array) {
 		uint8_t *ptr;
-        if( addr == NULL || address_octet_array == NULL)
-            return;
+		if( addr == NULL || address_octet_array == NULL)
+			return;
 
 		for (ptr = addr; ptr < addr + ETHER_ADDR_OCTETS;
 		     ++ptr, ++address_octet_array)
@@ -140,8 +139,8 @@ class LinkLayerAddress:public InterfaceLabel {
 	 */
 	void toOctetArray(uint8_t * address_octet_array) {
 		uint8_t *ptr;
-        if(addr == NULL || address_octet_array == NULL)
-            return;
+		if(addr == NULL || address_octet_array == NULL)
+			return;
 		for (ptr = addr; ptr < addr + ETHER_ADDR_OCTETS;
 		     ++ptr, ++address_octet_array)
 		{
@@ -151,8 +150,7 @@ class LinkLayerAddress:public InterfaceLabel {
 };
 
 /**
- * Class InterfaceName
- * Provides methods for dealing with the network interface name
+ * @brief Provides methods for dealing with the network interface name
  * @todo: Destructor doesnt delete this->name.
  */
 class InterfaceName: public InterfaceLabel {
@@ -161,11 +159,11 @@ class InterfaceName: public InterfaceLabel {
 	char *name;
  public:
 	/**
-	 * Default constructor
+	 * @brief Default constructor
 	 */
 	InterfaceName() { }
 	/**
-	 * Initializes Interface name with name and size lenght+1
+	 * @brief Initializes Interface name with name and size lenght+1
 	 * @param name [in] String with the interface name
 	 * @param length Size of name
 	 */
@@ -173,9 +171,9 @@ class InterfaceName: public InterfaceLabel {
 		this->name = new char[length + 1];
 		PLAT_strncpy(this->name, name, length);
 	}
-    ~InterfaceName() {
-        delete(this->name);
-    }
+	~InterfaceName() {
+		delete(this->name);
+	}
 
 	/**
 	 * @brief  Operator '==' overloading method.
@@ -214,8 +212,8 @@ class InterfaceName: public InterfaceLabel {
 	 * @return TRUE if length is greater than size of interface name plus one. FALSE otherwise.
 	 */
 	bool toString(char *string, size_t length) {
-        if(string == NULL)
-            return false;
+		if(string == NULL)
+			return false;
 
 		if (length >= strlen(name) + 1) {
 			PLAT_strncpy(string, name, length);
@@ -226,8 +224,7 @@ class InterfaceName: public InterfaceLabel {
 };
 
 /**
- * factory_name_t class
- * Provides a generic class to be used as a key to create factory maps.
+ * @brief Provides a generic class to be used as a key to create factory maps.
  */
 class factory_name_t {
  private:
@@ -236,7 +233,7 @@ class factory_name_t {
 	factory_name_t();
  public:
 	/**
-	 * Assign a name to the factory_name
+	 * @brief Assign a name to the factory_name
 	 * @param name_a [in] Name to be assigned to the object
 	 */
 	factory_name_t(const char *name_a) {
@@ -275,7 +272,7 @@ class factory_name_t {
 };
 
 /**
- * Enumeration net_result:
+ * @brief Enumeration net_result:
  * 	- net_trfail
  * 	- net_fatal
  * 	- net_succeed
@@ -284,14 +281,14 @@ typedef enum { net_trfail, net_fatal, net_succeed } net_result;
 
 
 /**
- * Enumeration net_link_event:
+ * @brief Enumeration net_link_event:
  * 	- net_linkup
  * 	- net_linkdown
  */
 typedef enum { NET_LINK_EVENT_DOWN, NET_LINK_EVENT_UP, NET_LINK_EVENT_FAIL } net_link_event;
 
 /**
- * Provides a generic network interface
+ * @brief Provides a generic network interface
  */
 class OSNetworkInterface {
  public:
@@ -336,7 +333,7 @@ class OSNetworkInterface {
 	 virtual unsigned getPayloadOffset() = 0;
 
 	 /**
-	  * Native support for polimorphic destruction
+	  * @brief Native support for polimorphic destruction
 	  */
 	 virtual ~OSNetworkInterface() = 0;
 };
@@ -346,12 +343,12 @@ inline OSNetworkInterface::~OSNetworkInterface() {}
 class OSNetworkInterfaceFactory;
 
 /**
- * Provides a map for the OSNetworkInterfaceFactory::registerFactory method
+ * @brief Provides a map for the OSNetworkInterfaceFactory::registerFactory method
  */
 typedef std::map < factory_name_t, OSNetworkInterfaceFactory * >FactoryMap_t;
 
 /**
- * Builds and registers a network interface
+ * @brief Builds and registers a network interface
  */
 class OSNetworkInterfaceFactory {
  public:

--- a/daemons/gptp/common/avbts_osthread.hpp
+++ b/daemons/gptp/common/avbts_osthread.hpp
@@ -37,19 +37,19 @@
 /**@file*/
 
 /**
- * thread exit codes. Possible values are:
+ * @brief thread exit codes. Possible values are:
  * 	- osthread_ok;
  * 	- osthread_error;
  */
 typedef enum { osthread_ok, osthread_error } OSThreadExitCode;
 
 /**
- * Provides the OSThreadExitCode callback format
+ * @brief Provides the OSThreadExitCode callback format
  */
 typedef OSThreadExitCode(*OSThreadFunction) (void *);
 
 /**
- * Provides a generic interface for threads
+ * @brief Provides a generic interface for threads
  */
 class OSThread {
 public:
@@ -73,7 +73,7 @@ public:
 inline OSThread::~OSThread() {}
 
 /**
- * Provides factory design pattern for OSThread class
+ * @brief Provides factory design pattern for OSThread class
  */
 class OSThreadFactory {
 public:
@@ -84,7 +84,7 @@ public:
 	virtual OSThread * createThread() = 0;
 
 	/**
-	 * Destroys the new thread
+	 * @brief Destroys the new thread
 	 */
 	virtual ~OSThreadFactory() = 0;
 };

--- a/daemons/gptp/common/avbts_ostimer.hpp
+++ b/daemons/gptp/common/avbts_ostimer.hpp
@@ -37,7 +37,7 @@
 /**@file*/
 
 /**
- * OSTimer generic interface
+ * @brief OSTimer generic interface
  */
 class OSTimer {
 public:
@@ -57,7 +57,7 @@ public:
 inline OSTimer::~OSTimer() {}
 
 /**
- * Provides factory design patter for OSTimer class
+ * @brief Provides factory design patter for OSTimer class
  */
 class OSTimerFactory {
 public:

--- a/daemons/gptp/common/avbts_ostimerq.hpp
+++ b/daemons/gptp/common/avbts_ostimerq.hpp
@@ -37,14 +37,14 @@
 /**@file*/
 
 /**
- * ostimerq callback definition
+ * @brief ostimerq callback definition
  */
 typedef void (*ostimerq_handler) (void *);
 
 class IEEE1588Clock;
 
 /**
- * OSTimerQueue generic interface
+ * @brief OSTimerQueue generic interface
  */
 class OSTimerQueue {
 protected:
@@ -55,7 +55,7 @@ protected:
 	virtual bool init() { return true; }
 
 	/**
-	 * Default constructor
+	 * @brief Default constructor
 	 */
 	OSTimerQueue() {}
 public:
@@ -86,14 +86,14 @@ public:
 inline OSTimerQueue::~OSTimerQueue() {}
 
 /**
- * Implements factory design patter for OSTimerQueue class
+ * @brief Implements factory design patter for OSTimerQueue class
  */
 class OSTimerQueueFactory {
 public:
 	/**
 	 * @brief Creates the OSTimerQueue object
 	 * @param clock [in] Pointer to the IEEE1555Clock object
-	 * @return Pointer to OSTimerQueue 
+	 * @return Pointer to OSTimerQueue
 	 */
 	virtual OSTimerQueue *createOSTimerQueue( IEEE1588Clock *clock ) = 0;
 	virtual ~OSTimerQueueFactory() = 0;

--- a/daemons/gptp/common/avbts_persist.hpp
+++ b/daemons/gptp/common/avbts_persist.hpp
@@ -48,7 +48,7 @@ typedef void (*gPTPPersistWriteCB_t)(char *bufPtr, uint32_t bufSize);
 
 
 /**
- * Generic interface for Simple Persistence for gPTP values
+ * @brief Generic interface for Simple Persistence for gPTP values
  */
 class GPTPPersist {
 public:

--- a/daemons/gptp/common/avbts_port.hpp
+++ b/daemons/gptp/common/avbts_port.hpp
@@ -65,7 +65,7 @@
 #define LOG2_INTERVAL_INVALID -127	/* Simple out of range Log base 2 value used for Sync and PDelay msg internvals */
 
 /**
- * PortType enumeration. Selects between delay request-response (E2E) mechanism
+ * @brief PortType enumeration. Selects between delay request-response (E2E) mechanism
  * or PTPV1 or PTPV2 P2P (peer delay) mechanism.
  */
 typedef enum {
@@ -75,7 +75,7 @@ typedef enum {
 } PortType;
 
 /**
- * PortIdentity interface
+ * @brief PortIdentity interface
  * Defined at IEEE 802.1AS Clause 8.5.2
  */
 class PortIdentity {
@@ -84,7 +84,7 @@ private:
 	uint16_t portNumber;
 public:
 	/**
-	 * Default Constructor
+	 * @brief Default Constructor
 	 */
 	PortIdentity() { };
 
@@ -202,12 +202,12 @@ public:
 };
 
 /**
- * Provides a map for the identityMap member of IEEE1588Port class
+ * @brief Provides a map for the identityMap member of IEEE1588Port class
  */
 typedef std::map < PortIdentity, LinkLayerAddress > IdentityMap_t;
 
 /**
- * Structure for initializing the IEEE1588 class
+ * @brief Structure for initializing the IEEE1588 class
  */
 typedef struct {
 	/* clock IEEE1588Clock instance */
@@ -267,7 +267,7 @@ typedef struct {
 
 
 /**
- * Structure for IEE1588Port Counters
+ * @brief Structure for IEE1588Port Counters
  */
 typedef struct {
 	int32_t ieee8021AsPortStatRxSyncCount;
@@ -290,7 +290,7 @@ typedef struct {
 
 
 /**
- * Provides the IEEE 1588 port interface
+ * @brief Provides the IEEE 1588 port interface
  */
 class IEEE1588Port {
 	static LinkLayerAddress other_multicast;
@@ -598,7 +598,7 @@ class IEEE1588Port {
 	bool getAutomotiveProfile() { return( automotive_profile ); }
 
 	/**
-	 * Destroys a IEEE1588Port
+	 * @brief Destroys a IEEE1588Port
 	 */
 	~IEEE1588Port();
 

--- a/daemons/gptp/common/gptp_cfg.cpp
+++ b/daemons/gptp/common/gptp_cfg.cpp
@@ -29,10 +29,10 @@ https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
 *************************************************************************************************************/
 
 /**
- * \file
-* MODULE SUMMARY : Reads the .ini file and parses it into information
-* to be used on daemon_cl
-*/
+ * @file
+ * MODULE SUMMARY : Reads the .ini file and parses it into information
+ * to be used on daemon_cl
+ */
 
 #include <iostream>
 

--- a/daemons/gptp/common/gptp_cfg.hpp
+++ b/daemons/gptp/common/gptp_cfg.hpp
@@ -29,10 +29,10 @@ https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
 *************************************************************************************************************/
 
 /**
- * \file
-* MODULE SUMMARY : Reads the .ini file and parses it into information
-* to be used on daemon_cl
-*/
+ * @file
+ * MODULE SUMMARY : Reads the .ini file and parses it into information
+ * to be used on daemon_cl
+ */
 
 #include <string>
 
@@ -40,7 +40,7 @@ https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
 #include "ieee1588.hpp"
 
 /**
- * Provides the gptp interface for
+ * @brief Provides the gptp interface for
  * the iniParser external module
  */
 class GptpIniParser
@@ -48,7 +48,7 @@ class GptpIniParser
     public:
 
         /**
-         * Container with the information to get from the .ini file
+         * @brief Container with the information to get from the .ini file
          */
         typedef struct
         {

--- a/daemons/gptp/common/ieee1588.hpp
+++ b/daemons/gptp/common/ieee1588.hpp
@@ -55,7 +55,7 @@
 
 
 /**
- * Return codes for gPTP
+ * @brief Return codes for gPTP
 */
 #define GPTP_EC_SUCCESS     0       /*!< No errors.*/
 #define GPTP_EC_FAILURE     -1      /*!< Generic error */
@@ -101,7 +101,7 @@ typedef enum {
 } Event;
 
 /**
- * Defines an event descriptor type
+ * @brief Defines an event descriptor type
  */
 typedef struct {
 	IEEE1588Port *port;	//!< IEEE 1588 Port
@@ -117,7 +117,7 @@ struct phy_delay
 };
 
 /**
- * Provides a generic InterfaceLabel class
+ * @brief Provides a generic InterfaceLabel class
  */
 class InterfaceLabel {
  public:
@@ -126,7 +126,7 @@ class InterfaceLabel {
 };
 
 /**
- * Provides a ClockIdentity abstraction
+ * @brief Provides a ClockIdentity abstraction
  * See IEEE 802.1AS-2011 Clause 8.5.2.2
  */
 class ClockIdentity {
@@ -134,7 +134,7 @@ class ClockIdentity {
 	uint8_t id[PTP_CLOCK_IDENTITY_LENGTH];
  public:
 	/**
-	 * Default constructor. Sets ID to zero
+	 * @brief Default constructor. Sets ID to zero
 	 */
 	ClockIdentity() {
 		memset( id, 0, PTP_CLOCK_IDENTITY_LENGTH );
@@ -238,7 +238,7 @@ class ClockIdentity {
 #define MAX_TIMESTAMP_STRLEN 28				/*!< Maximum size of timestamp strlen*/
 
 /**
- * Provides a Timestamp interface
+ * @brief Provides a Timestamp interface
  */
 class Timestamp {
 private:
@@ -459,7 +459,7 @@ static inline void TIMESTAMP_ADD_NS( Timestamp &ts, uint64_t ns ) {
 #define HWTIMESTAMPER_EXTENDED_MESSAGE_SIZE 4096	/*!< Maximum size of HWTimestamper extended message */
 
 /**
- * Provides a generic interface for hardware timestamping
+ * @brief Provides a generic interface for hardware timestamping
  */
 class HWTimestamper {
 
@@ -643,12 +643,13 @@ public:
 	 }
 
 	 /**
-	 * Default constructor. Sets version to zero.
+	 * @brief Default constructor. Sets version to zero.
 	 */
 	HWTimestamper() { version = 0; }
 
-	/*Deletes HWtimestamper object
-	*/
+	 /**
+	 * @brief Deletes HWtimestamper object
+	 */
 	virtual ~HWTimestamper() { }
 };
 

--- a/daemons/gptp/common/ipcdef.hpp
+++ b/daemons/gptp/common/ipcdef.hpp
@@ -63,7 +63,7 @@
 #include <ptptypes.hpp>
 
 /**
- * Provides a data structure for gPTP time
+ * @brief Provides a data structure for gPTP time
  */
 typedef struct {
     int64_t ml_phoffset;			//!< Master to local phase offset

--- a/daemons/gptp/common/ptptypes.hpp
+++ b/daemons/gptp/common/ptptypes.hpp
@@ -44,7 +44,7 @@ typedef long double FrequencyRatio; /*!< Frequency Ratio */
 #define AVTP_ETHERTYPE 0x22F0   /*!< AVTP ethertype used for Test Status Message */
 
 /**
- * PortState enumeration
+ * @brief PortState enumeration
  */
 typedef enum {
 	PTP_MASTER = 7,		//!< Port is PTP Master

--- a/daemons/gptp/linux/src/linux_hal_common.hpp
+++ b/daemons/gptp/linux/src/linux_hal_common.hpp
@@ -65,12 +65,12 @@ extern Timestamp tsToTimestamp(struct timespec *ts);
 struct TicketingLockPrivate;
 
 /**
- * Provides the type for the TicketingLock private structure
+ * @brief Provides the type for the TicketingLock private structure
  */
 typedef struct TicketingLockPrivate * TicketingLockPrivate_t;
 
 /**
- * TicketingLock: Implements the ticket lock algorithm.
+ * @brief TicketingLock: Implements the ticket lock algorithm.
  * A ticket lock consists of two counters, one containing the
  * number of requests to acquire the lock, and the other the
  * number of times the lock has been released.  A processor acquires the lock
@@ -102,13 +102,13 @@ public:
 	bool init();
 
 	/**
-	 * Default constructor sets some flags to false that will be initialized on
+	 * @brief Default constructor sets some flags to false that will be initialized on
 	 * the init method. Protects against using lock/unlock without calling init.
 	 */
 	TicketingLock();
 
 	/**
-	 * Deletes the object and private structures.
+	 * @brief Deletes the object and private structures.
 	 */
 	~TicketingLock();
 private:
@@ -120,13 +120,13 @@ private:
 };
 
 /**
- * LinuxTimestamper: Provides a generic hardware
+ * @brief LinuxTimestamper: Provides a generic hardware
  * timestamp interface for linux based systems.
  */
 class LinuxTimestamper : public HWTimestamper {
 public:
 	/**
-	 * Destructor
+	 * @brief Destructor
 	 */
 	virtual ~LinuxTimestamper() = 0;
 
@@ -141,7 +141,7 @@ public:
 };
 
 /**
- * Provides a Linux network generic interface
+ * @brief Provides a Linux network generic interface
  */
 class LinuxNetworkInterface : public OSNetworkInterface {
 	friend class LinuxNetworkInterfaceFactory;
@@ -206,36 +206,36 @@ public:
 	virtual void watchNetLink(IEEE1588Port *pPort);
 
 	/**
-	 *  @brief Gets the payload offset
-	 *  @return payload offset
+	 * @brief Gets the payload offset
+	 * @return payload offset
 	 */
 	virtual unsigned getPayloadOffset() {
 		return 0;
 	}
 	/**
-	 * Destroys the network interface
+	 * @brief Destroys the network interface
 	 */
 	~LinuxNetworkInterface();
 protected:
 	/**
-	 * Default constructor
+	 * @brief Default constructor
 	 */
 	LinuxNetworkInterface() {};
 };
 
 /**
- * Provides a list of LinuxNetworkInterface members
+ * @brief Provides a list of LinuxNetworkInterface members
  */
 typedef std::list<LinuxNetworkInterface *> LinuxNetworkInterfaceList;
 
 struct LinuxLockPrivate;
 /**
- * Provides a type for the LinuxLock class
+ * @brief Provides a type for the LinuxLock class
  */
 typedef LinuxLockPrivate * LinuxLockPrivate_t;
 
 /**
- * Extends OSLock generic interface to Linux
+ * @brief Extends OSLock generic interface to Linux
  */
 class LinuxLock : public OSLock {
 	friend class LinuxLockFactory;
@@ -244,7 +244,7 @@ private:
 	LinuxLockPrivate_t _private;
 protected:
 	/**
-	 * Default constructor.
+	 * @brief Default constructor.
 	 */
 	LinuxLock() {
 		_private = NULL;
@@ -259,7 +259,7 @@ protected:
 	bool initialize( OSLockType type );
 
 	/**
-	 * Destroys mutexes if lock is still valid
+	 * @brief Destroys mutexes if lock is still valid
 	 */
 	~LinuxLock();
 
@@ -283,7 +283,7 @@ protected:
 };
 
 /**
- * Provides a factory pattern for LinuxLock class
+ * @brief Provides a factory pattern for LinuxLock class
  */
 class LinuxLockFactory:public OSLockFactory {
 public:
@@ -304,12 +304,12 @@ public:
 
 struct LinuxConditionPrivate;
 /**
- * Provides a private type for the LinuxCondition class
+ * @brief Provides a private type for the LinuxCondition class
  */
 typedef struct LinuxConditionPrivate * LinuxConditionPrivate_t;
 
 /**
- * Extends OSCondition class to Linux
+ * @brief Extends OSCondition class to Linux
  */
 class LinuxCondition : public OSCondition {
 	friend class LinuxConditionFactory;
@@ -357,7 +357,7 @@ public:
 };
 
 /**
- * Implements factory design pattern for LinuxCondition class
+ * @brief Implements factory design pattern for LinuxCondition class
  */
 class LinuxConditionFactory : public OSConditionFactory {
 public:
@@ -374,7 +374,7 @@ public:
 struct LinuxTimerQueueActionArg;
 
 /**
- * Provides a map type for the LinuxTimerQueue class
+ * @brief Provides a map type for the LinuxTimerQueue class
  */
 typedef std::map < int, struct LinuxTimerQueueActionArg *> LinuxTimerQueueMap_t;
 
@@ -387,12 +387,12 @@ void *LinuxTimerQueueHandler( void *arg );
 
 struct LinuxTimerQueuePrivate;
 /**
- * Provides a private type for the LinuxTimerQueue class
+ * @brief Provides a private type for the LinuxTimerQueue class
  */
 typedef struct LinuxTimerQueuePrivate * LinuxTimerQueuePrivate_t;
 
 /**
- * Extends OSTimerQueue to Linux
+ * @brief Extends OSTimerQueue to Linux
  */
 class LinuxTimerQueue : public OSTimerQueue {
 	friend class LinuxTimerQueueFactory;
@@ -406,7 +406,7 @@ private:
 	void LinuxTimerQueueAction( LinuxTimerQueueActionArg *arg );
 protected:
 	/**
-	 * Default constructor
+	 * @brief Default constructor
 	 */
 	LinuxTimerQueue() {
 		_private = NULL;
@@ -419,7 +419,7 @@ protected:
 	virtual bool init();
 public:
 	/**
-	 * Deletes pre-allocated internal variables.
+	 * @brief Deletes pre-allocated internal variables.
 	 */
 	~LinuxTimerQueue();
 
@@ -447,7 +447,7 @@ public:
 };
 
 /**
- * Implements factory design pattern for linux
+ * @brief Implements factory design pattern for linux
  */
 class LinuxTimerQueueFactory : public OSTimerQueueFactory {
 public:
@@ -460,7 +460,7 @@ public:
 };
 
 /**
- * Extends the OSTimer generic class to Linux
+ * @brief Extends the OSTimer generic class to Linux
  */
 class LinuxTimer : public OSTimer {
 	friend class LinuxTimerFactory;
@@ -473,13 +473,13 @@ class LinuxTimer : public OSTimer {
 	virtual unsigned long sleep(unsigned long micros);
  protected:
 	/**
-	 * Destroys linux timer
+	 * @brief Destroys linux timer
 	 */
 	LinuxTimer() {};
 };
 
 /**
- * Provides factory design pattern for LinuxTimer
+ * @brief Provides factory design pattern for LinuxTimer
  */
 class LinuxTimerFactory : public OSTimerFactory {
  public:
@@ -493,7 +493,7 @@ class LinuxTimerFactory : public OSTimerFactory {
 };
 
 /**
- * Privdes the default arguments for the OSThread class
+ * @brief Provides the default arguments for the OSThread class
  */
 struct OSThreadArg {
 	OSThreadFunction func;  /*!< Callback function */
@@ -510,12 +510,12 @@ void *OSThreadCallback(void *input);
 
 struct LinuxThreadPrivate;
 /**
- * Provides a private type for the LinuxThread class
+ * @brief Provides a private type for the LinuxThread class
  */
 typedef LinuxThreadPrivate * LinuxThreadPrivate_t;
 
 /**
- * Extends OSThread class to Linux
+ * @brief Extends OSThread class to Linux
  */
 class LinuxThread : public OSThread {
 	friend class LinuxThreadFactory;
@@ -543,7 +543,7 @@ class LinuxThread : public OSThread {
 };
 
 /**
- * Provides factory design pattern for LinuxThread class
+ * @brief Provides factory design pattern for LinuxThread class
  */
 class LinuxThreadFactory:public OSThreadFactory {
  public:
@@ -557,7 +557,7 @@ class LinuxThreadFactory:public OSThreadFactory {
 };
 
 /**
- * Extends OSNetworkInterfaceFactory for LinuxNetworkInterface
+ * @brief Extends OSNetworkInterfaceFactory for LinuxNetworkInterface
  */
 class LinuxNetworkInterfaceFactory : public OSNetworkInterfaceFactory {
 public:
@@ -574,7 +574,7 @@ public:
 };
 
 /**
- * Extends IPC ARG generic interface to linux
+ * @brief Extends IPC ARG generic interface to linux
  */
 class LinuxIPCArg : public OS_IPC_ARG {
 private:
@@ -591,7 +591,7 @@ public:
 		this->group_name[len] = '\0';
 	}
 	/**
-	 * Destroys IPCArg internal variables
+	 * @brief Destroys IPCArg internal variables
 	 */
 	virtual ~LinuxIPCArg() {
 		delete group_name;
@@ -602,7 +602,7 @@ public:
 #define DEFAULT_GROUPNAME "ptp"		/*!< Default groupname for the shared memory interface*/
 
 /**
- * Linux shared memory interface
+ * @brief Linux shared memory interface
  */
 class LinuxSharedMemoryIPC:public OS_IPC {
 private:
@@ -611,7 +611,7 @@ private:
 	int err;
 public:
 	/**
-	 * Initializes the internal flags
+	 * @brief Initializes the internal flags
 	 */
 	LinuxSharedMemoryIPC() {
 		shm_fd = 0;
@@ -619,7 +619,7 @@ public:
 		master_offset_buffer = NULL;
 	};
 	/**
-	 * Destroys and unlinks shared memory
+	 * @brief Destroys and unlinks shared memory
 	 */
 	~LinuxSharedMemoryIPC();
 
@@ -640,7 +640,7 @@ public:
 	 * @param sync_count Count of syncs
 	 * @param pdelay_count Count of pdelays
 	 * @param port_state Port's state
-     * @param asCapable asCapable flag
+	 * @param asCapable asCapable flag
 	 * @return TRUE
 	 */
 	virtual bool update

--- a/daemons/gptp/linux/src/linux_hal_generic.hpp
+++ b/daemons/gptp/linux/src/linux_hal_generic.hpp
@@ -40,7 +40,7 @@
 
 struct LinuxTimestamperGenericPrivate;
 /**
- * Povides LinuxTimestamperGeneric a private type
+ * @brief Provides LinuxTimestamperGeneric a private type
  */
 typedef struct LinuxTimestamperGenericPrivate * LinuxTimestamperGenericPrivate_t;
 
@@ -50,7 +50,7 @@ typedef struct LinuxTimestamperIGBPrivate * LinuxTimestamperIGBPrivate_t;
 #endif
 
 /**
- * Linux timestamper generic interface
+ * @brief Linux timestamper generic interface
  */
 class LinuxTimestamperGeneric : public LinuxTimestamper {
 private:
@@ -71,7 +71,7 @@ private:
 
 public:
 	/**
-	 * Default constructor. Initializes internal variables
+	 * @brief Default constructor. Initializes internal variables
 	 */
 	LinuxTimestamperGeneric();
 
@@ -185,7 +185,7 @@ public:
 #endif
 
 	/**
-	 * deletes LinuxTimestamperGeneric object
+	 * @brief deletes LinuxTimestamperGeneric object
 	 */
 	virtual ~LinuxTimestamperGeneric();
 };

--- a/daemons/gptp/linux/src/linux_hal_generic_tsprivate.hpp
+++ b/daemons/gptp/linux/src/linux_hal_generic_tsprivate.hpp
@@ -42,7 +42,7 @@ extern "C" {
 #include <igb.h>
 }
 /**
- * Private IGB structure.
+ * @brief Private IGB structure.
  */
 struct LinuxTimestamperIGBPrivate {
 	device_t igb_dev;
@@ -51,8 +51,7 @@ struct LinuxTimestamperIGBPrivate {
 #endif
 
 /**
- * Provides private members for the
- * LinuxTimestamperGeneric class
+ * @brief Provides private members for the LinuxTimestamperGeneric class
  */
 struct LinuxTimestamperGenericPrivate {
 	pthread_mutex_t cross_stamp_lock;		/*!< Cross timestamp lock*/

--- a/daemons/gptp/linux/src/linux_hal_intelce.hpp
+++ b/daemons/gptp/linux/src/linux_hal_intelce.hpp
@@ -40,7 +40,7 @@
 /**@file*/
 
 /**
- * Extends the LinuxTimestamper to IntelCE cards
+ * @brief Extends the LinuxTimestamper to IntelCE cards
  */
 class LinuxTimestamperIntelCE : public LinuxTimestamper {
 private:
@@ -99,13 +99,13 @@ public:
 	bool post_init( int ifindex, int sd, TicketingLock *lock );
 
 	/**
-	 * Destroys timestamper
+	 * @brief Destroys timestamper
 	 */
 	virtual ~LinuxTimestamperIntelCE() {
 	}
 
 	/**
-	 * Default constructor. Initialize some internal variables
+	 * @brief Default constructor. Initialize some internal variables
 	 */
 	LinuxTimestamperIntelCE() {
 		last_tx_time = 0;

--- a/daemons/gptp/windows/daemon_cl/IPCListener.hpp
+++ b/daemons/gptp/windows/daemon_cl/IPCListener.hpp
@@ -42,14 +42,14 @@ POSSIBILITY OF SUCH DAMAGE.
 /**@file */
 
 /**
- * Provides an interface for offset with lock
+ * @brief Provides an interface for offset with lock
  */
 class LockableOffset : public Lockable, public Offset {
 private:
 	bool ready;
 public:
 	/**
-	 * Default constructor. Initializes internal variables
+	 * @brief Default constructor. Initializes internal variables
 	 */
 	LockableOffset() {
 		ml_phoffset = 0;
@@ -71,7 +71,7 @@ public:
 };
 
 /**
- * Provides an interface for the IPC shared data
+ * @brief Provides an interface for the IPC shared data
  */
 class IPCSharedData {
 public:
@@ -80,7 +80,7 @@ public:
 };
 
 /**
- * Provides an interface for the IPC Listener
+ * @brief Provides an interface for the IPC Listener
  */
 class IPCListener : public Stoppable {
 private:
@@ -112,7 +112,7 @@ public:
 		else return false;
 	}
 	/**
-	 * Destroys the IPC listener interface
+	 * @brief Destroys the IPC listener interface
 	 */
 	~IPCListener() {}
 };

--- a/daemons/gptp/windows/daemon_cl/Lockable.hpp
+++ b/daemons/gptp/windows/daemon_cl/Lockable.hpp
@@ -39,14 +39,14 @@ POSSIBILITY OF SUCH DAMAGE.
 /**@file*/
 
 /**
- * Provides a lock abstraction
+ * @brief Provides a lock abstraction
  */
 class Lockable {
 private:
 	SRWLOCK lock;
 public:
 	/**
-	 * Initializes lock interface
+	 * @brief Initializes lock interface
 	 */
 	Lockable() { InitializeSRWLock( &lock ); }
 	/**

--- a/daemons/gptp/windows/daemon_cl/PeerList.hpp
+++ b/daemons/gptp/windows/daemon_cl/PeerList.hpp
@@ -41,7 +41,7 @@ POSSIBILITY OF SUCH DAMAGE.
 /**@file*/
 
 /**
- * Type Peer address with state
+ * @brief Type Peer address with state
  */
 typedef struct {
 	PeerAddr addr;	/*!< Peer address */
@@ -49,21 +49,21 @@ typedef struct {
 } PeerAddrWithState;
 
 /**
- * Peer init handler callback definition
+ * @brief Peer init handler callback definition
  */
 typedef bool (*peer_init_handler)( void **, void *, PeerAddr addr );
 /**
- * Peer remove callback definition
+ * @brief Peer remove callback definition
  */
 typedef bool (*peer_rm_handler)( void *, void * );
 
 /**
- * Type peer vector
+ * @brief Type peer vector
  */
 typedef std::vector<PeerAddrWithState> PeerVector;
 
 /**
- * Peer List interface
+ * @brief Peer List interface
  */
 class PeerList : public Lockable {
 private:
@@ -76,7 +76,7 @@ public:
 	typedef PeerVector::const_iterator const_iterator;	/*!< Peer constant iterator*/
 	typedef PeerVector::iterator PeerVectorIt;			/*!< Peer vector iterator*/
 	/**
-	 * Initializes peer list
+	 * @brief Initializes peer list
 	 */
 	PeerList() { rm = NULL; init = NULL; }
 	/**

--- a/daemons/gptp/windows/daemon_cl/Stoppable.hpp
+++ b/daemons/gptp/windows/daemon_cl/Stoppable.hpp
@@ -40,7 +40,7 @@ POSSIBILITY OF SUCH DAMAGE.
 /**@file*/
 
 /**
- * Provides an interface to stop threads
+ * @brief Provides an interface to stop threads
  */
 class Stoppable {
 protected:
@@ -48,7 +48,7 @@ protected:
 	HANDLE thread;		/*!< Thread handler */
 public:
 	/**
-	 * Initializes interface
+	 * @brief Initializes interface
 	 */
 	Stoppable() { thread = NULL; exit_waiting = false; }
 	/**
@@ -67,7 +67,7 @@ public:
 		return true;
 	}
 	/**
-	 * destroys the interface
+	 * @brief destroys the interface
 	 */
 	virtual ~Stoppable() = 0 {};
 };

--- a/daemons/gptp/windows/daemon_cl/packet.hpp
+++ b/daemons/gptp/windows/daemon_cl/packet.hpp
@@ -43,7 +43,7 @@
 #define PACKET_HDR_LENGTH 14	/*!< Packet header length in bytes */
 
 /**
- * Packet error enumeration. Possible values are:
+ * @brief Packet error enumeration. Possible values are:
  * 	- PACKET_NO_ERROR;
  * 	- PACKET_NOMEMORY_ERROR;
  * 	- PACKET_BADBUFFER_ERROR;
@@ -64,13 +64,13 @@ typedef enum {
 } packet_error_t; 
 
 /**
- * type to ethernet address
+ * @brief type to ethernet address
  */
 typedef struct { 
 	uint8_t addr[ETHER_ADDR_OCTETS];	/*!< Link layer address*/
 } packet_addr_t;
 /**
- * Type to packet handle
+ * @brief Type to packet handle
  */
 typedef struct packet_handle * pfhandle_t;
 

--- a/daemons/gptp/windows/daemon_cl/platform.hpp
+++ b/daemons/gptp/windows/daemon_cl/platform.hpp
@@ -39,11 +39,11 @@
 #include <stdio.h>
 
 /**
- * Provides strncpy
+ * @brief Provides strncpy
  */
 errno_t PLAT_strncpy( char *dest, const char *src, rsize_t max );
 /**
- * provides snprintf
+ * @brief provides snprintf
  */
 #define PLAT_snprintf(buffer,count,...) _snprintf_s(buffer,count,count,__VA_ARGS__);
 

--- a/daemons/gptp/windows/daemon_cl/windows_hal.hpp
+++ b/daemons/gptp/windows/daemon_cl/windows_hal.hpp
@@ -58,7 +58,7 @@
 #include <list>
 
 /**
- * WindowsPCAPNetworkInterface implements an interface to the network adapter
+ * @brief WindowsPCAPNetworkInterface implements an interface to the network adapter
  * through calls to the publicly available libraries known as PCap.
  */
 class WindowsPCAPNetworkInterface : public OSNetworkInterface {
@@ -119,7 +119,7 @@ public:
 		return PACKET_HDR_LENGTH;
 	}
 	/**
-	 * Destroys the network interface
+	 * @brief Destroys the network interface
 	 */
 	virtual ~WindowsPCAPNetworkInterface() {
 		closeInterface( handle );
@@ -127,13 +127,13 @@ public:
 	}
 protected:
 	/**
-	 * Default constructor
+	 * @brief Default constructor
 	 */
 	WindowsPCAPNetworkInterface() { handle = NULL; };
 };
 
 /**
- * WindowsPCAPNetworkInterface implements an interface to the network adapter
+ * @brief WindowsPCAPNetworkInterface implements an interface to the network adapter
  * through calls to the publicly available libraries known as PCap.
  */
 class WindowsPCAPNetworkInterfaceFactory : public OSNetworkInterfaceFactory {
@@ -168,7 +168,7 @@ error_nofree:
 };
 
 /**
- * Provides lock interface for windows
+ * @brief Provides lock interface for windows
  */
 class WindowsLock : public OSLock {
 	friend class WindowsLockFactory;
@@ -202,7 +202,7 @@ private:
 	}
 protected:
 	/**
-	 * Default constructor
+	 * @brief Default constructor
 	 */
 	WindowsLock() {
 		lock_c = NULL;
@@ -248,7 +248,7 @@ protected:
 };
 
 /**
- * Provides the LockFactory abstraction
+ * @brief Provides the LockFactory abstraction
  */
 class WindowsLockFactory : public OSLockFactory {
 public:
@@ -268,7 +268,7 @@ public:
 };
 
 /**
- * Provides a OSCondition interface for windows
+ * @brief Provides a OSCondition interface for windows
  */
 class WindowsCondition : public OSCondition {
 	friend class WindowsConditionFactory;
@@ -277,7 +277,7 @@ private:
 	CONDITION_VARIABLE condition;
 protected:
 	/**
-	 * Initializes the locks and condition variables
+	 * @brief Initializes the locks and condition variables
 	 */
 	bool initialize() {
 		InitializeSRWLock( &lock );
@@ -322,7 +322,7 @@ public:
 };
 
 /**
- * Condition factory for windows
+ * @brief Condition factory for windows
  */
 class WindowsConditionFactory : public OSConditionFactory {
 public:
@@ -337,7 +337,7 @@ class WindowsTimerQueue;
 struct TimerQueue_t;
 
 /**
- * Timer queue handler arguments structure
+ * @brief Timer queue handler arguments structure
  * @todo Needs more details from original developer
  */
 struct WindowsTimerQueueHandlerArg {
@@ -352,11 +352,11 @@ struct WindowsTimerQueueHandlerArg {
 };
 
 /**
- * Creates a list of type WindowsTimerQueueHandlerArg
+ * @brief Creates a list of type WindowsTimerQueueHandlerArg
  */
 typedef std::list<WindowsTimerQueueHandlerArg *> TimerArgList_t;
 /**
- * Timer queue type
+ * @brief Timer queue type
  */
 struct TimerQueue_t {
 	TimerArgList_t arg_list;		/*!< Argument list */
@@ -365,17 +365,17 @@ struct TimerQueue_t {
 };
 
 /**
- * Windows Timer queue handler callback definition
+ * @brief Windows Timer queue handler callback definition
  */
 VOID CALLBACK WindowsTimerQueueHandler( PVOID arg_in, BOOLEAN ignore );
 
 /**
- * Creates a map for the timerQueue
+ * @brief Creates a map for the timerQueue
  */
 typedef std::map<int,TimerQueue_t> TimerQueueMap_t;
 
 /**
- * Windows timer queue interface
+ * @brief Windows timer queue interface
  */
 class WindowsTimerQueue : public OSTimerQueue {
 	friend class WindowsTimerQueueFactory;
@@ -400,7 +400,7 @@ private:
 	}
 protected:
 	/**
-	 * Default constructor. Initializes timers lock
+	 * @brief Default constructor. Initializes timers lock
 	 */
 	WindowsTimerQueue() {
 		InitializeSRWLock( &retiredTimersLock );
@@ -462,12 +462,12 @@ public:
 };
 
 /**
- * Windows callback for the timer queue handler
+ * @brief Windows callback for the timer queue handler
  */
 VOID CALLBACK WindowsTimerQueueHandler( PVOID arg_in, BOOLEAN ignore );
 
 /**
- * Windows implementation of OSTimerQueueFactory
+ * @brief Windows implementation of OSTimerQueueFactory
  */
 class WindowsTimerQueueFactory : public OSTimerQueueFactory {
 public:
@@ -483,7 +483,7 @@ public:
 };
 
 /**
- * Windows implementation of OSTimer
+ * @brief Windows implementation of OSTimer
  */
 class WindowsTimer : public OSTimer {
     friend class WindowsTimerFactory;
@@ -499,13 +499,13 @@ public:
     }
 protected:
 	/**
-	 * Default constructor
+	 * @brief Default constructor
 	 */
     WindowsTimer() {};
 };
 
 /**
- * Windows implementation of OSTimerFactory
+ * @brief Windows implementation of OSTimerFactory
  */
 class WindowsTimerFactory : public OSTimerFactory {
 public:
@@ -519,7 +519,7 @@ public:
 };
 
 /**
- * OSThread argument structure
+ * @brief OSThread argument structure
  */
 struct OSThreadArg {
     OSThreadFunction func;	/*!< Thread callback function */
@@ -528,12 +528,12 @@ struct OSThreadArg {
 };
 
 /**
- * Windows OSThread callback
+ * @brief Windows OSThread callback
  */
 DWORD WINAPI OSThreadCallback( LPVOID input );
 
 /**
- * Implements OSThread interface for windows
+ * @brief Implements OSThread interface for windows
  */
 class WindowsThread : public OSThread {
     friend class WindowsThreadFactory;
@@ -568,13 +568,13 @@ public:
     }
 protected:
 	/**
-	 * Default constructor
+	 * @brief Default constructor
 	 */
 	WindowsThread() {};
 };
 
 /**
- * Provides a windows implmementation of OSThreadFactory
+ * @brief Provides a windows implmementation of OSThreadFactory
  */
 class WindowsThreadFactory : public OSThreadFactory {
 public:
@@ -624,7 +624,7 @@ static DevicePhyDelayMapping DevicePhyDelayMap[] =
 
 
 /**
- * Windows HWTimestamper implementation
+ * @brief Windows HWTimestamper implementation
  */
 class WindowsTimestamper : public HWTimestamper {
 private:
@@ -782,7 +782,7 @@ public:
 
 
 /**
- * Named pipe interface
+ * @brief Named pipe interface
  */
 class WindowsNamedPipeIPC : public OS_IPC {
 private:
@@ -791,11 +791,11 @@ private:
 	PeerList peerList_;
 public:
 	/**
-	 * Default constructor. Initializes the IPC interface
+	 * @brief Default constructor. Initializes the IPC interface
 	 */
 	WindowsNamedPipeIPC() : pipe_(INVALID_HANDLE_VALUE) { };
 	/**
-	 * Destroys the IPC interface
+	 * @brief Destroys the IPC interface
 	 */
 	~WindowsNamedPipeIPC() {
 		if (pipe_ != 0 && pipe_ != INVALID_HANDLE_VALUE)

--- a/daemons/gptp/windows/daemon_cl/windows_ipc.hpp
+++ b/daemons/gptp/windows/daemon_cl/windows_ipc.hpp
@@ -49,7 +49,7 @@
 #pragma pack(push,1)
 
 /**
- * Enumeration named pipe message type. Possible values are:
+ * @brief Enumeration named pipe message type. Possible values are:
  *  - BASE_MSG;
  *  - CTRL_MSG;
  *  - QUERY_MSG;
@@ -58,7 +58,7 @@
 typedef enum { BASE_MSG = 0, CTRL_MSG, QUERY_MSG, OFFSET_MSG } NPIPE_MSG_TYPE;
 
 /**
- * Provides a windows named pipe interface
+ * @brief Provides a windows named pipe interface
  */
 class WindowsNPipeMessage {
     protected:
@@ -153,7 +153,7 @@ class WindowsNPipeMessage {
 };
 
 /**
- * Provides an interface for the phase/frequency offsets
+ * @brief Provides an interface for the phase/frequency offsets
  */
 class Offset {
     public:
@@ -165,7 +165,7 @@ class Offset {
 };
 
 /**
- * Provides an interface to update the Offset information
+ * @brief Provides an interface to update the Offset information
  */
 class WinNPipeOffsetUpdateMessage : public WindowsNPipeMessage {
     private:
@@ -241,13 +241,13 @@ class WinNPipeOffsetUpdateMessage : public WindowsNPipeMessage {
 };
 
 /**
- * Enumeration CtrlWhich. It can assume the following values:
+ * @brief Enumeration CtrlWhich. It can assume the following values:
  *  - ADD_PEER;
  *  - REMOVE_PEER;
  */
 typedef enum { ADD_PEER, REMOVE_PEER } CtrlWhich;
 /**
- * Enumeration AddrWhich. It can assume the following values:
+ * @brief Enumeration AddrWhich. It can assume the following values:
  *  - MAC_ADDR;
  *  - IP_ADDR;
  *  - INVALID_ADDR;
@@ -255,13 +255,13 @@ typedef enum { ADD_PEER, REMOVE_PEER } CtrlWhich;
 typedef enum { MAC_ADDR, IP_ADDR, INVALID_ADDR } AddrWhich;
 
 /**
- * Provides an interface for Peer addresses
+ * @brief Provides an interface for Peer addresses
  */
 class PeerAddr {
     public:
         AddrWhich which;	/*!< Peer address */
         /**
-         * shared memory between mac and ip addresses
+         * @brief shared memory between mac and ip addresses
          */
         union {
             uint8_t mac[ETHER_ADDR_OCTETS];	/*!< Link Layer address */
@@ -310,7 +310,7 @@ class PeerAddr {
 };
 
 /**
- * Provides an interface for named pipe control messages
+ * @brief Provides an interface for named pipe control messages
  */
 class WinNPipeCtrlMessage : public WindowsNPipeMessage {
     private:
@@ -370,7 +370,7 @@ class WinNPipeCtrlMessage : public WindowsNPipeMessage {
 };
 
 /**
- * WindowsNPipeQueryMessage is sent from the client to gPTP daemon to query the
+ * @brief WindowsNPipeQueryMessage is sent from the client to gPTP daemon to query the
  * offset of type ::NPIPE_MSG_TYPE.  The daemon sends WindowsNPipeMessage in response.
  * Currently there is no data associated with this message.
  */
@@ -384,7 +384,7 @@ class WinNPipeQueryMessage : public WindowsNPipeMessage {
 };
 
 /**
- * Provides the client's named pipe interface
+ * @brief Provides the client's named pipe interface
  * @todo Not in use and should be removed.
  */
 typedef union {
@@ -393,7 +393,7 @@ typedef union {
 } WindowsNPipeMsgClient;
 
 /**
- * Provides the server's named pipe interface
+ * @brief Provides the server's named pipe interface
  * @todo Not in use and should be removed.
  */
 typedef union {


### PR DESCRIPTION
As promised in the automotive profile pull request review, I've put together a patch that fixes all the Doxygen-style comments that didn't have any tags at all. They now all have at least a @brief tag. There were just a couple that got a slight bit of extra rewording, but this is mostly a mechanical change.

There are also two or three places where I fixed the whitespace in close proximity to one of these comment blocks.

I found there was a common theme: C++ constructors and destructors almost universally had Doxygen-style comment blocks with no @brief or other tags. If this was intentional, maybe a better fix for those would be to turn them into regular comments instead of Doxygen comments with @brief? The Doxygen output with this patch in place doesn't look objectionable to me, although I haven't gone through all of it.