### PR TITLE
Memory leak

### DIFF
--- a/daemons/gptp/linux/src/daemon_cl.cpp
+++ b/daemons/gptp/linux/src/daemon_cl.cpp
@@ -320,10 +320,6 @@ int main(int argc, char **argv)
       restoredataptr = (char *)restoredata;
     }
 
-    if (argc < 2)
-        return -1;
-    ifname = new InterfaceName(argv[1], strlen(argv[1]));
-
 #ifdef ARCH_INTELCE
     HWTimestamper *timestamper = new LinuxTimestamperIntelCE();
 #else


### PR DESCRIPTION
The first patch fixes memory leak that occurs when receive unexpected message in PTP packet.
In addition,  checking transportSpecifit needs to be done after calling getRxTimestamp().
If buildPTPMessage() is returned before calling getRxTimeStamp() rxTimestampList will keep increasing in LinuxTimestamperGeneric class.

The second patch removes to assign duplicated InterfaceName object unnecessarily.
And this also occurs memory leak.