### PR TITLE
Fix logic for starting PDelay sending

### DIFF
--- a/daemons/gptp/common/ieee1588port.cpp
+++ b/daemons/gptp/common/ieee1588port.cpp
@@ -241,10 +241,10 @@ void IEEE1588Port::startPDelay() {
 				pdelay_started = true;
 				startPDelayIntervalTimer(waitTime);
 			}
-			else {
-				pdelay_started = true;
-				startPDelayIntervalTimer(32000000);
-			}
+		}
+		else {
+			pdelay_started = true;
+			startPDelayIntervalTimer(32000000);
 		}
 	}
 }


### PR DESCRIPTION
The else clause was attached to the wrong if condition; as a result, sending of PDelay messages only worked when the automotive profile was enabled. Without PDelay transactions, the peer would never be asCapable and the rest of the protocol would never run.

I have verified that it does send PDelay requests when this patch is applied.