### PR TITLE
Removing redundant line causing AVB streamhandler writeback error

### DIFF
--- a/kmod/igb/igb_main.c
+++ b/kmod/igb/igb_main.c
@@ -10397,7 +10397,6 @@ static int igb_mmap(struct file *file, struct vm_area_struct *vma)
 	} else {
 		physaddr = pgoff;
 	}
-	vma->vm_page_prot = pgprot_noncached(vma->vm_page_prot);
 
 	if (remap_pfn_range(vma, vma->vm_start,  \
 				physaddr,


### PR DESCRIPTION
This change prevents from receiving kernel warnings ("map pfn RAM range req uncached-minus for[...]"). It is unecessary to call that method within igb_mmap(). The behaviour of the code after that change has been tested and proved to be working (no more kernel warnings and audio playback possible)