### PR TITLE
Change gptpscaling calls to gptpgetdata to avoid printfs

### DIFF
--- a/lib/avtp_pipeline/platform/Linux/openavb_time_osal.c
+++ b/lib/avtp_pipeline/platform/Linux/openavb_time_osal.c
@@ -71,8 +71,8 @@ static bool x_timeInit(void) {
 		return FALSE;
 	}
 
-	if (gptpscaling(gIgbMmap, &gPtpTD) < 0) {
-		AVB_LOG_ERROR("GPTP scaling failed");
+	if (gptpgetdata(gIgbMmap, &gPtpTD) < 0) {
+		AVB_LOG_ERROR("GPTP data fetch failed");
 		AVB_TRACE_EXIT(AVB_TRACE_TIME);
 		return FALSE;
 	}
@@ -88,8 +88,8 @@ static bool x_timeInit(void) {
 static bool x_getPTPTime(U64 *timeNsec) {
 	AVB_TRACE_ENTRY(AVB_TRACE_TIME);
 
-	if (gptpscaling(gIgbMmap, &gPtpTD) < 0) {
-		AVB_LOG_ERROR("GPTP scaling failed");
+	if (gptpgetdata(gIgbMmap, &gPtpTD) < 0) {
+		AVB_LOG_ERROR("GPTP data fetch failed");
 		AVB_TRACE_EXIT(AVB_TRACE_TIME);
 		return FALSE;
 	}


### PR DESCRIPTION
The version of gptpscaling in the new centralized avb library is just a wrapper around gptpgetdata with some printfs; the avtp_pipeline library doesn't need the printfs, so I have changed it to use gptpgetdata instead.