### PR TITLE
igb_avb: add mutex lock for memory alloc/free for userpage.

### DIFF
--- a/kmod/igb/igb.h
+++ b/kmod/igb/igb.h
@@ -676,6 +676,7 @@ struct igb_adapter {
 	u32 rss_indir_tbl_init;
 	u8 rss_indir_tbl[IGB_RETA_SIZE];
 #endif
+	struct mutex lock;
 };
 
 #ifdef CONFIG_IGB_VMDQ_NETDEV


### PR DESCRIPTION
Prevent NULL pointer dereference at (null).

Kernel oops for put_page can be occurred by mutated application.

kernel: [ 2591.077666] BUG: unable to handle kernel NULL pointer dereference at           (null)
kernel: [ 2591.077672] IP: [<ffffffff81167625>] put_page+0x5/0x40
kernel: [ 2591.077674] PGD 7a3d16067 PUD 7ee0f4067 PMD 0 
kernel: [ 2591.077675] Oops: 0000 [#1] SMP
~~ snip ~~
kernel: [ 2591.077727]  ffff8807f07a74d8 ffff880035f4a480 ffff880798c73ee8 ffffffff811cce6d
kernel: [ 2591.077729]  ffff8807a3ca0210 ffff8807f2d88f20 0000000000000000 0000000000000000
kernel: [ 2591.077729] Call Trace:
kernel: [ 2591.077739]  [<ffffffffa067f631>] ? igb_close_file+0x81/0x170 [igb_avb]
kernel: [ 2591.077746]  [<ffffffff811cce6d>] __fput+0xbd/0x270
kernel: [ 2591.077748]  [<ffffffff811cd06e>] ____fput+0xe/0x10
kernel: [ 2591.077752]  [<ffffffff8108c797>] task_work_run+0xa7/0xe0
kernel: [ 2591.077758]  [<ffffffff81014f27>] do_notify_resume+0xc7/0xd0
kernel: [ 2591.077763]  [<ffffffff8177109a>] int_signal+0x12/0x17
kernel: [ 2591.077777] Code: fc 00 00 00 00 e8 ac fe ff ff 48 63 45 fc 65 48 01 04 25 70 f5 00 00 c9 c3 66 66 66 66 2e 0f 1f 84 00 00 00 00 00 0f 1f 44 00 00 <48> f7 07 00 c0 00 00 55 48 89 e5 75 15 f0 ff 4f 1c 74 08 5d c3  
kernel: [ 2591.077779] RIP  [<ffffffff81167625>] put_page+0x5/0x40
kernel: [ 2591.077779]  RSP <ffff880798c73e68>