### PR TITLE
add direct DMA for RX and misc fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,14 @@ simple_listener:
 	$(call descend,examples/$@)
 
 simple_listener_clean:
-	$(call descend,examples/simple_listener/,clean)
+	$(call descend,examples/simple_rx/,clean)
+
+simple_rx:
+	$(MAKE) lib
+	$(call descend,examples/$@)
+
+simple_rx_clean:
+	$(call descend,examples/simple_rx/,clean)
 
 mrp_client:
 	$(call descend,examples/$@)
@@ -118,10 +125,10 @@ avtp_pipeline_doc: lib
 	$(MAKE) -s -C lib/avtp_pipeline -f avtp_pipeline.mk doc
 
 examples_all: simple_talker simple_listener mrp_client live_stream jackd-talker \
-	jackd-listener
+	jackd-listener simple_rx
 
 examples_all_clean: simple_talker_clean simple_listener_clean mrp_client_clean \
-	jackd-talker_clean jackd-listener_clean live_stream_clean
+	jackd-talker_clean jackd-listener_clean live_stream_clean simple_rx_clean
 
 all: igb lib daemons_all examples_all avtp_pipeline
 

--- a/examples/simple_rx/Makefile
+++ b/examples/simple_rx/Makefile
@@ -1,0 +1,26 @@
+CC ?= gcc
+OPT = -O2 -g
+CFLAGS = $(OPT) -Wall -Wextra -Wno-parentheses
+IGBDIR = ../../lib/igb
+INCFLAGS = -I../../daemons/mrpd -I../common -I../../daemons/common -I$(IGBDIR)
+LDLIBS = -lpcap -lsndfile -pthread -lpci
+
+all: simple_rx
+
+simple_rx: simple_rx.o ../common/listener_mrp_client.o $(IGBDIR)/igb.o
+
+simple_rx.o: simple_rx.c
+	$(CC) $(CFLAGS) $(INCFLAGS) -c simple_rx.c
+
+../common/listener_mrp_client.o: ../common/listener_mrp_client.c ../common/listener_mrp_client.h
+	make -C ../common/ listener_mrp_client.o
+
+$(IGBDIR)/igb.o:  $(IGBDIR)/igb.c
+	make -C $(IGBDIR) igb.o
+
+%: %.o
+	$(CC) $(LDFLAGS) $^ $(LDLIBS) -o $@
+
+clean:
+	$(RM)  simple_listener
+	$(RM) `find . -name "*~" -o -name "*.[oa]" -o -name "\#*\#" -o -name TAGS -o -name core -o -name "*.orig"`

--- a/examples/simple_rx/README
+++ b/examples/simple_rx/README
@@ -1,0 +1,22 @@
+EXAMPLE APPLICATIONS
+
+The 'simple_rx' application illustrates the various steps to receive packets
+directly into a user-space AVB application.
+
+The simple rx application requires root permissions to execute and 
+attach to the driver.
+	sudo ./simple_rx -i enp3s0 -f out.wav
+
+To exit the app, hit Ctrl-C. The application gracefully tears down
+the connection to the driver. If the application unexpectedly aborts the
+kernel-mode driver also reclaims the various buffers and attempts to clean up.
+The application should be able to re-initialize and use the transmit queues
+without restarting the driver.
+
+To build the application, you need to have the pciutils library
+installed. the latest version can be downloaded from:
+
+	< ftp://ftp.kernel.org/pub/software/utils/pciutils/ >.
+
+Download and extract the library, and run 'make;make install;make install-lib'.
+

--- a/examples/simple_rx/simple_rx.c
+++ b/examples/simple_rx/simple_rx.c
@@ -1,0 +1,818 @@
+/*
+Copyright (c) 2013 Katja Rohloff <Katja.Rohloff@uni-jena.de>
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+/******************************************************************************
+
+  Copyright (c) 2016, Intel Corporation
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+   3. Neither the name of the Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived from
+      this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+
+******************************************************************************/
+
+#include <errno.h>
+#include <signal.h>
+
+#include <pcap/pcap.h>
+#include <sndfile.h>
+
+#include <search.h>
+#include <pci/pci.h>
+#include <linux/if_ether.h>
+#include <linux/if_vlan.h>
+
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <linux/if.h>
+#include <linux/if_packet.h>
+#include <linux/if_ether.h>
+#include <linux/if_vlan.h>
+
+#include "igb.h"
+#include "listener_mrp_client.h"
+
+#define DEBUG 0
+#define PCAP 0
+#define LIBSND 1
+#define DIRECT_RX 1
+
+#if DIRECT_RX
+#undef PCAP
+#endif
+
+#define VERSION_STR "1.1"
+
+#define ETHERNET_HEADER_SIZE (18)
+#define SEVENTEEN22_HEADER_PART1_SIZE (4)
+#define STREAM_ID_SIZE (8)
+#define SEVENTEEN22_HEADER_PART2_SIZE (10)
+#define SIX1883_HEADER_SIZE (10)
+#define HEADER_SIZE (ETHERNET_HEADER_SIZE		\
+			+ SEVENTEEN22_HEADER_PART1_SIZE \
+			+ STREAM_ID_SIZE		\
+			+ SEVENTEEN22_HEADER_PART2_SIZE \
+			+ SIX1883_HEADER_SIZE)
+#define SAMPLES_PER_SECOND (48000)
+#define SAMPLES_PER_FRAME (6)
+#define CHANNELS (2)
+
+#if DIRECT_RX
+#define IGB_BIND_NAMESZ (24)
+#define IGB_QUEUE_0 (0)
+
+#define PKT_SZ   (2048)
+#define PKT_NUM  (256)
+
+#ifndef ETH_P_IEEE1722
+#define ETH_P_IEEE1722 0x22F0
+#endif
+
+struct myqelem {
+	struct myqelem *q_forw;
+	struct myqelem *q_back;
+	void	*q_data;
+};
+#endif /* DIRECT_RX */
+
+struct mrp_listener_ctx *ctx_sig;//Context pointer for signal handler
+
+struct ethernet_header{
+	u_char dst[6];
+	u_char src[6];
+	u_char stuff[4];
+	u_char type[2];
+};
+
+/* globals */
+
+static const char *version_str = "simple_listener v" VERSION_STR "\n"
+    "Copyright (c) 2012, Intel Corporation\n";
+
+pcap_t* glob_pcap_handle;
+u_char glob_ether_type[] = { 0x22, 0xf0 };
+SNDFILE* glob_snd_file;
+
+#if DIRECT_RX
+/* Global variable for signal handler */
+volatile int halt_rx_sig;
+
+struct myqelem *glob_pkt_head  = NULL;
+struct myqelem *glob_page_head = NULL;
+struct igb_packet		*glob_rx_packets[PKT_NUM];
+struct igb_dma_alloc	glob_dma_pages[PKT_NUM];
+
+/* used to configure the device to accept multicast packets */
+int glob_sock = -1;
+
+void igb_stop_rx(device_t *igb_dev);
+void cleanup(void);
+#endif /* DIRECT_RX */
+
+static void help()
+{
+	fprintf(stderr, "\n"
+		"Usage: listener [-h] -i interface -f file_name.wav"
+		"\n"
+		"Options:\n"
+		"    -h  show this message\n"
+		"    -i  specify interface for AVB connection\n"
+		"    -f  set the name of the output wav-file\n"
+		"\n" "%s" "\n", version_str);
+	exit(EXIT_FAILURE);
+}
+
+void pcap_callback(u_char* args, const struct pcap_pkthdr* packet_header, const u_char* packet)
+{
+	unsigned char* test_stream_id;
+	struct ethernet_header* eth_header;
+	uint32_t *buf;
+	uint32_t frame[2] = { 0 , 0 };
+	int i;
+	struct mrp_listener_ctx *ctx = (struct mrp_listener_ctx*) args;
+	(void) packet_header; /* unused */
+
+#if DEBUG
+	fprintf(stdout,"Got packet.\n");
+#endif /* DEBUG*/
+
+	eth_header = (struct ethernet_header*)(packet);
+
+#if DEBUG
+	fprintf(stdout,"Ether Type: 0x%02x%02x\n", eth_header->type[0], eth_header->type[1]);
+#endif /* DEBUG*/
+
+	if (0 == memcmp(glob_ether_type,eth_header->type,sizeof(eth_header->type)))
+	{
+		test_stream_id = (unsigned char*)(packet + ETHERNET_HEADER_SIZE + SEVENTEEN22_HEADER_PART1_SIZE);
+
+#if DEBUG
+		fprintf(stderr, "Received stream id: %02x%02x%02x%02x%02x%02x%02x%02x\n ",
+			     test_stream_id[0], test_stream_id[1],
+			     test_stream_id[2], test_stream_id[3],
+			     test_stream_id[4], test_stream_id[5],
+			     test_stream_id[6], test_stream_id[7]);
+#endif /* DEBUG*/
+
+		if (0 == memcmp(test_stream_id, ctx->stream_id, sizeof(STREAM_ID_SIZE)))
+		{
+
+#if DEBUG
+			fprintf(stdout,"Stream ids matched.\n");
+#endif /* DEBUG*/
+			buf = (uint32_t*) (packet + HEADER_SIZE);
+			for(i = 0; i < SAMPLES_PER_FRAME * CHANNELS; i += 2)
+			{
+				memcpy(&frame[0], &buf[i], sizeof(frame));
+
+				frame[0] = ntohl(frame[0]);   /* convert to host-byte order */
+				frame[1] = ntohl(frame[1]);
+				frame[0] &= 0x00ffffff;       /* ignore leading label */
+				frame[1] &= 0x00ffffff;
+				frame[0] <<= 8;               /* left-align remaining PCM-24 sample */
+				frame[1] <<= 8;
+
+				sf_writef_int(glob_snd_file, (const int *)frame, 1);
+			}
+		}
+	}
+}
+
+void sigint_handler(int signum)
+{
+	fprintf(stdout,"Received signal %d:leaving...\n", signum);
+
+#if PCAP
+	if (NULL != glob_pcap_handle)
+	{
+		pcap_breakloop(glob_pcap_handle);
+		pcap_close(glob_pcap_handle);
+	}
+#endif /* PCAP */
+
+#if DIRECT_RX
+	halt_rx_sig = 0;
+#endif /* DIRECT_RX */
+}
+
+#if DIRECT_RX
+int join_mcast(char *interface, struct mrp_listener_ctx *ctx)
+{
+	struct sockaddr_ll addr;
+	struct ifreq if_request;
+	int rc;
+	struct packet_mreq multicast_req;
+
+	if (NULL == ctx)
+		return -1;
+
+	glob_sock = socket(PF_PACKET, SOCK_RAW, htons(0x2272));
+	if (glob_sock < 0)
+		return -1;
+
+	memset(&if_request, 0, sizeof(if_request));
+	strncpy(if_request.ifr_name, interface, sizeof(if_request.ifr_name)-1);
+
+	rc = ioctl(glob_sock, SIOCGIFINDEX, &if_request);
+	if (rc < 0) {
+		/* glob_sock will be closed by cleanup() */
+		return -1;
+	}
+
+	memset(&addr, 0, sizeof(addr));
+	addr.sll_ifindex = if_request.ifr_ifindex;
+	addr.sll_family = AF_PACKET;
+	addr.sll_protocol = htons(0x2272);
+
+	rc = bind(glob_sock, (struct sockaddr *)&addr, sizeof(addr));
+	if (0 != rc)
+		return -1;
+
+	rc = setsockopt(glob_sock, SOL_SOCKET, SO_BINDTODEVICE, interface,
+			strlen(interface));
+	if (0 != rc)
+		return -1;
+
+	memset(&multicast_req, 0, sizeof(multicast_req));
+	multicast_req.mr_ifindex = if_request.ifr_ifindex;
+	multicast_req.mr_type = PACKET_MR_MULTICAST;
+	multicast_req.mr_alen = 6;
+	memcpy(multicast_req.mr_address, (void*)ctx->dst_mac, 6);
+
+	rc = setsockopt(glob_sock, SOL_PACKET, PACKET_ADD_MEMBERSHIP,
+			&multicast_req, sizeof(multicast_req));
+	if (0 != rc)
+		return -1;
+
+	return 0;
+}
+
+int pci_connect(device_t *igb_dev)
+{
+	char devpath[IGB_BIND_NAMESZ];
+	struct pci_access *pacc;
+	struct pci_dev *dev;
+	int err;
+
+	memset(igb_dev, 0, sizeof(device_t));
+	pacc = pci_alloc();
+	pci_init(pacc);
+	pci_scan_bus(pacc);
+	for (dev = pacc->devices; dev; dev = dev->next) {
+		pci_fill_info(dev,
+			      PCI_FILL_IDENT | PCI_FILL_BASES | PCI_FILL_CLASS);
+		igb_dev->pci_vendor_id = dev->vendor_id;
+		igb_dev->pci_device_id = dev->device_id;
+		igb_dev->domain = dev->domain;
+		igb_dev->bus = dev->bus;
+		igb_dev->dev = dev->dev;
+		igb_dev->func = dev->func;
+		snprintf(devpath, IGB_BIND_NAMESZ, "%04x:%02x:%02x.%d",
+			 dev->domain, dev->bus, dev->dev, dev->func);
+
+		err = igb_probe(igb_dev);
+
+		if (err)
+			continue;
+
+		printf("attaching to %s\n", devpath);
+
+		if (igb_attach(devpath, igb_dev)) {
+			printf("attach failed! (%s)\n", strerror(errno));
+			continue;
+		}
+		if (igb_attach_rx(igb_dev)) {
+			printf("rx attach failed! (%s)\n", strerror(err));
+			continue;
+		}
+		goto out;
+	}
+	pci_cleanup(pacc);
+	return -ENXIO;
+out:
+	pci_cleanup(pacc);
+	return 0;
+}
+
+int igb_start_rx(device_t *igb_dev, struct mrp_listener_ctx *ctx)
+{
+	int rc = -1;
+	int err;
+
+	uint32_t i;
+	uint32_t count = 0;
+
+	struct myqelem *page_qelem		= NULL;
+	struct myqelem *prev_page_qelem	= NULL;
+	struct myqelem *pkt_qelem		= NULL;
+	struct myqelem *prev_pkt_qelem	= NULL;
+
+	struct igb_dma_alloc	*a_page		= NULL;
+	struct igb_packet		*a_packet	= NULL;
+
+	uint8_t test_filter[128];
+	uint8_t filter_mask[64];
+	struct ethhdr *ethhdr = NULL;
+	uint16_t *ethtype = NULL;
+
+	if (0 != pci_connect(igb_dev))
+		goto out;
+
+	if (0 != igb_init(igb_dev))
+		goto out;
+
+	memset (glob_dma_pages, 0, sizeof(glob_dma_pages));
+	memset (glob_rx_packets, 0, sizeof(glob_rx_packets));
+
+	while (count < PKT_NUM) {
+		page_qelem = calloc(1, sizeof(struct myqelem));
+		if (!page_qelem)
+			goto out;
+
+		if (!glob_page_head)
+			glob_page_head = page_qelem;
+
+		a_page = (struct igb_dma_alloc*)calloc(1, sizeof(struct igb_dma_alloc));
+		if (!a_page)
+			goto out;
+
+		page_qelem->q_data = (void*)a_page;
+		insque(page_qelem, prev_page_qelem);
+		prev_page_qelem = page_qelem;
+
+		err = igb_dma_malloc_page(igb_dev, a_page);
+		if (err) {
+			printf("malloc failed (%s) - out of memory?\n",
+			       strerror(err));
+			goto out;
+		}
+
+		if (a_page->mmap_size < PKT_SZ)
+			goto out;
+
+		/* divide the dma page into buffers for packets */
+		for (i = 0; i < a_page->mmap_size/PKT_SZ; i++) {
+			pkt_qelem = calloc(1, sizeof(struct myqelem));
+			if (!pkt_qelem)
+				goto out;
+
+			if (!glob_pkt_head)
+				glob_pkt_head = pkt_qelem;
+
+			a_packet = (struct igb_packet*)calloc(1, sizeof(struct igb_packet));
+			if (a_packet == NULL) {
+				printf("failed to allocate igb_packet memory!\n");
+				err = -errno;
+				goto out;
+			}
+
+			a_packet->dmatime = 0;
+			a_packet->attime = 0;
+			a_packet->flags = 0;
+			a_packet->map.paddr = a_page->dma_paddr;
+			a_packet->map.mmap_size = a_page->mmap_size;
+			a_packet->offset = (i * PKT_SZ);
+			a_packet->vaddr = a_page->dma_vaddr + a_packet->offset;
+			a_packet->len = PKT_SZ;
+			memset(a_packet->vaddr, 0, a_packet->len);
+			if (prev_pkt_qelem)
+				((struct igb_packet*)prev_pkt_qelem->q_data)->next = a_packet;	
+
+			igb_refresh_buffers(igb_dev, IGB_QUEUE_0, &a_packet, 1);
+
+			pkt_qelem->q_data = (void*)a_packet;
+			insque(pkt_qelem, prev_pkt_qelem);
+			prev_pkt_qelem = pkt_qelem;
+
+			count++;
+		}
+	}
+
+	/* filtering example */
+	memset(filter_mask, 0, sizeof(filter_mask));
+	memset(test_filter, 0, sizeof(test_filter));
+
+	/* the filter for IEEE1722 with VLAN */
+
+	/* accept packets toward the multicast dst mac given by MRP */
+	ethhdr = (struct ethhdr *)test_filter;
+	memcpy((void*)ethhdr->h_dest, (void*)ctx->dst_mac, ETH_ALEN);
+
+	/* ethtype in ethernet frame = 802.1Q */
+	ethhdr->h_proto = htons(ETH_P_8021Q);
+
+	/* real ethtype = IEEE1722 */
+	ethtype = (uint16_t*)(test_filter + ETH_HLEN + 2);
+	*ethtype = htons(ETH_P_IEEE1722);
+
+	filter_mask[0] = 0x3F; /* 00111111b = dst mac */
+	filter_mask[1] = 0x30; /* 00110000b = ethtype */
+	filter_mask[2] = 0x03; /* 00000011b = ethtype after a vlan tag */
+
+	/* install the filter on queue0 */
+	igb_setup_flex_filter(igb_dev, IGB_QUEUE_0, 0, ETHERNET_HEADER_SIZE,
+								test_filter, filter_mask);
+	
+	rc = 0;
+out:
+	if (rc != 0)
+		igb_stop_rx(igb_dev);
+
+	return rc;
+}
+
+void igb_stop_rx(device_t *igb_dev)
+{
+	struct myqelem *qelem = NULL;
+
+	igb_clear_flex_filter(igb_dev, 0);
+
+	while (glob_pkt_head) {
+		qelem = glob_pkt_head;
+		glob_pkt_head = qelem->q_forw;
+		if (qelem->q_data)
+			free(qelem->q_data);
+		free(qelem);
+	}
+
+	while (glob_page_head) {
+		qelem = glob_page_head;
+		glob_page_head = qelem->q_forw;
+		if (qelem->q_data){
+			igb_dma_free_page(igb_dev, (struct igb_dma_alloc*)qelem->q_data);
+			free(qelem->q_data);
+		}
+		free(qelem);
+	}
+
+	igb_detach(igb_dev);
+}
+
+void igb_process_rx(device_t *igb_dev, struct mrp_listener_ctx *ctx)
+{
+	uint32_t i;
+	uint32_t count;
+	uint8_t  *packet;
+	uint32_t *buf;
+	uint32_t frame[2] = { 0 , 0 };
+	uint8_t  *test_stream_id;
+
+	struct igb_packet *igb_pkt = NULL;
+	struct ethhdr* eth_hdr;
+	uint16_t *ethtype = NULL;
+
+	halt_rx_sig = 1;
+
+	while (halt_rx_sig) {
+
+		/* put back */
+		if (igb_pkt) {
+			igb_refresh_buffers(igb_dev, IGB_QUEUE_0, &igb_pkt, 1);
+			igb_pkt = NULL;
+		}
+
+		count = 1;
+		igb_receive(igb_dev, IGB_QUEUE_0, &igb_pkt, &count);
+		if (igb_pkt == NULL) {
+			continue;
+		}
+
+		packet = igb_pkt->vaddr;
+		eth_hdr = (struct ethhdr*)(packet);
+		switch (htons(eth_hdr->h_proto)) {
+			case ETH_P_8021Q:
+				ethtype = (uint16_t*)(packet + ETH_HLEN + 2);
+				if (*ethtype != htons(ETH_P_IEEE1722))
+					continue; 	/* drop the packet */
+				break;
+			case ETH_P_IEEE1722:
+				break;
+			default:
+				continue;	/* drop the packet */
+				break;
+		}
+
+		test_stream_id = (uint8_t*)(packet + ETHERNET_HEADER_SIZE + 
+										SEVENTEEN22_HEADER_PART1_SIZE);
+		buf = (uint32_t*)(packet + HEADER_SIZE);
+
+		if (ETH_P_IEEE1722 == htons(eth_hdr->h_proto)) {
+			/* I210 would strip the VLAN tag field when CTRL.VME = 1b */
+			/* pull 4 bytes the VLAN tag size */
+			test_stream_id = ((uint8_t*)test_stream_id - 4);
+			buf = ((uint32_t*)buf - 1);
+		}
+
+		if (0 == memcmp(test_stream_id, ctx->stream_id, STREAM_ID_SIZE))
+		{
+			for(i = 0; i < SAMPLES_PER_FRAME * CHANNELS; i += 2)
+			{
+				memcpy(&frame[0], &buf[i], sizeof(frame));
+
+				frame[0] = ntohl(frame[0]);   /* convert to host-byte order */
+				frame[1] = ntohl(frame[1]);
+				frame[0] &= 0x00ffffff;       /* ignore leading label */
+				frame[1] &= 0x00ffffff;
+				frame[0] <<= 8;               /* left-align remaining PCM-24 sample */
+				frame[1] <<= 8;
+
+				sf_writef_int(glob_snd_file, (const int *)frame, 1);
+			}
+		}
+	}
+}
+
+void cleanup(void)
+{
+	int ret;
+
+	if (0 != ctx_sig->talker) {
+		ret = send_leave(ctx_sig);
+		if (ret)
+			printf("send_leave failed\n");
+	}
+
+	if (2 > ctx_sig->control_socket)
+	{
+		close(ctx_sig->control_socket);
+		ctx_sig->control_socket = -1;
+		ret = mrp_disconnect(ctx_sig);
+		if (ret)
+			printf("mrp_disconnect failed\n");
+	}
+
+#if LIBSND
+	if (glob_snd_file) {
+		sf_write_sync(glob_snd_file);
+		sf_close(glob_snd_file);
+		glob_snd_file = NULL;
+	}
+#endif /* LIBSND */
+
+	if (glob_sock >= 0) {
+		close (glob_sock);
+		glob_sock = -1;
+	}
+
+	halt_rx_sig = 0;
+}
+#endif /* DIRECT_RX */
+
+int main(int argc, char *argv[])
+{
+	char* file_name = NULL;
+	char* dev = NULL;
+#if PCAP
+	char errbuf[PCAP_ERRBUF_SIZE];
+	struct bpf_program comp_filter_exp;		/* The compiled filter expression */
+	char filter_exp[100];				/* The filter expression */
+#endif
+	struct mrp_listener_ctx *ctx = malloc(sizeof(struct mrp_listener_ctx));
+	struct mrp_domain_attr *class_a = malloc(sizeof(struct mrp_domain_attr));
+	struct mrp_domain_attr *class_b = malloc(sizeof(struct mrp_domain_attr));
+
+#if LIBSND
+	SF_INFO* sf_info = NULL;
+#endif /* LIBSND */
+
+#if DIRECT_RX
+	device_t igb_dev;
+#endif /* DIRECT_RX */
+
+	int c,rc;
+
+	if ((NULL == ctx) || (NULL == class_a) || (NULL == class_b)) {
+		fprintf(stderr, "failed allocating memory\n");
+		rc = EXIT_FAILURE;
+		goto out;
+	}
+
+	ctx_sig = ctx;
+	signal(SIGINT, sigint_handler);
+
+	while((c = getopt(argc, argv, "hi:f:")) > 0)
+	{
+		switch (c)
+		{
+		case 'h':
+			help();
+			break;
+		case 'i':
+			dev = strdup(optarg);
+			break;
+		case 'f':
+			file_name = strdup(optarg);
+			break;
+		default:
+          		fprintf(stderr, "Unrecognized option!\n");
+		}
+	}
+
+	if ((NULL == dev) || (NULL == file_name))
+		help();
+
+	rc = mrp_listener_client_init(ctx);
+	if (rc)
+	{
+		printf("failed to initialize global variables\n");
+		goto out;
+	}
+
+	if (create_socket(ctx))
+	{
+		fprintf(stderr, "Socket creation failed.\n");
+		rc = EXIT_FAILURE;
+		goto out;
+	}
+
+	rc = mrp_monitor(ctx);
+	if (rc)
+	{
+		printf("failed creating MRP monitor thread\n");
+		goto out;
+	}
+	rc=mrp_get_domain(ctx, class_a, class_b);
+	if (rc)
+	{
+		printf("failed calling mrp_get_domain()\n");
+		goto out;
+	}
+
+	printf("detected domain Class A PRIO=%d VID=%04x...\n",class_a->priority,class_a->vid);
+
+	rc = report_domain_status(class_a,ctx);
+	if (rc) {
+		printf("report_domain_status failed\n");
+		goto out;
+	}
+
+	rc = join_vlan(class_a, ctx);
+	if (rc) {
+		printf("join_vlan failed\n");
+		goto out;
+	}
+
+	fprintf(stdout,"Waiting for talker...\n");
+	await_talker(ctx);
+
+#if DEBUG
+	fprintf(stdout,"Send ready-msg...\n");
+#endif /* DEBUG */
+	rc = send_ready(ctx);
+	if (rc) {
+		printf("send_ready failed\n");
+		goto out;
+	}
+
+#if LIBSND
+	sf_info = (SF_INFO*)malloc(sizeof(SF_INFO));
+	if (NULL == sf_info) {
+		fprintf(stderr, "failed allocating memory\n");
+		rc = EXIT_FAILURE;
+		goto out;
+	}
+
+	memset(sf_info, 0, sizeof(SF_INFO));
+
+	sf_info->samplerate = SAMPLES_PER_SECOND;
+	sf_info->channels = CHANNELS;
+	sf_info->format = SF_FORMAT_WAV | SF_FORMAT_PCM_24;
+
+	if (0 == sf_format_check(sf_info))
+	{
+		fprintf(stderr, "Wrong format.");
+		rc = EXIT_FAILURE;
+		goto out;
+	}
+
+	if (NULL == (glob_snd_file = sf_open(file_name, SFM_WRITE, sf_info)))
+	{
+		fprintf(stderr, "Could not create file.");
+		rc = EXIT_FAILURE;
+		goto out;
+	}
+	fprintf(stdout,"Created file called %s\n", file_name);
+#endif /* LIBSND */
+
+#if PCAP
+	/** session, get session handler */
+	/* take promiscuous vs. non-promiscuous sniffing? (0 or 1) */
+	glob_pcap_handle = pcap_open_live(dev, BUFSIZ, 1, -1, errbuf);
+	if (NULL == glob_pcap_handle)
+	{
+		fprintf(stderr, "Could not open device %s: %s\n", dev, errbuf);
+		rc = EXIT_FAILURE;
+		goto out;
+	}
+
+#if DEBUG
+	fprintf(stdout,"Got session pcap handler.\n");
+#endif /* DEBUG */
+	/* compile and apply filter */
+	sprintf(filter_exp,"ether dst %02x:%02x:%02x:%02x:%02x:%02x",ctx->dst_mac[0],ctx->dst_mac[1],ctx->dst_mac[2],ctx->dst_mac[3],ctx->dst_mac[4],ctx->dst_mac[5]);
+	if (-1 == pcap_compile(glob_pcap_handle, &comp_filter_exp, filter_exp, 0, PCAP_NETMASK_UNKNOWN))
+	{
+		fprintf(stderr, "Could not parse filter %s: %s\n", filter_exp, pcap_geterr(glob_pcap_handle));
+		rc = EXIT_FAILURE;
+		goto out;
+	}
+
+	if (-1 == pcap_setfilter(glob_pcap_handle, &comp_filter_exp))
+	{
+		fprintf(stderr, "Could not install filter %s: %s\n", filter_exp, pcap_geterr(glob_pcap_handle));
+		rc = EXIT_FAILURE;
+		goto out;
+	}
+
+#if DEBUG
+	fprintf(stdout,"Compiled and applied filter.\n");
+#endif /* DEBUG */
+
+	/** loop forever and call callback-function for every received packet */
+	pcap_loop(glob_pcap_handle, -1, pcap_callback, (u_char*)ctx);
+#endif /* PCAP */
+
+#if DIRECT_RX
+	if (0 != join_mcast(dev, ctx)) {
+		fprintf(stderr, "Could not join the mcast group\n");
+		rc = EXIT_FAILURE;
+		goto out;
+	}
+
+	if (0 != igb_start_rx(&igb_dev, ctx)) {
+		fprintf(stderr, "Could not start the igb device\n");
+		rc = EXIT_FAILURE;
+		goto out;
+	}
+
+	igb_process_rx(&igb_dev, ctx);
+
+#endif
+	rc = EXIT_SUCCESS;
+out:
+#if DIRECT_RX
+	igb_stop_rx(&igb_dev);
+	cleanup();
+#endif /* DIRECT_RX */
+
+	if (ctx)
+		free(ctx);
+	if (class_a)
+		free(class_a);
+	if (class_b)
+		free(class_b);
+	if (dev)
+		free(dev);
+	if (file_name)
+		free(file_name);
+#if LIBSND
+	if (sf_info)
+		free(sf_info);
+#endif /* LIBSND */
+
+	return rc;
+}
+

--- a/kmod/igb/igb.h
+++ b/kmod/igb/igb.h
@@ -1,7 +1,7 @@
 /*******************************************************************************
 
   Intel(R) Gigabit Ethernet Linux driver
-  Copyright(c) 2007-2015 Intel Corporation.
+  Copyright(c) 2007-2016 Intel Corporation.
 
   This program is free software; you can redistribute it and/or modify it
   under the terms and conditions of the GNU General Public License,
@@ -576,7 +576,8 @@ struct igb_adapter {
 	struct pci_dev *pdev;
 	/* user-dma specific variables */
 	struct igb_user_page	*userpages;
-	u32	uring_init;
+	u32	uring_tx_init;
+	u32	uring_rx_init;
 #ifndef HAVE_NETDEV_STATS_IN_NETDEV
 	struct net_device_stats net_stats;
 #endif
@@ -860,10 +861,14 @@ void igb_procfs_topdir_exit(void);
 #define IGB_BIND       _IOW('E', 200, int)
 #define IGB_UNBIND     _IOW('E', 201, int)
 #define IGB_MAPRING    _IOW('E', 202, int)
+#define IGB_MAP_TX_RING    IGB_MAPRING
 #define IGB_UNMAPRING  _IOW('E', 203, int)
+#define IGB_UNMAP_TX_RING  IGB_UNMAPRING
 #define IGB_MAPBUF     _IOW('E', 204, int)
 #define IGB_UNMAPBUF   _IOW('E', 205, int)
 #define IGB_LINKSPEED  _IOW('E', 206, int)
+#define IGB_MAP_RX_RING    _IOW('E', 207, int)
+#define IGB_UNMAP_RX_RING  _IOW('E', 208, int)
 
 #define IGB_BIND_NAMESZ	24
 

--- a/kmod/igb/igb_ptp.c
+++ b/kmod/igb/igb_ptp.c
@@ -34,6 +34,7 @@
 #include <linux/device.h>
 #include <linux/pci.h>
 #include <linux/ptp_classify.h>
+#include <linux/clocksource.h>
 
 #define INCVALUE_MASK		0x7fffffff
 #define ISGN			0x80000000

--- a/kmod/igb/kcompat.h
+++ b/kmod/igb/kcompat.h
@@ -1,7 +1,7 @@
 /*******************************************************************************
 
   Intel(R) Gigabit Ethernet Linux driver
-  Copyright(c) 2007-2015 Intel Corporation.
+  Copyright(c) 2007-2016 Intel Corporation.
 
   This program is free software; you can redistribute it and/or modify it
   under the terms and conditions of the GNU General Public License,

--- a/lib/igb/e1000_defines.h
+++ b/lib/igb/e1000_defines.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  Copyright (c) 2001-2012, Intel Corporation
+  Copyright (c) 2001-2016, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -60,6 +60,7 @@
 #define E1000_WUFC_ARP	0x00000020 /* ARP Request Packet Wakeup Enable */
 #define E1000_WUFC_IPV4	0x00000040 /* Directed IPv4 Packet Wakeup Enable */
 #define E1000_WUFC_IPV6	0x00000080 /* Directed IPv6 Packet Wakeup Enable */
+#define E1000_WUFC_FLEX_HQ	0x00004000 /* Flex Filters Host Queuing  (AVB) */
 #define E1000_WUFC_IGNORE_TCO	0x00008000 /* Ignore WakeOn TCO packets */
 #define E1000_WUFC_FLX0		0x00010000 /* Flexible Filter 0 Enable */
 #define E1000_WUFC_FLX1		0x00020000 /* Flexible Filter 1 Enable */

--- a/lib/igb/e1000_osdep.h
+++ b/lib/igb/e1000_osdep.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  Copyright (c) 2001-2012, Intel Corporation
+  Copyright (c) 2001-2016, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -39,13 +39,7 @@
 #undef FALSE
 #define TRUE true
 #define FALSE false
-#ifdef GCC_VERSION
-#if ( GCC_VERSION < 3000 )
 #define _Bool char
-#endif
-#else
-#define _Bool char
-#endif
 #ifndef bool
 #define bool _Bool
 #define true 1
@@ -77,10 +71,13 @@ typedef int8_t		s8;
 /* Register READ/WRITE macros */
 
 #define E1000_READ_REG(hw, reg) \
-    (*(volatile u32 *)(((hw)->hw_addr + reg)))
+	(*(u32 *)(((hw)->hw_addr + reg)))
 
 #define E1000_WRITE_REG(hw, reg, value) \
-    (*(volatile u32 *)(((hw)->hw_addr + reg)) = value)
+	(*(u32 *)(((hw)->hw_addr + reg)) = value)
+
+#define E1000_WRITE_REG_ARRAY(hw, reg, index, value) \
+	E1000_WRITE_REG((hw), (reg) + ((index) << 2), (value))
 
 #endif  /* _OSDEP_H_ */
 

--- a/lib/igb/igb.c
+++ b/lib/igb/igb.c
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  Copyright (c) 2001-2015, Intel Corporation
+  Copyright (c) 2001-2016, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -53,6 +53,8 @@
 #include "e1000_82575.h"
 #include "igb_internal.h"
 
+#undef DEBUG
+
 /*********************************************************************
  *  PCI Device ID Table
  *
@@ -63,19 +65,18 @@
  *  { Vendor ID, Device ID, SubVendor ID, SubDevice ID, String Index }
  *********************************************************************/
 
-static igb_vendor_info_t igb_vendor_info_array[] =
-{
-	{ 0x8086, E1000_DEV_ID_I210_COPPER,	PCI_ANY_ID, PCI_ANY_ID, 0},
+static igb_vendor_info_t igb_vendor_info_array[] = {
+	{ 0x8086, E1000_DEV_ID_I210_COPPER, PCI_ANY_ID, PCI_ANY_ID, 0},
 	{ 0x8086, E1000_DEV_ID_I210_COPPER_FLASHLESS,
-						PCI_ANY_ID, PCI_ANY_ID, 0},
-	{ 0x8086, E1000_DEV_ID_I210_COPPER_IT,	PCI_ANY_ID, PCI_ANY_ID, 0},
+		PCI_ANY_ID, PCI_ANY_ID, 0},
+	{ 0x8086, E1000_DEV_ID_I210_COPPER_IT, PCI_ANY_ID, PCI_ANY_ID, 0},
 	{ 0x8086, E1000_DEV_ID_I210_COPPER_OEM1,
-						PCI_ANY_ID, PCI_ANY_ID, 0},
-	{ 0x8086, E1000_DEV_ID_I210_FIBER,	PCI_ANY_ID, PCI_ANY_ID, 0},
-	{ 0x8086, E1000_DEV_ID_I210_SERDES,	PCI_ANY_ID, PCI_ANY_ID, 0},
+		PCI_ANY_ID, PCI_ANY_ID, 0},
+	{ 0x8086, E1000_DEV_ID_I210_FIBER, PCI_ANY_ID, PCI_ANY_ID, 0},
+	{ 0x8086, E1000_DEV_ID_I210_SERDES, PCI_ANY_ID, PCI_ANY_ID, 0},
 	{ 0x8086, E1000_DEV_ID_I210_SERDES_FLASHLESS,
-						PCI_ANY_ID, PCI_ANY_ID, 0},
-	{ 0x8086, E1000_DEV_ID_I210_SGMII,	PCI_ANY_ID, PCI_ANY_ID, 0},
+		PCI_ANY_ID, PCI_ANY_ID, 0},
+	{ 0x8086, E1000_DEV_ID_I210_SGMII, PCI_ANY_ID, PCI_ANY_ID, 0},
 	/* required last entry */
 	{ 0, 0, 0, 0, 0}
 };
@@ -83,80 +84,90 @@ static igb_vendor_info_t igb_vendor_info_array[] =
 /*********************************************************************
  *  Function prototypes
  *********************************************************************/
-static int	igb_read_mac_addr(struct e1000_hw *hw);
-static int	igb_allocate_pci_resources(struct adapter *adapter);
-static void	igb_free_pci_resources(struct adapter *adapter);
-static void	igb_reset(struct adapter *adapter);
-static int	igb_allocate_queues(struct adapter *adapter);
-static void	igb_setup_transmit_structures(struct adapter *adapter);
-static void	igb_setup_transmit_ring(struct tx_ring *txr);
-static void	igb_initialize_transmit_units(struct adapter *adapter);
-static void	igb_free_transmit_structures(struct adapter *adapter);
-static void	igb_tx_ctx_setup(struct tx_ring *txr, struct igb_packet *packet);
+static int igb_read_mac_addr(struct e1000_hw *hw);
+static int igb_allocate_pci_resources(struct adapter *adapter);
+static void igb_free_pci_resources(struct adapter *adapter);
+static void igb_reset(struct adapter *adapter);
+static int igb_allocate_queues(struct adapter *adapter);
+static int igb_allocate_rx_queues(struct adapter *adapter);
+static void igb_setup_transmit_structures(struct adapter *adapter);
+static void igb_setup_receive_structures(struct adapter *adapter);
+static void igb_setup_transmit_ring(struct tx_ring *txr);
+static void igb_initialize_transmit_units(struct adapter *adapter);
+static void igb_initialize_receive_units(struct adapter *adapter);
+static void igb_free_transmit_structures(struct adapter *adapter);
+static void igb_free_receive_structures(struct adapter *adapter);
+static void igb_tx_ctx_setup(struct tx_ring *txr, struct igb_packet *packet);
+static void igb_free_receive_buffers(struct rx_ring *rxr);
 
-int
-igb_probe( device_t *dev )
+int igb_probe(device_t *dev)
 {
 	igb_vendor_info_t *ent;
 
-	if (NULL == dev) return EINVAL;
+	if (dev == NULL)
+		return -EINVAL;
 
 	if (dev->pci_vendor_id != IGB_VENDOR_ID)
-		return (ENXIO);
+		return -ENXIO;
 
 	ent = igb_vendor_info_array;
 	while (ent->vendor_id != 0) {
 		if ((dev->pci_vendor_id == ent->vendor_id) &&
-		    (dev->pci_device_id == ent->device_id) ) {
+		    (dev->pci_device_id == ent->device_id)) {
 
-			return (0);
+			return 0;
 		}
 		ent++;
 	}
 
-	return (ENXIO);
+	return -ENXIO;
 }
 
 #define IGB_SEM "igb_sem"
 
-int
-igb_attach(char *dev_path, device_t *pdev)
+int igb_attach(char *dev_path, device_t *pdev)
 {
-	struct adapter	*adapter;
+	struct adapter *adapter;
 	struct igb_bind_cmd	bind;
-	int		error = 0;
+	int error = 0;
 
-	if (NULL == pdev) return EINVAL;
+	if (pdev == NULL)
+		return -EINVAL;
 
 	adapter = (struct adapter *)pdev->private_data;
 
-	if (NULL != adapter) return EBUSY;
+	if (adapter != NULL)
+		return -EBUSY;
 
 	/* allocate an adapter */
 	pdev->private_data = malloc(sizeof(struct adapter));
-	if (NULL == pdev->private_data) return ENXIO;
+	if (pdev->private_data == NULL)
+		return -ENXIO;
 
 	memset(pdev->private_data, 0, sizeof(struct adapter));
 
 	adapter = (struct adapter *)pdev->private_data;
 
 	adapter->ldev = open("/dev/igb_avb", O_RDWR);
+
 	if (adapter->ldev < 0) {
-		error = ENXIO;
+		error = -ENXIO;
 		goto err_prebind;
 	}
 
 	adapter->memlock =
-		sem_open( IGB_SEM, O_CREAT, S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP, 1 );
-	if( adapter->memlock == ((sem_t *)SEM_FAILED)) {
+		sem_open(IGB_SEM, O_CREAT, S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP, 1);
+
+	if (adapter->memlock == ((sem_t *)SEM_FAILED)) {
 		error = errno;
 		close(adapter->ldev);
 		goto err_prebind;
 	}
-	if( sem_wait( adapter->memlock ) != 0 ) {
+
+	if (sem_wait(adapter->memlock) != 0) {
 		error = errno;
 		close(adapter->ldev);
-		sem_close( adapter->memlock );
+		sem_close(adapter->memlock);
 		goto err_prebind;
 	}
 
@@ -167,7 +178,7 @@ igb_attach(char *dev_path, device_t *pdev)
 	strncpy(bind.iface, dev_path, IGB_BIND_NAMESZ - 1);
 
 	if (ioctl(adapter->ldev, IGB_BIND, &bind) < 0) {
-		error = ENXIO;
+		error = -ENXIO;
 		goto err_bind;
 	}
 
@@ -183,10 +194,11 @@ igb_attach(char *dev_path, device_t *pdev)
 
 	/* Set MAC type early for PCI setup */
 	adapter->hw.mac.type = e1000_i210;
+
 	/* Setup PCI resources */
-	if (error = igb_allocate_pci_resources(adapter)) {
+	error = igb_allocate_pci_resources(adapter);
+	if (error)
 		goto err_pci;
-	}
 
 	/*
 	 * Set the frame limits assuming
@@ -196,126 +208,164 @@ igb_attach(char *dev_path, device_t *pdev)
 	adapter->min_frame_size = 64;
 
 	/*
-	** Copy the permanent MAC address out of the EEPROM
-	*/
+	 * Copy the permanent MAC address out of the EEPROM
+	 */
 	if (igb_read_mac_addr(&adapter->hw) < 0) {
-		error = EIO;
+		error = -EIO;
 		goto err_late;
 	}
 
-	if( sem_post( adapter->memlock ) != 0 ) {
-		error = errno;
+	if (sem_post(adapter->memlock) != 0) {
+		error = -errno;
 		goto err_gen;
 	}
 
-	return (0);
+	return 0;
 
- err_late:
- err_pci:
+err_late:
+err_pci:
 	igb_free_pci_resources(adapter);
- err_bind:
-	sem_post( adapter->memlock );
-	sem_close( adapter->memlock );
+err_bind:
+	sem_post(adapter->memlock);
+	sem_close(adapter->memlock);
 	close(adapter->ldev);
- err_prebind:
+err_prebind:
 	free(pdev->private_data);
 	pdev->private_data = NULL;
 
- err_gen:
-	return (error);
+err_gen:
+	return error;
 }
 
-int
-igb_attach_tx( device_t *pdev )
+int igb_attach_tx(device_t *pdev)
 {
 	int error;
-	struct adapter	*adapter;
+	struct adapter *adapter;
 
-	if (NULL == pdev) return EINVAL;
+	if (pdev == NULL)
+		return -EINVAL;
 
 	adapter = (struct adapter *)pdev->private_data;
 
-	if (NULL == adapter) return EINVAL;
+	if (adapter == NULL)
+		return -EINVAL;
 
-	if( sem_wait( adapter->memlock ) != 0 ) {
-		return errno;
-	}
+	if (sem_wait(adapter->memlock) != 0)
+		return -errno;
 
-	/*
-	** Allocate and Setup Queues
-	*/
+	/* Allocate and Setup Queues */
 	adapter->num_queues = 2;  /* XXX parameterize this */
-	if (error = igb_allocate_queues(adapter)) {
+	error = igb_allocate_queues(adapter);
+	if (error) {
 		adapter->num_queues = 0;
 		goto release;
 	}
 
 	/*
-	** Start from a known state, which means
-	** reset the transmit queues we own to a known
-	** starting state.
-	*/
+	 * Start from a known state, which means
+	 * reset the transmit queues we own to a known
+	 * starting state.
+	 */
 	igb_reset(adapter);
 
- release:
-	if( sem_post( adapter->memlock ) != 0 ) {
-		return errno;
-	}
+release:
+	if (sem_post(adapter->memlock) != 0)
+		return -errno;
 
-	return (error);
+	return error;
 }
 
-int
-igb_detach(device_t *dev)
+int igb_attach_rx(device_t *pdev)
 {
-	struct adapter	*adapter;
+	int error;
+	struct adapter *adapter;
 
-	if (NULL == dev) return EINVAL;
-	adapter = (struct adapter *)dev->private_data;
-	if (NULL == adapter) return ENXIO;
+	if (pdev == NULL)
+		return -EINVAL;
 
-	if( sem_wait( adapter->memlock ) != 0 ) {
-		goto err_nolock;
+	adapter = (struct adapter *)pdev->private_data;
+
+	if (adapter == NULL)
+		return -EINVAL;
+
+	if (sem_wait(adapter->memlock) != 0)
+		return errno;
+
+	/*
+	 * Allocate and Setup Rx Queues
+	 */
+	adapter->num_queues = 2;  /* XXX parameterize this */
+	error = igb_allocate_rx_queues(adapter);
+	if (error) {
+		adapter->num_queues = 0;
+		goto release;
 	}
+
+release:
+	if (sem_post(adapter->memlock) != 0)
+		return errno;
+
+	return error;
+}
+
+int igb_detach(device_t *dev)
+{
+	struct adapter *adapter;
+
+	if (dev == NULL)
+		return -EINVAL;
+	adapter = (struct adapter *)dev->private_data;
+	if (adapter == NULL)
+		return -ENXIO;
+
+	if (sem_wait(adapter->memlock) != 0)
+		goto err_nolock;
 
 	igb_reset(adapter);
 
-	sem_post( adapter->memlock );
+	sem_post(adapter->memlock);
 
-	igb_free_transmit_structures(adapter);
 	igb_free_pci_resources(adapter);
 
- err_nolock:
-	sem_close( adapter->memlock );
+	if (adapter->tx_rings)
+		igb_free_transmit_structures(adapter);
 
-	close (adapter->ldev);
+	if (adapter->rx_rings)
+		igb_free_receive_structures(adapter);
+
+err_nolock:
+	sem_close(adapter->memlock);
+
+	close(adapter->ldev);
 
 	free(dev->private_data);
 	dev->private_data = NULL;
-	return (0);
+	return 0;
 }
 
-int
-igb_suspend(device_t *dev)
+int igb_suspend(device_t *dev)
 {
-	struct adapter	*adapter;
-	struct tx_ring	*txr;
+	struct adapter *adapter;
+	struct tx_ring *txr;
+	struct rx_ring *rxr;
 	struct e1000_hw *hw;
-	u32		txdctl;
-	int	i;
+	u32 txdctl, srrctl = 0;
+	int i;
 
-	if (NULL == dev) return EINVAL;
+	if (dev == NULL)
+		return -EINVAL;
 	adapter = (struct adapter *)dev->private_data;
-	if (NULL == adapter) return ENXIO;
+	if (adapter == NULL)
+		return -ENXIO;
 
 	txr = adapter->tx_rings;
+	rxr = adapter->rx_rings;
 	hw = &adapter->hw;
 
 	txdctl = 0;
 
-	if( sem_wait( adapter->memlock ) != 0 ) {
+	if (sem_wait(adapter->memlock) != 0)
 		return errno;
-	}
 
 	/* stop but don't reset the Tx Descriptor Rings */
 	for (i = 0; i < adapter->num_queues; i++, txr++) {
@@ -326,35 +376,60 @@ igb_suspend(device_t *dev)
 		txr->queue_status = IGB_QUEUE_IDLE;
 	}
 
-	if( sem_post( adapter->memlock ) != 0 ) {
-		return errno;
+	srrctl |= 2048 >> E1000_SRRCTL_BSIZEPKT_SHIFT;
+	srrctl |= E1000_SRRCTL_DESCTYPE_ADV_ONEBUF;
+
+	for (i = 0; i < adapter->num_queues; i++, rxr++) {
+		u64 bus_addr = rxr->rxdma.paddr;
+		u32 rxdctl;
+
+		E1000_WRITE_REG(hw, E1000_RDLEN(i),
+				adapter->num_rx_desc *
+				sizeof(union e1000_adv_rx_desc));
+		E1000_WRITE_REG(hw, E1000_RDBAH(i),
+				(uint32_t)(bus_addr >> 32));
+		E1000_WRITE_REG(hw, E1000_RDBAL(i),
+				(uint32_t)bus_addr);
+		E1000_WRITE_REG(hw, E1000_SRRCTL(i), srrctl);
+		/* Enable this Queue */
+		rxdctl = E1000_READ_REG(hw, E1000_RXDCTL(i));
+		rxdctl |= E1000_RXDCTL_QUEUE_ENABLE;
+		rxdctl &= 0xFFF00000;
+		rxdctl |= IGB_RX_PTHRESH;
+		rxdctl |= IGB_RX_HTHRESH << 8;
+		rxdctl |= IGB_RX_WTHRESH << 16;
+		E1000_WRITE_REG(hw, E1000_RXDCTL(i), rxdctl);
 	}
 
-	return (0);
+	if (sem_post(adapter->memlock) != 0)
+		return errno;
+
+	return 0;
 }
 
-int
-igb_resume(device_t *dev)
+int igb_resume(device_t *dev)
 {
-	struct adapter	*adapter;
-	struct tx_ring	*txr;
+	struct adapter *adapter;
+	struct tx_ring *txr;
+	struct rx_ring *rxr;
 	struct e1000_hw *hw;
-	u32		txdctl;
-	int	i;
-	int error;
+	u32 txdctl, srrctl = 0;
+	int i;
 
-	if (NULL == dev) return EINVAL;
+	if (dev == NULL)
+		return -EINVAL;
 	adapter = (struct adapter *)dev->private_data;
-	if (NULL == adapter) return ENXIO;
+	if (adapter == NULL)
+		return -ENXIO;
 
 	txr = adapter->tx_rings;
+	rxr = adapter->rx_rings;
 	hw = &adapter->hw;
 
 	txdctl = 0;
 
-	if( sem_wait( adapter->memlock ) != 0 ) {
+	if (sem_wait(adapter->memlock) != 0)
 		return errno;
-	}
 
 	/* resume but don't reset the Tx Descriptor Rings */
 	for (i = 0; i < adapter->num_queues; i++, txr++) {
@@ -368,80 +443,152 @@ igb_resume(device_t *dev)
 		txr->queue_status = IGB_QUEUE_WORKING;
 	}
 
-	if( sem_post( adapter->memlock ) != 0 ) {
-		return errno;
+	srrctl |= 2048 >> E1000_SRRCTL_BSIZEPKT_SHIFT;
+	srrctl |= E1000_SRRCTL_DESCTYPE_ADV_ONEBUF;
+
+	for (i = 0; i < adapter->num_queues; i++, rxr++) {
+		u64 bus_addr = rxr->rxdma.paddr;
+		u32 rxdctl;
+
+		E1000_WRITE_REG(hw, E1000_RDLEN(i),
+				adapter->num_rx_desc *
+				sizeof(union e1000_adv_rx_desc));
+		E1000_WRITE_REG(hw, E1000_RDBAH(i),
+				(uint32_t)(bus_addr >> 32));
+		E1000_WRITE_REG(hw, E1000_RDBAL(i),
+				(uint32_t)bus_addr);
+		E1000_WRITE_REG(hw, E1000_SRRCTL(i), srrctl);
+		/* Enable this Queue */
+		rxdctl = E1000_READ_REG(hw, E1000_RXDCTL(i));
+		rxdctl |= E1000_RXDCTL_QUEUE_ENABLE;
+		rxdctl &= 0xFFF00000;
+		rxdctl |= IGB_RX_PTHRESH;
+		rxdctl |= IGB_RX_HTHRESH << 8;
+		rxdctl |= IGB_RX_WTHRESH << 16;
+		E1000_WRITE_REG(hw, E1000_RXDCTL(i), rxdctl);
 	}
 
-	return (0);
+	if (sem_post(adapter->memlock) != 0)
+		return errno;
 
- err_lockfail:
-	return error;
+	return 0;
 }
 
-int
-igb_init(device_t *dev)
+int igb_init(device_t *dev)
 {
-	struct adapter	*adapter;
+	struct adapter *adapter;
 
-	if (NULL == dev) return EINVAL;
+	if (dev == NULL)
+		return -EINVAL;
 	adapter = (struct adapter *)dev->private_data;
-	if (NULL == adapter) return ENXIO;
+	if (adapter == NULL)
+		return -ENXIO;
 
-	if( sem_wait( adapter->memlock ) != 0 ) {
+	if (sem_wait(adapter->memlock) != 0)
 		return errno;
-	}
+
 	igb_reset(adapter);
 
 	/* Prepare transmit descriptors and buffers */
-	igb_setup_transmit_structures(adapter);
-	igb_initialize_transmit_units(adapter);
-
-	if( sem_post( adapter->memlock ) != 0 ) {
-		return errno;
+	if (adapter->tx_rings) {
+		igb_setup_transmit_structures(adapter);
+		igb_initialize_transmit_units(adapter);
 	}
 
-	return(0);
+	if (adapter->rx_rings) {
+		igb_setup_receive_structures(adapter);
+		igb_initialize_receive_units(adapter);
+	}
+
+	if (sem_post(adapter->memlock) != 0)
+		return errno;
+
+	return 0;
 }
 
 static void
 igb_reset(struct adapter *adapter)
 {
-	struct tx_ring	*txr = adapter->tx_rings;
+	struct tx_ring *txr = adapter->tx_rings;
+	struct rx_ring *rxr = adapter->rx_rings;
 	struct e1000_hw *hw = &adapter->hw;
-	u32		tctl, txdctl;
-	int 	i;
+	u32 txdctl, srrctl;
+	int i;
 
-	tctl = txdctl = 0;
+	srrctl = 0;
+	txdctl = 0;
 
-	/* Setup the Tx Descriptor Rings, leave queues idle */
-	for (i = 0; i < adapter->num_queues; i++, txr++) {
-		u64 bus_addr = txr->txdma.paddr;
+	/* Set up the Tx Descriptor Rings, leave queues idle */
+	if (adapter->tx_rings == NULL) {
+#if DEBUG
+		printf("txr null\n");
+#endif
+	} else {
+		for (i = 0; i < adapter->num_queues; i++, txr++) {
+			u64 bus_addr = txr->txdma.paddr;
 
-		/* idle the queue */
-		txdctl |= IGB_TX_PTHRESH;
-		txdctl |= IGB_TX_HTHRESH << 8;
-		txdctl |= IGB_TX_WTHRESH << 16;
-		E1000_WRITE_REG(hw, E1000_TXDCTL(i), txdctl);
+			/* idle the queue */
+			txdctl |= IGB_TX_PTHRESH;
+			txdctl |= IGB_TX_HTHRESH << 8;
+			txdctl |= IGB_TX_WTHRESH << 16;
+			E1000_WRITE_REG(hw, E1000_TXDCTL(i), txdctl);
 
-		/* reset the descriptor head/tail */
-		E1000_WRITE_REG(hw, E1000_TDLEN(i),
-		    adapter->num_tx_desc * sizeof(struct e1000_tx_desc));
-		E1000_WRITE_REG(hw, E1000_TDBAH(i),
-		    (u_int32_t)(bus_addr >> 32));
-		E1000_WRITE_REG(hw, E1000_TDBAL(i),
-		    (u_int32_t)bus_addr);
+			/* reset the descriptor head/tail */
+			E1000_WRITE_REG(hw, E1000_TDLEN(i),
+					adapter->num_tx_desc *
+					sizeof(struct e1000_tx_desc));
+			E1000_WRITE_REG(hw, E1000_TDBAH(i),
+					(u_int32_t)(bus_addr >> 32));
+			E1000_WRITE_REG(hw, E1000_TDBAL(i),
+					(u_int32_t)bus_addr);
 
-		/* Setup the HW Tx Head and Tail descriptor pointers */
-		E1000_WRITE_REG(hw, E1000_TDT(i), 0);
-		E1000_WRITE_REG(hw, E1000_TDH(i), 0);
+			/* Setup the HW Tx Head and Tail descriptor pointers */
+			E1000_WRITE_REG(hw, E1000_TDT(i), 0);
+			E1000_WRITE_REG(hw, E1000_TDH(i), 0);
 
-		txr->queue_status = IGB_QUEUE_IDLE;
+			txr->queue_status = IGB_QUEUE_IDLE;
+		}
 	}
 
+	srrctl |= 2048 >> E1000_SRRCTL_BSIZEPKT_SHIFT;
+	srrctl |= E1000_SRRCTL_DESCTYPE_ADV_ONEBUF;
+
+	/* Setup the Base and Length of the Rx Descriptor Rings */
+	if (adapter->rx_rings == NULL) {
+#if DEBUG
+		printf("rxr null\n");
+#endif
+	} else {
+
+		for (i = 0; i < adapter->num_queues; i++, rxr++) {
+			u64 bus_addr = rxr->rxdma.paddr;
+			u32 rxdctl;
+
+			/* Disable this Queue */
+			E1000_WRITE_REG(hw, E1000_RXDCTL(i), 0);
+
+			E1000_WRITE_REG(hw, E1000_RDLEN(i),
+					adapter->num_rx_desc *
+					sizeof(union e1000_adv_rx_desc));
+			E1000_WRITE_REG(hw, E1000_RDBAH(i),
+					(uint32_t)(bus_addr >> 32));
+			E1000_WRITE_REG(hw, E1000_RDBAL(i),
+					(uint32_t)bus_addr);
+			E1000_WRITE_REG(hw, E1000_SRRCTL(i), srrctl);
+
+			/* Enable this Queue */
+			rxdctl = E1000_READ_REG(hw, E1000_RXDCTL(i));
+			rxdctl |= E1000_RXDCTL_QUEUE_ENABLE;
+			rxdctl &= 0xFFF00000;
+			rxdctl |= IGB_RX_PTHRESH;
+			rxdctl |= IGB_RX_HTHRESH << 8;
+			rxdctl |= IGB_RX_WTHRESH << 16;
+			E1000_WRITE_REG(hw, E1000_RXDCTL(i), rxdctl);
+		}
+	}
 }
 
-static int
-igb_read_mac_addr(struct e1000_hw *hw)
+static int igb_read_mac_addr(struct e1000_hw *hw)
 {
 	u32 rar_high;
 	u32 rar_low;
@@ -459,110 +606,110 @@ igb_read_mac_addr(struct e1000_hw *hw)
 	for (i = 0; i < ETH_ADDR_LEN; i++)
 		hw->mac.addr[i] = hw->mac.perm_addr[i];
 
-	return E1000_SUCCESS;
+	return 0;
 
 }
 
-static int
-igb_allocate_pci_resources(struct adapter *adapter)
+static int igb_allocate_pci_resources(struct adapter *adapter)
 {
-	int		dev = adapter->ldev;
+	int dev = adapter->ldev;
 
-	adapter->hw.hw_addr = (u8 *)mmap(NULL, \
-		adapter->csr.mmap_size, \
-		PROT_READ | PROT_WRITE, \
-		MAP_SHARED, \
-		dev,
-		0);
+	adapter->hw.hw_addr = (u8 *)mmap(NULL, adapter->csr.mmap_size,
+					 PROT_READ | PROT_WRITE, MAP_SHARED,
+					 dev, 0);
 
-	if (MAP_FAILED == adapter->hw.hw_addr)
-		return (ENXIO);
+	if (adapter->hw.hw_addr == MAP_FAILED)
+		return -ENXIO;
 
-	return (0);
+	return 0;
 }
 
-static void
-igb_free_pci_resources(struct adapter *adapter)
+static void igb_free_pci_resources(struct adapter *adapter)
 {
-	munmap( adapter->hw.hw_addr, adapter->csr.mmap_size);
-
-	return ;
+	munmap(adapter->hw.hw_addr, adapter->csr.mmap_size);
 }
 
 /*
  * Manage DMA'able memory.
  */
-int
-igb_dma_malloc_page(device_t *dev, struct igb_dma_alloc *dma)
+int igb_dma_malloc_page(device_t *dev, struct igb_dma_alloc *dma)
 {
-	struct adapter	*adapter;
+	struct adapter *adapter;
 	int error = 0;
-	struct igb_buf_cmd      ubuf;
+	struct igb_buf_cmd ubuf;
 
-	if (NULL == dev) return EINVAL;
-	if (NULL == dma) return EINVAL;
+	if (dev == NULL)
+		return -EINVAL;
+	if (dma == NULL)
+		return -EINVAL;
+
 	adapter = (struct adapter *)dev->private_data;
-	if (NULL == adapter) return ENXIO;
+	if (adapter == NULL)
+		return -ENXIO;
 
-	if( sem_wait( adapter->memlock ) != 0 ) {
+	if (sem_wait(adapter->memlock) != 0) {
 		error = errno;
 		goto err;
 	}
 	error = ioctl(adapter->ldev, IGB_MAPBUF, &ubuf);
-	if( sem_post( adapter->memlock ) != 0 ) {
+	if (sem_post(adapter->memlock) != 0) {
 		error = errno;
 		goto err;
 	}
 
-	if (error < 0) { error = ENOMEM; goto err; }
+	if (error < 0) {
+		error = -ENOMEM;
+		goto err;
+	}
 
 	dma->dma_paddr = ubuf.physaddr;
 	dma->mmap_size = ubuf.mmap_size;
-	dma->dma_vaddr = (void *)mmap(NULL, \
-		ubuf.mmap_size, \
-		PROT_READ | PROT_WRITE, \
-		MAP_SHARED, \
-		adapter->ldev, \
-		ubuf.physaddr);
+	dma->dma_vaddr = (void *)mmap(NULL,
+				      ubuf.mmap_size,
+				      PROT_READ | PROT_WRITE,
+				      MAP_SHARED,
+				      adapter->ldev,
+				      ubuf.physaddr);
 
-	if (MAP_FAILED == dma->dma_vaddr)
-		error = ENOMEM;
+	if (dma->dma_vaddr == MAP_FAILED)
+		error = -ENOMEM;
 err:
-	return (error);
+	return error;
 }
 
-void
-igb_dma_free_page(device_t *dev, struct igb_dma_alloc *dma)
+void igb_dma_free_page(device_t *dev, struct igb_dma_alloc *dma)
 {
-	struct adapter	*adapter;
+	struct adapter *adapter;
 	struct igb_buf_cmd      ubuf;
 
-	if (NULL == dev) return;
-	if (NULL == dma) return;
-	adapter = (struct adapter *)dev->private_data;
-	if (NULL == adapter) return;
+	if (dev == NULL)
+		return;
+	if (dma == NULL)
+		return;
 
-	munmap( dma->dma_vaddr,
+	adapter = (struct adapter *)dev->private_data;
+	if (adapter == NULL)
+		return;
+
+	munmap(dma->dma_vaddr,
 		dma->mmap_size);
 
 	ubuf.physaddr = dma->dma_paddr;
 
-	if( sem_wait( adapter->memlock ) != 0 ) {
+	if (sem_wait(adapter->memlock) != 0)
 		goto err;
-	}
+
 	ioctl(adapter->ldev, IGB_UNMAPBUF, &ubuf);
-	if( sem_post( adapter->memlock ) != 0 ) {
+	if (sem_post(adapter->memlock) != 0)
 		goto err;
-	}
 
 	dma->dma_paddr = 0;
 	dma->dma_vaddr = NULL;
 	dma->mmap_size = 0;
 
- err:
+err:
 	return;
 }
-
 
 /*********************************************************************
  *
@@ -570,22 +717,23 @@ igb_dma_free_page(device_t *dev, struct igb_dma_alloc *dma)
  *  the descriptors associated with each, called only once at attach.
  *
  **********************************************************************/
-static int
-igb_allocate_queues(struct adapter *adapter)
+static int igb_allocate_queues(struct adapter *adapter)
 {
-	int 			dev = adapter->ldev;
-	struct igb_buf_cmd	ubuf;
-	int 			i, error = E1000_SUCCESS;
+	struct igb_buf_cmd ubuf;
+	int dev = adapter->ldev;
+	int i, error = 0;
 
 	/* allocate the TX ring struct memory */
-	adapter->tx_rings = (struct tx_ring *) malloc(sizeof(struct tx_ring) \
-		* adapter->num_queues);
-	if (NULL == adapter->tx_rings) {
-		error = ENOMEM;
+	adapter->tx_rings = (struct tx_ring *) malloc(sizeof(struct tx_ring) *
+						      adapter->num_queues);
+
+	if (adapter->tx_rings == NULL) {
+		error = -ENOMEM;
 		goto tx_fail;
 	}
 
-	memset(adapter->tx_rings, 0, sizeof(struct tx_ring) * adapter->num_queues);
+	memset(adapter->tx_rings, 0, sizeof(struct tx_ring) *
+					    adapter->num_queues);
 
 	for (i = 0; i < adapter->num_queues; i++) {
 		ubuf.queue = i;
@@ -597,66 +745,65 @@ igb_allocate_queues(struct adapter *adapter)
 		adapter->tx_rings[i].txdma.paddr = ubuf.physaddr;
 		adapter->tx_rings[i].txdma.mmap_size = ubuf.mmap_size;
 		adapter->tx_rings[i].tx_base = NULL;
-		adapter->tx_rings[i].tx_base = (struct e1000_tx_desc *)mmap(NULL, \
-				ubuf.mmap_size, \
-				PROT_READ | PROT_WRITE, \
-				MAP_SHARED, \
-				adapter->ldev, \
-				ubuf.physaddr);
+		adapter->tx_rings[i].tx_base =
+			(struct e1000_tx_desc *)mmap(NULL, ubuf.mmap_size,
+						     PROT_READ | PROT_WRITE,
+						     MAP_SHARED, adapter->ldev,
+						     ubuf.physaddr);
 
-		if (MAP_FAILED == adapter->tx_rings[i].tx_base) {
-			error = ENOMEM;
+		if (adapter->tx_rings[i].tx_base == MAP_FAILED) {
+			error = -ENOMEM;
 			goto tx_desc;
 		}
+
 		adapter->tx_rings[i].adapter = adapter;
 		adapter->tx_rings[i].me = i;
 		/* XXX Initialize a TX lock ?? */
-		adapter->num_tx_desc = ubuf.mmap_size / sizeof(union e1000_adv_tx_desc);
+		adapter->num_tx_desc = ubuf.mmap_size /
+				       sizeof(union e1000_adv_tx_desc);
 
 		memset((void *)adapter->tx_rings[i].tx_base, 0, ubuf.mmap_size);
-		adapter->tx_rings[i].tx_buffers = (struct igb_tx_buffer *) malloc(sizeof(struct igb_tx_buffer) * \
-			 adapter->num_tx_desc);
+		adapter->tx_rings[i].tx_buffers =
+			(struct igb_tx_buffer *)
+				malloc(sizeof(struct igb_tx_buffer) *
+				       adapter->num_tx_desc);
 
-		if (NULL == adapter->tx_rings[i].tx_buffers) {
-			error = ENOMEM;
+		if (adapter->tx_rings[i].tx_buffers == NULL) {
+			error = -ENOMEM;
 			goto tx_desc;
 		}
 
-		memset(adapter->tx_rings[i].tx_buffers, 0, sizeof(struct igb_tx_buffer) * adapter->num_tx_desc);
+		memset(adapter->tx_rings[i].tx_buffers, 0,
+		       sizeof(struct igb_tx_buffer) * adapter->num_tx_desc);
 	}
 
-	return (0);
+	return 0;
 
 tx_desc:
 	for (i = 0; i < adapter->num_queues; i++) {
 		if (adapter->tx_rings[i].tx_base)
-			munmap(adapter->tx_rings[i].tx_base, \
-				adapter->tx_rings[i].txdma.mmap_size);
+			munmap(adapter->tx_rings[i].tx_base,
+			       adapter->tx_rings[i].txdma.mmap_size);
 		ubuf.queue = i;
 		ioctl(dev, IGB_UNMAPRING, &ubuf);
 	};
 tx_fail:
 	free(adapter->tx_rings);
 	adapter->tx_rings = NULL;
-	return (error);
+	return error;
 }
 
-/*********************************************************************
- *
- *  Initialize a transmit ring.
- *
- **********************************************************************/
-static void
-igb_setup_transmit_ring(struct tx_ring *txr)
+/* Initialize a transmit ring. */
+static void igb_setup_transmit_ring(struct tx_ring *txr)
 {
 	struct adapter *adapter = txr->adapter;
 
 	/* Clear the old descriptor contents */
-	memset((void *)txr->tx_base, \
-		0, \
-	      (sizeof(union e1000_adv_tx_desc)) * adapter->num_tx_desc);
+	memset((void *)txr->tx_base,  0,
+	       (sizeof(union e1000_adv_tx_desc)) * adapter->num_tx_desc);
 
-	memset(txr->tx_buffers, 0, sizeof(struct igb_tx_buffer) * txr->adapter->num_tx_desc);
+	memset(txr->tx_buffers, 0, sizeof(struct igb_tx_buffer) *
+				   txr->adapter->num_tx_desc);
 
 	/* Reset indices */
 	txr->next_avail_desc = 0;
@@ -664,39 +811,27 @@ igb_setup_transmit_ring(struct tx_ring *txr)
 
 	/* Set number of descriptors available */
 	txr->tx_avail = adapter->num_tx_desc;
-
 }
 
-/*********************************************************************
- *
- *  Initialize all transmit rings.
- *
- **********************************************************************/
-static void
-igb_setup_transmit_structures(struct adapter *adapter)
+/*  Initialize all transmit rings. */
+static void igb_setup_transmit_structures(struct adapter *adapter)
 {
 	struct tx_ring *txr = adapter->tx_rings;
 	int i;
 
 	for (i = 0; i < adapter->num_queues; i++, txr++)
 		igb_setup_transmit_ring(txr);
-
-	return;
 }
 
-/*********************************************************************
- *
- *  Enable transmit unit.
- *
- **********************************************************************/
-static void
-igb_initialize_transmit_units(struct adapter *adapter)
+/*Enable transmit unit. */
+static void igb_initialize_transmit_units(struct adapter *adapter)
 {
-	struct tx_ring	*txr = adapter->tx_rings;
+	struct tx_ring *txr = adapter->tx_rings;
 	struct e1000_hw *hw = &adapter->hw;
-	u32		tctl, txdctl;
-	int	i;
-	tctl = txdctl = 0;
+	u32 txdctl;
+	int i;
+
+	txdctl = 0;
 
 	/* Setup the Tx Descriptor Rings */
 	for (i = 0; i < adapter->num_queues; i++, txr++) {
@@ -719,47 +854,34 @@ igb_initialize_transmit_units(struct adapter *adapter)
 
 }
 
-/*********************************************************************
- *
- *  Free all transmit rings.
- *
- **********************************************************************/
-static void
-igb_free_transmit_structures(struct adapter *adapter)
+/* Free all transmit rings. */
+static void igb_free_transmit_structures(struct adapter *adapter)
 {
 	int i;
-	struct igb_buf_cmd	ubuf;
+	struct igb_buf_cmd ubuf;
 
 	for (i = 0; i < adapter->num_queues; i++) {
 		if (adapter->tx_rings[i].tx_base)
-			munmap(adapter->tx_rings[i].tx_base,				\
-				   adapter->tx_rings[i].txdma.mmap_size);
+			munmap(adapter->tx_rings[i].tx_base,
+			       adapter->tx_rings[i].txdma.mmap_size);
 		ubuf.queue = i;
 		ioctl(adapter->ldev, IGB_UNMAPRING, &ubuf);
 		free(adapter->tx_rings[i].tx_buffers);
 	}
 
-
 	free(adapter->tx_rings);
 	adapter->tx_rings = NULL;
 }
 
-
-/*********************************************************************
- *
- *  Context Descriptor setup for VLAN or CSUM
- *
- **********************************************************************/
-
-static void
-igb_tx_ctx_setup(struct tx_ring *txr, struct igb_packet *packet)
+/* Context Descriptor setup for VLAN or CSUM */
+static void igb_tx_ctx_setup(struct tx_ring *txr, struct igb_packet *packet)
 {
 	struct adapter *adapter = txr->adapter;
 	struct e1000_adv_tx_context_desc *TXD;
-	struct igb_tx_buffer	*tx_buffer;
+	struct igb_tx_buffer *tx_buffer;
 	u32 type_tucmd_mlhl;
-	int  ctxd;
-	u_int64_t	remapped_time;
+	int ctxd;
+	u_int64_t remapped_time;
 
 	ctxd = txr->next_avail_desc;
 	tx_buffer = &txr->tx_buffers[ctxd];
@@ -773,7 +895,8 @@ igb_tx_ctx_setup(struct tx_ring *txr, struct igb_packet *packet)
 	TXD->mss_l4len_idx = 0;
 
 	/* remap the 64-bit nsec time to the value represented in the desc */
-	remapped_time = packet->attime - ((packet->attime / 1000000000)*1000000000);
+	remapped_time = packet->attime - ((packet->attime / 1000000000) *
+					  1000000000);
 
 	remapped_time /= 32; /* scale to 32 nsec increments */
 
@@ -788,8 +911,6 @@ igb_tx_ctx_setup(struct tx_ring *txr, struct igb_packet *packet)
 		ctxd = 0;
 	txr->next_avail_desc = ctxd;
 	--txr->tx_avail;
-
-	return;
 }
 
 
@@ -804,34 +925,35 @@ igb_tx_ctx_setup(struct tx_ring *txr, struct igb_packet *packet)
  *  been previously mapped with the provided dma_malloc_page routines.
  *
  **********************************************************************/
-
-int
-igb_xmit(device_t *dev, unsigned int queue_index, struct igb_packet *packet)
+int igb_xmit(device_t *dev, unsigned int queue_index, struct igb_packet *packet)
 {
-	struct adapter		*adapter;
-	struct tx_ring	  *txr;
-	struct igb_tx_buffer	*tx_buffer;
-	union e1000_adv_tx_desc	*txd = NULL;
-	u32			cmd_type_len, olinfo_status = 0;
-	int			i, first, last = 0;
+	struct adapter *adapter;
+	struct tx_ring *txr;
+	struct igb_tx_buffer *tx_buffer;
+	union e1000_adv_tx_desc *txd = NULL;
+	u32 cmd_type_len, olinfo_status = 0;
+	int i, first, last = 0;
 	int error = 0;
 
-	if (NULL == dev) return EINVAL;
+	if (dev == NULL)
+		return -EINVAL;
+
 	adapter = (struct adapter *)dev->private_data;
-	if (NULL == adapter) return ENXIO;
+	if (adapter == NULL)
+		return -ENXIO;
 
 	txr = &adapter->tx_rings[queue_index];
-	if( !txr ) return EINVAL;
+	if (!txr)
+		return -EINVAL;
 
 	if (queue_index > adapter->num_queues)
-		return EINVAL;
+		return -EINVAL;
 
-	if (NULL == packet)
-		return EINVAL;
+	if (packet == NULL)
+		return -EINVAL;
 
-	if( sem_wait( adapter->memlock ) != 0 ) {
+	if (sem_wait(adapter->memlock) != 0)
 		return errno;
-	}
 
 	packet->next = NULL; /* used for cleanup */
 
@@ -853,11 +975,11 @@ igb_xmit(device_t *dev, unsigned int queue_index, struct igb_packet *packet)
 	tx_buffer = &txr->tx_buffers[first];
 
 	/*
-	** Make sure we don't overrun the ring,
-	** we need nsegs descriptors and one for
-	** the context descriptor used for the
-	** offloads.
-	*/
+	 * Make sure we don't overrun the ring,
+	 * we need nsegs descriptors and one for
+	 * the context descriptor used for the
+	 * offloads.
+	 */
 	if (txr->tx_avail <= 2) {
 		error = ENOSPC;
 		goto unlock;
@@ -895,9 +1017,8 @@ igb_xmit(device_t *dev, unsigned int queue_index, struct igb_packet *packet)
 	tx_buffer->next_eop = -1;
 
 	txr->next_avail_desc = i;
-	txr->tx_avail-- ;
+	txr->tx_avail--;
 	tx_buffer->packet = packet;
-
 
 	/*
 	 * Last Descriptor of Packet
@@ -923,80 +1044,89 @@ igb_xmit(device_t *dev, unsigned int queue_index, struct igb_packet *packet)
 	++txr->tx_packets;
 
 unlock:
-	if( sem_post( adapter->memlock ) != 0 ) {
+	if (sem_post(adapter->memlock) != 0)
 		return errno;
-	}
 
-	return(error);
+	return error;
 }
 
-void
-igb_trigger(device_t *dev, u_int32_t data)
+void igb_trigger(device_t *dev, u_int32_t data)
 {
-	struct adapter	*adapter;
+	struct adapter *adapter;
 
-	if (NULL == dev) return;
+	if (dev == NULL)
+		return;
+
 	adapter = (struct adapter *)dev->private_data;
-	if (NULL == adapter) return;
+	if (adapter == NULL)
+		return;
 
-	if( sem_wait( adapter->memlock ) != 0 ) {
-		goto err;
-	}
+	if (sem_wait(adapter->memlock) != 0)
+		return;
+
 	E1000_WRITE_REG(&(adapter->hw), E1000_WUS, data);
-	if( sem_post( adapter->memlock ) != 0 ) {
-		goto err;
-	}
-
- err:
-	return;
+	if (sem_post(adapter->memlock) != 0)
+		return;
 }
 
-void
-igb_writereg(device_t *dev, u_int32_t reg, u_int32_t data)
+void igb_writereg(device_t *dev, u_int32_t reg, u_int32_t data)
 {
-	struct adapter	*adapter;
+	struct adapter *adapter;
 
-	if (NULL == dev) return;
+	if (dev == NULL)
+		return;
+
 	adapter = (struct adapter *)dev->private_data;
-	if (NULL == adapter) return;
+	if (adapter == NULL)
+		return;
 
 	E1000_WRITE_REG(&(adapter->hw), reg, data);
 }
 
-void
-igb_readreg(device_t *dev, u_int32_t reg, u_int32_t *data)
+void igb_readreg(device_t *dev, u_int32_t reg, u_int32_t *data)
 {
-	struct adapter	*adapter;
+	struct adapter *adapter;
 
-	if (NULL == dev) return;
+	if (dev == NULL)
+		return;
+
 	adapter = (struct adapter *)dev->private_data;
-	if (NULL == adapter) return;
+	if (adapter == NULL)
+		return;
 
-	if (NULL == data) return;
+	if (data == NULL)
+		return;
 
 	*data = E1000_READ_REG(&(adapter->hw), reg);
 }
 
-int igb_lock( device_t *dev ) {
-	struct adapter	*adapter;
+int igb_lock(device_t *dev)
+{
+	struct adapter *adapter;
 
-	if (NULL == dev) return ENODEV;
+	if (dev == NULL)
+		return -ENODEV;
+
 	adapter = (struct adapter *)dev->private_data;
-	if (NULL == adapter) return ENXIO;
+	if (adapter == NULL)
+		return -ENXIO;
 
-	return sem_wait( adapter->memlock );
+	return sem_wait(adapter->memlock);
 }
 
-int igb_unlock( device_t *dev ) {
-	struct adapter	*adapter;
+int igb_unlock(device_t *dev)
+{
+	struct adapter *adapter;
 
-	if (NULL == dev) return ENODEV;
+	if (dev == NULL)
+		return -ENODEV;
+
 	adapter = (struct adapter *)dev->private_data;
-	if (NULL == adapter) return ENXIO;
+	if (adapter == NULL)
+		return -ENXIO;
 
-	return sem_post( adapter->memlock );
+	return sem_post(adapter->memlock);
 }
-
 
 /**********************************************************************
  *
@@ -1004,28 +1134,29 @@ int igb_unlock( device_t *dev ) {
  *  processing the packet then return the linked list of associated resources.
  *
  **********************************************************************/
-void
-igb_clean(device_t *dev, struct igb_packet **cleaned_packets)
+void igb_clean(device_t *dev, struct igb_packet **cleaned_packets)
 {
-	struct adapter	*adapter;
-	struct tx_ring	  *txr;
-	int first, last, done, processed;
-	struct igb_tx_buffer *tx_buffer;
-	struct e1000_tx_desc   *tx_desc, *eop_desc;
+	struct e1000_tx_desc *tx_desc, *eop_desc;
 	struct igb_packet *last_reclaimed;
-	int i;
+	struct igb_tx_buffer *tx_buffer;
+	struct adapter *adapter;
+	struct tx_ring *txr;
+	int first, last, done, processed, i;
 
-	if (NULL == dev) return;
+	if (dev == NULL)
+		return;
+
 	adapter = (struct adapter *)dev->private_data;
-	if (NULL == adapter) return;
+	if (adapter == NULL)
+		return;
 
-	if (NULL == cleaned_packets) return;
+	if (cleaned_packets == NULL)
+		return;
 
 	*cleaned_packets = NULL; /* nothing reclaimed yet */
 
-	if( sem_wait( adapter->memlock ) != 0 ) {
+	if (sem_wait(adapter->memlock) != 0)
 		return;
-	}
 
 	for (i = 0; i < adapter->num_queues; i++) {
 		txr = &adapter->tx_rings[i];
@@ -1049,21 +1180,31 @@ igb_clean(device_t *dev, struct igb_packet **cleaned_packets)
 		 * simple comparison on the inner while loop.
 		 */
 		if (++last == adapter->num_tx_desc)
-	 		last = 0;
+			last = 0;
 		done = last;
 
 		while (eop_desc->upper.fields.status & E1000_TXD_STAT_DD) {
+			if (tx_buffer->packet)
+				last_reclaimed = tx_buffer->packet;
+
 			/* We clean the range of the packet */
 			while (first != done) {
 				if (tx_buffer->packet) {
-					tx_buffer->packet->dmatime = (0xffffffff) & tx_desc->buffer_addr;
-					/* tx_buffer->packet->dmatime += (tx_desc->buffer_addr >> 32) * 1000000000; */
-					txr->bytes +=
-					    tx_buffer->packet->len;
-					if (*cleaned_packets == NULL)
-						*cleaned_packets = tx_buffer->packet;
-					else
-						last_reclaimed->next = tx_buffer->packet;
+					tx_buffer->packet->dmatime =
+						(0xffffffff) &
+						 tx_desc->buffer_addr;
+					/* tx_buffer->packet->dmatime +=
+					 *	(tx_desc->buffer_addr >> 32) *
+					 *	 1000000000;
+					 */
+					txr->bytes += tx_buffer->packet->len;
+					if (*cleaned_packets == NULL) {
+						*cleaned_packets =
+							tx_buffer->packet;
+					} else {
+						last_reclaimed->next =
+							tx_buffer->packet;
+					}
 					last_reclaimed = tx_buffer->packet;
 
 					tx_buffer->packet = NULL;
@@ -1074,7 +1215,6 @@ igb_clean(device_t *dev, struct igb_packet **cleaned_packets)
 				tx_desc->buffer_addr = 0;
 				++txr->tx_avail;
 				++processed;
-
 
 				if (++first == adapter->num_tx_desc)
 					first = 0;
@@ -1087,7 +1227,9 @@ igb_clean(device_t *dev, struct igb_packet **cleaned_packets)
 			last = tx_buffer->next_eop;
 			if (last != -1) {
 				eop_desc = &txr->tx_base[last];
-				/* Get new done point */ if (++last == adapter->num_tx_desc) last = 0;
+				/* Get new done point */
+				if (++last == adapter->num_tx_desc)
+					last = 0;
 				done = last;
 			} else
 				break;
@@ -1098,99 +1240,582 @@ igb_clean(device_t *dev, struct igb_packet **cleaned_packets)
 		if (txr->tx_avail >= IGB_QUEUE_THRESHOLD)
 			txr->queue_status &= ~IGB_QUEUE_DEPLETED;
 	}
+	sem_post(adapter->memlock);
+}
 
-unlock:
-	if( sem_post( adapter->memlock ) != 0 ) {
-		return;
+/*********************************************************************
+ *
+ *  Allocate memory for the receive rings, and then
+ *  the descriptors associated with each, called only once at attach.
+ *
+ **********************************************************************/
+static int igb_allocate_rx_queues(struct adapter *adapter)
+{
+	struct igb_buf_cmd ubuf;
+	int dev = adapter->ldev;
+	int i, error = 0;
+
+	/* allocate the RX ring struct memory */
+	adapter->rx_rings = (struct rx_ring *) malloc(sizeof(struct rx_ring) *
+						      adapter->num_queues);
+
+	if (adapter->rx_rings == NULL) {
+		error = -ENOMEM;
+		goto rx_fail;
 	}
 
-	return;
+	memset(adapter->rx_rings, 0, sizeof(struct rx_ring) *
+					    adapter->num_queues);
+
+	for (i = 0; i < adapter->num_queues; i++) {
+
+		if (sem_init(&adapter->rx_rings[i].lock, 0, 1) != 0) {
+			error = errno;
+			goto rx_desc;
+		}
+
+		if (sem_wait(&adapter->rx_rings[i].lock) != 0) {
+			error = errno;
+			goto rx_desc;
+		}
+
+		ubuf.queue = i;
+		error = ioctl(dev, IGB_MAP_RX_RING, &ubuf);
+		if (error < 0) {
+			error = EBUSY;
+			goto rx_desc;
+		}
+		adapter->rx_rings[i].rxdma.paddr = ubuf.physaddr;
+		adapter->rx_rings[i].rxdma.mmap_size = ubuf.mmap_size;
+		adapter->rx_rings[i].rx_base = NULL;
+		adapter->rx_rings[i].rx_base =
+			mmap(NULL, ubuf.mmap_size, PROT_READ | PROT_WRITE,
+			     MAP_SHARED, adapter->ldev, ubuf.physaddr);
+
+		if (adapter->rx_rings[i].rx_base == MAP_FAILED) {
+			error = -ENOMEM;
+			goto rx_desc;
+		}
+
+		adapter->rx_rings[i].adapter = adapter;
+		adapter->rx_rings[i].me = i;
+
+		adapter->num_rx_desc = ubuf.mmap_size /
+				       sizeof(union e1000_adv_rx_desc);
+
+		memset((void *)adapter->rx_rings[i].rx_base, 0, ubuf.mmap_size);
+		adapter->rx_rings[i].rx_buffers =
+			(struct igb_rx_buffer *)
+				malloc(sizeof(struct igb_rx_buffer) *
+				       adapter->num_rx_desc);
+
+		if (adapter->rx_rings[i].rx_buffers == NULL) {
+			error = -ENOMEM;
+			goto rx_desc;
+		}
+
+		memset(adapter->rx_rings[i].rx_buffers, 0,
+		       sizeof(struct igb_rx_buffer) * adapter->num_rx_desc);
+
+		if (sem_post(&adapter->rx_rings[i].lock) != 0) {
+			error = errno;
+			goto rx_desc;
+		}
+	}
+
+	return 0;
+
+rx_desc:
+	for (i = 0; i < adapter->num_queues; i++) {
+		if (adapter->rx_rings[i].rx_base)
+			munmap(adapter->rx_rings[i].rx_base,
+			       adapter->rx_rings[i].rxdma.mmap_size);
+		ubuf.queue = i;
+		ioctl(dev, IGB_UNMAP_RX_RING, &ubuf);
+
+		sem_destroy(&adapter->rx_rings[i].lock);
+	};
+rx_fail:
+	free(adapter->rx_rings);
+	adapter->rx_rings = NULL;
+	return error;
+}
+
+static void igb_free_receive_ring(struct rx_ring *rxr)
+{
+	struct adapter *adapter = rxr->adapter;
+	struct igb_rx_buffer *rxbuf;
+	int i;
+
+	for (i = 0; i < adapter->num_rx_desc; i++) {
+		rxbuf = &rxr->rx_buffers[i];
+		rxbuf->next_eop = 0;
+		rxbuf->packet = NULL;
+	}
+}
+
+/* Initialize a receive ring. */
+static void igb_setup_receive_ring(struct rx_ring *rxr)
+{
+	struct adapter *adapter = rxr->adapter;
+
+	(void)sem_wait(&rxr->lock);
+
+	/* Clear the ring contents */
+	memset((void *)rxr->rx_base,  0,
+	       (sizeof(union e1000_adv_rx_desc)) * adapter->num_rx_desc);
+
+	memset(rxr->rx_buffers, 0, sizeof(struct igb_rx_buffer) *
+				   rxr->adapter->num_rx_desc);
+
+	/* Free current RX buffer structures */
+	igb_free_receive_ring(rxr);
+
+	/* Setup our descriptor indices */
+	rxr->next_to_check = 0;
+	rxr->next_to_refresh = 0;
+	rxr->rx_split_packets = 0;
+	rxr->rx_bytes = 0;
+
+	(void)sem_post(&rxr->lock);
+}
+
+/* Initialize all receive rings. */
+static void igb_setup_receive_structures(struct adapter *adapter)
+{
+	struct rx_ring *rxr = adapter->rx_rings;
+	int i;
+
+	for (i = 0; i < adapter->num_queues; i++, rxr++)
+		igb_setup_receive_ring(rxr);
+}
+
+/* Enable receive unit. */
+static void igb_initialize_receive_units(struct adapter *adapter)
+{
+	struct rx_ring *rxr = adapter->rx_rings;
+	struct e1000_hw *hw = &adapter->hw;
+	u32 rctl, rxcsum, srrctl = 0;
+	int i;
+
+	/*
+	 * Make sure receives are disabled while setting
+	 * up the descriptor ring
+	 */
+	rctl = E1000_READ_REG(hw, E1000_RCTL);
+	E1000_WRITE_REG(hw, E1000_RCTL, rctl & ~E1000_RCTL_EN);
+
+	rctl &= ~E1000_RCTL_LPE;
+	srrctl |= 2048 >> E1000_SRRCTL_BSIZEPKT_SHIFT;
+	srrctl |= E1000_SRRCTL_DESCTYPE_ADV_ONEBUF;
+	rctl |= E1000_RCTL_SZ_2048;
+
+	/* Setup the Base and Length of the Rx Descriptor Rings */
+	for (i = 0; i < adapter->num_queues; i++, rxr++) {
+		u64 bus_addr = rxr->rxdma.paddr;
+		u32 rxdctl;
+
+		/* Disable this Queue */
+		E1000_WRITE_REG(hw, E1000_RXDCTL(i), 0);
+
+		E1000_WRITE_REG(hw, E1000_RDLEN(i),
+				adapter->num_rx_desc *
+					sizeof(union e1000_adv_rx_desc));
+		E1000_WRITE_REG(hw, E1000_RDBAH(i),
+				(uint32_t)(bus_addr >> 32));
+		E1000_WRITE_REG(hw, E1000_RDBAL(i),
+				(uint32_t)bus_addr);
+		E1000_WRITE_REG(hw, E1000_SRRCTL(i), srrctl);
+
+		/* Enable this Queue */
+		rxdctl = E1000_READ_REG(hw, E1000_RXDCTL(i));
+		rxdctl |= E1000_RXDCTL_QUEUE_ENABLE;
+		rxdctl &= 0xFFF00000;
+		rxdctl |= IGB_RX_PTHRESH;
+		rxdctl |= IGB_RX_HTHRESH << 8;
+		rxdctl |= IGB_RX_WTHRESH << 16;
+		E1000_WRITE_REG(hw, E1000_RXDCTL(i), rxdctl);
+	}
+
+	/*
+	 * Setup for RX MultiQueue
+	 * Non RSS setup
+	 */
+	rxcsum = E1000_READ_REG(hw, E1000_RXCSUM);
+	rxcsum |= E1000_RXCSUM_IPPCSE;
+	/*	rxcsum &= ~E1000_RXCSUM_TUOFL; */
+	E1000_WRITE_REG(hw, E1000_RXCSUM, rxcsum);
+
+	/* Setup the Receive Control Register */
+	rctl &= ~(3 << E1000_RCTL_MO_SHIFT);
+	rctl |= E1000_RCTL_EN | E1000_RCTL_BAM | E1000_RCTL_LBM_NO |
+		E1000_RCTL_RDMTS_HALF;
+	/* Strip CRC bytes. */
+	rctl |= E1000_RCTL_SECRC;
+	/* Make sure VLAN Filters are off */
+	rctl &= ~E1000_RCTL_VFE;
+	/* Don't store bad packets */
+	rctl &= ~E1000_RCTL_SBP;
+
+	/* Enable Receives */
+	E1000_WRITE_REG(hw, E1000_RCTL, rctl);
+
+	/*
+	 * Setup the HW Rx Head and Tail Descriptor Pointers
+	 *   - needs to be after enable
+	 */
+	for (i = 0; i < adapter->num_queues; i++) {
+		rxr = &adapter->rx_rings[i];
+		E1000_WRITE_REG(hw, E1000_RDH(i), rxr->next_to_check);
+		E1000_WRITE_REG(hw, E1000_RDT(i), rxr->next_to_refresh);
+	}
+}
+
+/* Free all receive rings. */
+static void igb_free_receive_structures(struct adapter *adapter)
+{
+	struct rx_ring *rxr = adapter->rx_rings;
+	int i;
+	struct igb_buf_cmd ubuf;
+
+	for (i = 0; i < adapter->num_queues; i++, rxr++) {
+		(void)sem_wait(&adapter->rx_rings[i].lock);
+
+		if (rxr->rx_base) {
+			memset(rxr->rx_base, 0, rxr->rxdma.mmap_size);
+			munmap(rxr->rx_base, rxr->rxdma.mmap_size);
+		}
+		ubuf.queue = i;
+		ioctl(adapter->ldev, IGB_UNMAP_RX_RING, &ubuf);
+		igb_free_receive_buffers(rxr);
+
+		(void)sem_destroy(&adapter->rx_rings[i].lock);
+	}
+
+	free(adapter->rx_rings);
+	adapter->rx_rings = NULL;
+}
+
+
+/* Free receive ring data structures. */
+static void igb_free_receive_buffers(struct rx_ring *rxr)
+{
+	struct adapter *adapter = rxr->adapter;
+	struct igb_rx_buffer *rxbuf;
+	int i;
+
+	/* Cleanup any existing buffers */
+	if (rxr->rx_buffers != NULL) {
+		for (i = 0; i < adapter->num_rx_desc; i++) {
+			rxbuf = &rxr->rx_buffers[i];
+			rxbuf->next_eop = 0;
+			rxbuf->packet = NULL;
+		}
+		if (rxr->rx_buffers != NULL) {
+			free(rxr->rx_buffers);
+			rxr->rx_buffers = NULL;
+		}
+	}
+}
+
+/*
+ *  Refresh mbuf buffers for RX descriptor rings
+ *   - now keeps its own state so discards due to resource
+ *     exhaustion are unnecessary, if an mbuf cannot be obtained
+ *     it just returns, keeping its placeholder, thus it can simply
+ *     be recalled to try again.
+ *
+ */
+int igb_refresh_buffers(device_t *dev, u_int32_t idx,
+			 struct igb_packet **rxbuf_packets, u_int32_t num_bufs)
+{
+	struct igb_packet *cur_pkt;
+	struct adapter *adapter;
+	struct rx_ring *rxr;
+	u_int32_t i, j, bufs_used;
+	bool refreshed = FALSE;
+
+	if (dev == NULL)
+		return -EINVAL;
+
+	adapter = (struct adapter *)dev->private_data;
+	if (adapter == NULL)
+		return -EINVAL;
+
+	if (rxbuf_packets == NULL)
+		return -EINVAL;
+
+	if (idx > 1)
+		return -EINVAL;
+
+	rxr = &adapter->rx_rings[idx];
+	if (rxr == NULL)
+		return -EINVAL;
+
+	if (sem_trywait(&rxr->lock) != 0)
+		return errno; /* EAGAIN */
+
+	i = j = rxr->next_to_refresh;
+	cur_pkt = *rxbuf_packets;
+
+	/*
+	 * Get one descriptor beyond
+	 * our work mark to control
+	 * the loop.
+	 */
+	if (++j == adapter->num_rx_desc)
+		j = 0;
+
+	bufs_used = 0;
+
+	while (bufs_used < num_bufs) {
+		if (!cur_pkt)
+			break;
+		rxr->rx_base[i].read.pkt_addr =
+			htole64(cur_pkt->map.paddr + cur_pkt->offset);
+		rxr->rx_buffers[i].packet = cur_pkt;
+
+		refreshed = TRUE; /* I feel wefreshed :) */
+
+		i = j; /* our next is precalculated */
+		rxr->next_to_refresh = i;
+		if (++j == adapter->num_rx_desc)
+			j = 0;
+		bufs_used++;
+		cur_pkt = cur_pkt->next;
+	}
+
+	if (refreshed) /* update tail */
+		E1000_WRITE_REG(&adapter->hw,
+				E1000_RDT(rxr->me), rxr->next_to_refresh);
+
+	if (sem_post(&rxr->lock) != 0)
+		return errno;
+
+	return 0;
+}
+
+
+/**********************************************************************
+ *
+ *  Examine each rx_buffer in the used queue. If the hardware is done
+ *  processing the packet then return the linked list of associated resources.
+ *
+ **********************************************************************/
+int igb_receive(device_t *dev, unsigned int queue_index, 
+					struct igb_packet **received_packets, u_int32_t *count)
+{
+	struct adapter *adapter;
+	struct rx_ring *rxr;
+	union e1000_adv_rx_desc *cur;
+	bool eop = FALSE;
+	u_int32_t staterr = 0;
+	u_int32_t desc    = 0;
+	u_int32_t max_pkt = 0;
+	struct igb_packet *curr_pkt = NULL;
+	struct igb_packet *prev_pkt = NULL;
+
+	if (dev == NULL)
+		return -EINVAL;
+
+	adapter = (struct adapter *)dev->private_data;
+	if (adapter == NULL)
+		return -ENXIO;
+
+	if (queue_index > adapter->num_queues)
+		return -EINVAL;
+
+	rxr = &(adapter->rx_rings[queue_index]);
+	if (!rxr)
+		return -EINVAL;
+
+	if (count == NULL)
+		return -EINVAL;
+
+	max_pkt = *count;
+	*count  = 0;
+
+	if (received_packets == NULL)
+		return -EINVAL;
+
+	*received_packets = NULL; /* nothing reclaimed yet */
+
+	if (sem_trywait(&rxr->lock) != 0)
+		return errno; /* EAGAIN */
+
+	/* Main clean loop - receive packets until no more
+	 * received_packets[]
+	 */
+	for (desc = rxr->next_to_check; *count < max_pkt;) {
+		cur = &(rxr->rx_base[desc]);
+#ifdef DEBUG
+		if (i%2)
+			printf("\033[2A");
+
+		printf("desc.status_error=%x desc.length=%x desc.vlan=%x desc.rss=%x desc.pkt_info=%x desc.hdr_info=%x\n", 
+				cur->wb.upper.status_error, 
+				cur->wb.upper.length, 
+				cur->wb.upper.vlan, 
+				cur->wb.lower.hi_dword.rss,
+				cur->wb.lower.lo_dword.hs_rss.pkt_info,
+				cur->wb.lower.lo_dword.hs_rss.hdr_info);
+#endif
+		staterr = le32toh(cur->wb.upper.status_error);
+		if ((staterr & E1000_RXD_STAT_DD) == 0)
+			break;
+
+		cur->wb.upper.status_error = 0;
+
+		eop = ((staterr & E1000_RXD_STAT_EOP) ==
+				E1000_RXD_STAT_EOP);
+
+		if (eop) {
+			/*
+			 * Free the frame (all segments) if we're at EOP and
+			 * it's an error.
+			 *
+			 * The datasheet states that EOP + status is only valid
+			 * for the final segment in a multi-segment frame.
+			 */
+			if (staterr & E1000_RXDEXT_ERR_FRAME_ERR_MASK) {
+				++rxr->rx_discarded;
+				printf ("discard error packet\n");
+				igb_refresh_buffers(dev, queue_index,
+						&rxr->rx_buffers[desc].packet, 1);
+			} else {
+				/*
+				 * add new packet to list of received packets
+				 * to return
+				 */
+				curr_pkt = rxr->rx_buffers[desc].packet;
+				curr_pkt->len = cur->wb.upper.length;
+
+				if (*received_packets == NULL)
+					*received_packets = curr_pkt;
+				if (prev_pkt)
+					prev_pkt->next = curr_pkt;
+				prev_pkt = curr_pkt;
+				(*count)++;
+
+				++rxr->rx_packets;
+			}
+		} else {
+			/* multi-segment frame is not supported yet */
+			++rxr->rx_discarded;
+			printf ("discard non-eop packet\n");
+			igb_refresh_buffers(dev, queue_index,
+					&rxr->rx_buffers[desc].packet, 1);
+		}
+next_desc:
+		/* Advance our pointers to the next descriptor. */
+		if (++desc == adapter->num_rx_desc)
+			desc = 0;
+	}
+
+	rxr->next_to_check = desc;
+
+	if (sem_post(&rxr->lock) != 0)
+		return errno;
+
+	if (*received_packets == NULL) {
+		/* nothing reclaimed yet */
+		errno = EAGAIN;
+		return errno;
+	}
+
+	return 0;
 }
 
 #define MAX_ITER 32
 #define MIN_WALLCLOCK_TSC_WINDOW 80 /* cycles */
 #define MIN_SYSCLOCK_WINDOW 72 /* ns */
 
-static inline void rdtscpll( uint64_t *val ) {
+static inline void rdtscpll(uint64_t *val)
+{
 	uint32_t high, low;
-	__asm__ __volatile__( "lfence;"
+
+	__asm__ __volatile__("lfence;"
 						  "rdtsc;"
 						  : "=d"(high), "=a"(low)
 						  :
-						  : "memory" );
+						  : "memory");
 	*val = high;
 	*val = (*val << 32) | low;
 }
 
-static inline void __sync() {
-	__asm__ __volatile__( "mfence;"
+static inline void __sync(void)
+{
+	__asm__ __volatile__("mfence;"
 						  :
 						  :
-						  : "memory" );
+						  : "memory");
 }
 
-int
-igb_get_wallclock(device_t *dev, u_int64_t	*curtime, u_int64_t *rdtsc)
+int igb_get_wallclock(device_t *dev, u_int64_t *curtime, u_int64_t *rdtsc)
 {
-	u_int64_t	t0 = 0, t1 = -1;
-	u_int32_t   duration = -1;
-	u_int32_t	timh, timl, tsauxc;
-	struct adapter	*adapter;
+	u_int64_t t0 = 0, t1 = -1;
+	u_int32_t duration = -1;
+	u_int32_t timh, timl, tsauxc;
+	struct adapter *adapter;
 	struct e1000_hw *hw;
-	int iter = 0;
 	int error = 0;
+	int iter = 0;
 
-	if (NULL == dev) return EINVAL;
+	if (dev == NULL)
+		return -EINVAL;
+
 	adapter = (struct adapter *)dev->private_data;
-	if (NULL == adapter) return ENXIO;
+	if (adapter == NULL)
+		return -ENXIO;
 
 	hw = &adapter->hw;
 
-	if( sem_wait( adapter->memlock ) != 0 ) {
+	if (sem_wait(adapter->memlock) != 0)
 		return errno;
-	}
 
 	/* sample the timestamp bracketed by the RDTSC */
-	for
-		( iter = 0; iter < MAX_ITER && t1 - t0 > MIN_WALLCLOCK_TSC_WINDOW;
-		  ++iter )
-		{
-			tsauxc = E1000_READ_REG(hw, E1000_TSAUXC);
-			tsauxc |= E1000_TSAUXC_SAMP_AUTO;
-			// Invalidate AUXSTMPH/L0
-			E1000_READ_REG(hw, E1000_AUXSTMPH0);
-			rdtscpll(&t0);
-			E1000_WRITE_REG(hw, E1000_TSAUXC, tsauxc );
-			rdtscpll(&t1);
+	for (iter = 0; iter < MAX_ITER && t1 - t0 > MIN_WALLCLOCK_TSC_WINDOW;
+	     ++iter) {
+		tsauxc = E1000_READ_REG(hw, E1000_TSAUXC);
+		tsauxc |= E1000_TSAUXC_SAMP_AUTO;
 
-			if( t1 - t0 < duration ) {
-				duration = t1 - t0;
-				timl = E1000_READ_REG(hw, E1000_AUXSTMPL0);
-				timh = E1000_READ_REG(hw, E1000_AUXSTMPH0);
+		/* Invalidate AUXSTMPH/L0 */
+		E1000_READ_REG(hw, E1000_AUXSTMPH0);
+		rdtscpll(&t0);
+		E1000_WRITE_REG(hw, E1000_TSAUXC, tsauxc);
+		rdtscpll(&t1);
 
-				if( curtime )
-					*curtime = (u_int64_t)timh * 1000000000 + (u_int64_t)timl;
-				if( rdtsc )
-					*rdtsc = (t1 - t0) / 2 + t0; /* average */
-			}
+		if (t1 - t0 < duration) {
+			duration = t1 - t0;
+			timl = E1000_READ_REG(hw, E1000_AUXSTMPL0);
+			timh = E1000_READ_REG(hw, E1000_AUXSTMPH0);
+
+			if (curtime)
+				*curtime = (u_int64_t)timh * 1000000000 +
+					   (u_int64_t)timl;
+			if (rdtsc)
+				/* average */
+				*rdtsc = (t1 - t0) / 2 + t0;
 		}
+	}
 
-	if( sem_post( adapter->memlock ) != 0 ) {
+	if (sem_post(adapter->memlock) != 0) {
 		error = errno;
 		goto err;
 	}
 
-	return -duration;  // Return the window size * -1
+	/* Return the window size * -1 */
+	return -duration;
 
- err:
+err:
 	return error;
 }
 
-struct timespec timespec_subtract( struct timespec *a, struct timespec *b )
+struct timespec timespec_subtract(struct timespec *a, struct timespec *b)
 {
 	a->tv_nsec = a->tv_nsec - b->tv_nsec;
 	if (a->tv_nsec < 0) {
-		// borrow.
+		/* borrow */
 		a->tv_nsec += 1000000000;
 		--a->tv_sec;
 	}
@@ -1199,11 +1824,11 @@ struct timespec timespec_subtract( struct timespec *a, struct timespec *b )
 	return *a;
 }
 
-struct timespec timespec_addns( struct timespec *a, unsigned long addns )
+struct timespec timespec_addns(struct timespec *a, unsigned long addns)
 {
 	a->tv_nsec = a->tv_nsec + (addns % 1000000000);
-	if (a->tv_nsec > 1000000000 ) {
-		// carry
+	if (a->tv_nsec > 1000000000) {
+		/* carry */
 		a->tv_nsec -= 1000000000;
 		++a->tv_sec;
 	}
@@ -1214,90 +1839,90 @@ struct timespec timespec_addns( struct timespec *a, unsigned long addns )
 
 #define TS2NS(ts) (((ts).tv_sec*1000000000)+(ts).tv_nsec)
 
-int
-igb_gettime(device_t *dev, clockid_t clk_id, u_int64_t *curtime,
-			struct timespec *system_time )
+int igb_gettime(device_t *dev, clockid_t clk_id, u_int64_t *curtime,
+		struct timespec *system_time)
 {
 	struct timespec	t0 = { 0, 0 }, t1 = { .tv_sec = 4, .tv_nsec = 0 };
-	u_int32_t   duration = -1;
-	u_int32_t	timh, timl, tsauxc;
-	struct adapter	*adapter;
+	u_int32_t timh, timl, tsauxc;
+	u_int32_t duration = -1;
+	struct adapter *adapter;
 	struct e1000_hw *hw;
-	int iter = 0;
 	int error = 0;
+	int iter = 0;
 
-	if (NULL == dev) return EINVAL;
+	if (dev == NULL)
+		return -EINVAL;
 	adapter = (struct adapter *)dev->private_data;
-	if (NULL == adapter) return ENXIO;
+	if (adapter == NULL)
+		return -ENXIO;
 
 	hw = &adapter->hw;
 
-	if( sem_wait( adapter->memlock ) != 0 ) {
+	if (sem_wait(adapter->memlock) != 0)
 		return errno;
-	}
 
 	/* sample the timestamp bracketed by the clock_gettime() */
-	for
-		( iter = 0; iter < MAX_ITER && duration > MIN_SYSCLOCK_WINDOW; ++iter )
-		{
-			u_int32_t duration_c;
-			tsauxc = E1000_READ_REG(hw, E1000_TSAUXC);
-			tsauxc |= E1000_TSAUXC_SAMP_AUTO;
-			// Invalidate AUXSTMPH/L0
-			E1000_READ_REG( hw, E1000_AUXSTMPH0 );
-			clock_gettime( clk_id, &t0 );
-			E1000_WRITE_REG( hw, E1000_TSAUXC, tsauxc );
-			__sync();
-			clock_gettime( clk_id, &t1 );
+	for (iter = 0; iter < MAX_ITER && duration > MIN_SYSCLOCK_WINDOW;
+	     ++iter) {
+		u_int32_t duration_c;
 
-			timespec_subtract(&t1,&t0);
-			duration_c = TS2NS(t1);
-			if( duration_c < duration ) {
-				duration = duration_c;
-				timl = E1000_READ_REG(hw, E1000_AUXSTMPL0);
-				timh = E1000_READ_REG(hw, E1000_AUXSTMPH0);
+		tsauxc = E1000_READ_REG(hw, E1000_TSAUXC);
+		tsauxc |= E1000_TSAUXC_SAMP_AUTO;
 
-				if( curtime )
-					*curtime = (u_int64_t)timh * 1000000000 + (u_int64_t)timl;
-				if( system_time )
-					*system_time = timespec_addns
-						(&t0,duration/2);
-			}
+		/* Invalidate AUXSTMPH/L0 */
+		E1000_READ_REG(hw, E1000_AUXSTMPH0);
+		clock_gettime(clk_id, &t0);
+		E1000_WRITE_REG(hw, E1000_TSAUXC, tsauxc);
+		__sync();
+		clock_gettime(clk_id, &t1);
+
+		timespec_subtract(&t1, &t0);
+		duration_c = TS2NS(t1);
+		if (duration_c < duration) {
+			duration = duration_c;
+			timl = E1000_READ_REG(hw, E1000_AUXSTMPL0);
+			timh = E1000_READ_REG(hw, E1000_AUXSTMPH0);
+
+			if (curtime)
+				*curtime = (u_int64_t)timh * 1000000000 +
+					   (u_int64_t)timl;
+			if (system_time)
+				*system_time =
+					timespec_addns(&t0, duration/2);
 		}
+	}
 
-	if( sem_post( adapter->memlock ) != 0 ) {
+	if (sem_post(adapter->memlock) != 0) {
 		error = errno;
 		goto err;
 	}
+	/* Return the window size * -1 */
+	return -duration;
 
-	return -duration;  // Return the window size * -1
-
- err:
+err:
 	return error;
 }
 
-int
-igb_set_class_bandwidth(device_t *dev,
-	u_int32_t class_a,
-	u_int32_t class_b,
-	u_int32_t tpktsz_a,
-	u_int32_t tpktsz_b)
+int igb_set_class_bandwidth(device_t *dev, u_int32_t class_a, u_int32_t class_b,
+			    u_int32_t tpktsz_a, u_int32_t tpktsz_b)
 {
-	u_int32_t	tqavctrl;
-	u_int32_t	tqavcc0, tqavcc1;
-	u_int32_t	tqavhc0, tqavhc1;
-	u_int32_t	class_a_idle, class_b_idle;
-	u_int32_t	linkrate;
-	struct adapter	*adapter;
+	u_int32_t tqavctrl;
+	u_int32_t tqavcc0, tqavcc1;
+	u_int32_t tqavhc0, tqavhc1;
+	u_int32_t class_a_idle, class_b_idle;
+	u_int32_t linkrate;
+	struct adapter *adapter;
 	struct e1000_hw *hw;
-	struct igb_link_cmd	link;
-	int	err;
-	float		class_a_percent, class_b_percent;
+	struct igb_link_cmd link;
+	int err;
+	float class_a_percent, class_b_percent;
 	int error = 0;
 
-	if (NULL == dev) return EINVAL;
+	if (dev == NULL)
+		return -EINVAL;
 	adapter = (struct adapter *)dev->private_data;
-	if (NULL == adapter) return ENXIO;
+	if (adapter == NULL)
+		return -ENXIO;
 
 	hw = &adapter->hw;
 
@@ -1305,33 +1930,36 @@ igb_set_class_bandwidth(device_t *dev,
 
 	err = ioctl(adapter->ldev, IGB_LINKSPEED, &link);
 
-	if (err) return ENXIO;
+	if (err)
+		return -ENXIO;
 
-	if (0 == link.up) return EINVAL;
+	if (link.up == 0)
+		return -EINVAL;
 
-	if (link.speed < 100) return EINVAL;
+	if (link.speed < 100)
+		return -EINVAL;
 
-	if (link.duplex != FULL_DUPLEX ) return EINVAL;
+	if (link.duplex != FULL_DUPLEX)
+		return -EINVAL;
 
 	if (tpktsz_a < 64)
 		tpktsz_a = 64; /* minimum ethernet frame size */
 
 	if (tpktsz_a > 1500)
-		return EINVAL;
+		return -EINVAL;
 
 	if (tpktsz_b < 64)
 		tpktsz_b = 64; /* minimum ethernet frame size */
 
 	if (tpktsz_b > 1500)
-		return EINVAL;
+		return -EINVAL;
 
-	if( sem_wait( adapter->memlock ) != 0 ) {
+	if (sem_wait(adapter->memlock) != 0)
 		return errno;
-	}
 
 	tqavctrl = E1000_READ_REG(hw, E1000_TQAVCTRL);
 
-	if ((class_a + class_b) == 0 ) {
+	if ((class_a + class_b) == 0) {
 		/* disable the Qav shaper */
 		tqavctrl &= ~E1000_TQAVCTRL_TX_ARB;
 		E1000_WRITE_REG(hw, E1000_TQAVCTRL, tqavctrl);
@@ -1354,50 +1982,62 @@ igb_set_class_bandwidth(device_t *dev,
 	 * (tpktsz + (media overhead)) * rate -> percentage of media rate.
 	 */
 
-	/* 12=Ethernet IPG, 8=Preamble+Start of Frame, 18=Mac Header with VLAN+Etype, 4=CRC */
-	class_a_percent = (float)((tpktsz_a + (12 + 8 + 18 + 4)) * class_a) ;
-	class_b_percent = (float)((tpktsz_b + (12 + 8 + 18 + 4)) * class_b) ;
+	/* 12=Ethernet IPG,
+	 * 8=Preamble+Start of Frame,
+	 * 18=Mac Header with VLAN+Etype,
+	 * 4=CRC
+	 */
+	class_a_percent = (float)((tpktsz_a + (12 + 8 + 18 + 4)) * class_a);
+	class_b_percent = (float)((tpktsz_b + (12 + 8 + 18 + 4)) * class_b);
 
 	class_a_percent /= 0.000125; /* class A observation window */
 	class_b_percent /= 0.000250; /* class B observation window */
 
 	if (link.speed == 100) {
-		class_a_percent /= (100000000.0 / 8); /* bytes-per-sec @ 100Mbps */
+		/* bytes-per-sec @ 100Mbps */
+		class_a_percent /= (100000000.0 / 8);
 		class_b_percent /= (100000000.0 / 8);
-		class_a_idle = (u_int32_t)(class_a_percent * 0.2 * (float)linkrate + 0.5);
-		class_b_idle = (u_int32_t)(class_b_percent * 0.2 * (float)linkrate + 0.5);
+		class_a_idle = (u_int32_t)(class_a_percent * 0.2 *
+				(float)linkrate + 0.5);
+		class_b_idle = (u_int32_t)(class_b_percent * 0.2 *
+				(float)linkrate + 0.5);
 	} else {
-		class_a_percent /= (1000000000.0 / 8); /* bytes-per-sec @ 1Gbps */
+		/* bytes-per-sec @ 1Gbps */
+		class_a_percent /= (1000000000.0 / 8);
 		class_b_percent /= (1000000000.0 / 8);
-		class_a_idle = (u_int32_t)(class_a_percent * 2.0 * (float)linkrate + 0.5);
-		class_b_idle = (u_int32_t)(class_b_percent * 2.0 * (float)linkrate + 0.5);
+		class_a_idle = (u_int32_t)(class_a_percent *
+				2.0 * (float)linkrate + 0.5);
+		class_b_idle = (u_int32_t)(class_b_percent * 2.0 *
+				(float)linkrate + 0.5);
 	}
 
 	if ((class_a_percent + class_b_percent) > 0.75) {
-		error = EINVAL;
+		error = -EINVAL;
 		goto unlock;
 	}
 	tqavcc0 |= class_a_idle;
 	tqavcc1 |= class_b_idle;
 
 	/*
-	 * hiCredit is the number of idleslope credits accumulated due to delay T
+	 * hiCredit is the number of idleslope credits accumulated due to delay
 	 *
 	 * we assume the maxInterferenceSize is 18 + 4 + 1500 (1522).
 	 * Note: if EEE is enabled, we should use for maxInterferenceSize
 	 * the overhead of link recovery (a media-specific quantity).
 	 */
-	tqavhc0 = 0x80000000 + (class_a_idle * 1522 / linkrate ); /* L.10 */
+	tqavhc0 = 0x80000000 + (class_a_idle * 1522 / linkrate); /* L.10 */
 
 	/*
 	 * Class B high credit is is the same, except the delay
-	 * is the MaxBurstSize of Class A + maxInterferenceSize of non-SR traffic
+	 * is the MaxBurstSize of Class A + maxInterferenceSize of non-SR
+	 * traffic
 	 *
 	 * L.41
 	 * max Class B delay = (1522 + tpktsz_a) / (linkrate - class_a_idle)
 	 */
 
-	tqavhc1 = 0x80000000 + (class_b_idle * ((1522 + tpktsz_a)/ (linkrate - class_a_idle)));
+	tqavhc1 = 0x80000000 + (class_b_idle * ((1522 + tpktsz_a) /
+						(linkrate - class_a_idle)));
 
 	/* implicitly enable the Qav shaper */
 	tqavctrl |= E1000_TQAVCTRL_TX_ARB;
@@ -1407,36 +2047,36 @@ igb_set_class_bandwidth(device_t *dev,
 	E1000_WRITE_REG(hw, E1000_TQAVCC(1), tqavcc1);
 	E1000_WRITE_REG(hw, E1000_TQAVCTRL, tqavctrl);
 
- unlock:
-	if( sem_post( adapter->memlock ) != 0 ) {
+unlock:
+	if (sem_post(adapter->memlock) != 0)
 		error = errno;
-	}
 
 	return error;
 }
 
-int
-igb_set_class_bandwidth2(device_t *dev,
-	u_int32_t class_a_bytes_per_second,
-	u_int32_t class_b_bytes_per_second)
+int igb_set_class_bandwidth2(device_t *dev, u_int32_t class_a_bytes_per_second,
+			     u_int32_t class_b_bytes_per_second)
 {
-	u_int32_t	tqavctrl;
-	u_int32_t	tqavcc0, tqavcc1;
-	u_int32_t	tqavhc0, tqavhc1;
-	u_int32_t	class_a_idle, class_b_idle;
-	u_int32_t	linkrate;
-	u_int32_t	tpktsz_a;
-	int	temp;
-	struct adapter	*adapter;
+	u_int32_t tqavctrl;
+	u_int32_t tqavcc0, tqavcc1;
+	u_int32_t tqavhc0, tqavhc1;
+	u_int32_t class_a_idle, class_b_idle;
+	u_int32_t linkrate;
+	u_int32_t tpktsz_a;
+	int temp;
+	struct adapter *adapter;
 	struct e1000_hw *hw;
-	struct igb_link_cmd	link;
-	int	err;
-	float		class_a_percent, class_b_percent;
+	struct igb_link_cmd link;
+	int err;
+	float class_a_percent, class_b_percent;
 	int error = 0;
 
-	if (NULL == dev) return EINVAL;
+	if (dev == NULL)
+		return -EINVAL;
+
 	adapter = (struct adapter *)dev->private_data;
-	if (NULL == adapter) return ENXIO;
+	if (adapter == NULL)
+		return -ENXIO;
 
 	hw = &adapter->hw;
 
@@ -1444,21 +2084,24 @@ igb_set_class_bandwidth2(device_t *dev,
 
 	err = ioctl(adapter->ldev, IGB_LINKSPEED, &link);
 
-	if (err) return ENXIO;
+	if (err)
+		return -ENXIO;
 
-	if (0 == link.up) return EINVAL;
+	if (link.up == 0)
+		return -EINVAL;
 
-	if (link.speed < 100) return EINVAL;
+	if (link.speed < 100)
+		return -EINVAL;
 
-	if (link.duplex != FULL_DUPLEX ) return EINVAL;
+	if (link.duplex != FULL_DUPLEX)
+		return -EINVAL;
 
-	if( sem_wait( adapter->memlock ) != 0 ) {
+	if (sem_wait(adapter->memlock) != 0)
 		return errno;
-	}
 
 	tqavctrl = E1000_READ_REG(hw, E1000_TQAVCTRL);
 
-	if ((class_a_bytes_per_second + class_b_bytes_per_second) == 0 ) {
+	if ((class_a_bytes_per_second + class_b_bytes_per_second) == 0) {
 		/* disable the Qav shaper */
 		tqavctrl &= ~E1000_TQAVCTRL_TX_ARB;
 		E1000_WRITE_REG(hw, E1000_TQAVCTRL, tqavctrl);
@@ -1470,60 +2113,69 @@ igb_set_class_bandwidth2(device_t *dev,
 
 	linkrate = E1000_TQAVCC_LINKRATE;
 
-	// it is needed for Class B high credit calculations
-	// so we need to guess it
-	// TODO: check if it is right
+	/* it is needed for Class B high credit calculations
+	 * so we need to guess it
+	 * TODO: check if it is right
+	 */
 	temp = class_a_bytes_per_second / 8000 - (12 + 8 + 18 + 4);
-	if (temp > 0) {
+	if (temp > 0)
 		tpktsz_a = temp;
-	} else {
+	else
 		tpktsz_a = 0;
-		// TODO: in igb_set_class_bandwidth if given tpktsz_a < 64
-		// (for example 0) then the 64 value will be used even if
-		// there is no class_A streams (class_a is 0)
-		// I suspect that this is error, so we use 0 here.
-	}
+	/* TODO: in igb_set_class_bandwidth if given tpktsz_a < 64
+	 * (for example 0) then the 64 value will be used even if
+	 * there is no class_A streams (class_a is 0)
+	 * I suspect that this is error, so we use 0 here.
+	 */
 
 	class_a_percent = class_a_bytes_per_second;
 	class_b_percent = class_b_bytes_per_second;
 
 	if (link.speed == 100) {
-		class_a_percent /= (100000000.0 / 8); /* bytes-per-sec @ 100Mbps */
+		/* bytes-per-sec @ 100Mbps */
+		class_a_percent /= (100000000.0 / 8);
 		class_b_percent /= (100000000.0 / 8);
-		class_a_idle = (u_int32_t)(class_a_percent * 0.2 * (float)linkrate + 0.5);
-		class_b_idle = (u_int32_t)(class_b_percent * 0.2 * (float)linkrate + 0.5);
+		class_a_idle = (u_int32_t)(class_a_percent * 0.2 *
+				(float)linkrate + 0.5);
+		class_b_idle = (u_int32_t)(class_b_percent * 0.2 *
+				(float)linkrate + 0.5);
 	} else {
-		class_a_percent /= (1000000000.0 / 8); /* bytes-per-sec @ 1Gbps */
+		/* bytes-per-sec @ 1Gbps */
+		class_a_percent /= (1000000000.0 / 8);
 		class_b_percent /= (1000000000.0 / 8);
-		class_a_idle = (u_int32_t)(class_a_percent * 2.0 * (float)linkrate + 0.5);
-		class_b_idle = (u_int32_t)(class_b_percent * 2.0 * (float)linkrate + 0.5);
+		class_a_idle = (u_int32_t)(class_a_percent * 2.0 *
+				(float)linkrate + 0.5);
+		class_b_idle = (u_int32_t)(class_b_percent * 2.0 *
+				(float)linkrate + 0.5);
 	}
 
 	if ((class_a_percent + class_b_percent) > 0.75) {
-		error = EINVAL;
+		error = -EINVAL;
 		goto unlock;
 	}
 	tqavcc0 |= class_a_idle;
 	tqavcc1 |= class_b_idle;
 
 	/*
-	 * hiCredit is the number of idleslope credits accumulated due to delay T
+	 * hiCredit is the number of idleslope credits accumulated due to delay
 	 *
 	 * we assume the maxInterferenceSize is 18 + 4 + 1500 (1522).
 	 * Note: if EEE is enabled, we should use for maxInterferenceSize
 	 * the overhead of link recovery (a media-specific quantity).
 	 */
-	tqavhc0 = 0x80000000 + (class_a_idle * 1522 / linkrate ); /* L.10 */
+	tqavhc0 = 0x80000000 + (class_a_idle * 1522 / linkrate); /* L.10 */
 
 	/*
 	 * Class B high credit is is the same, except the delay
-	 * is the MaxBurstSize of Class A + maxInterferenceSize of non-SR traffic
+	 * is the MaxBurstSize of Class A + maxInterferenceSize of non-SR
+	 * traffic
 	 *
 	 * L.41
 	 * max Class B delay = (1522 + tpktsz_a) / (linkrate - class_a_idle)
 	 */
 
-	tqavhc1 = 0x80000000 + (class_b_idle * ((1522 + tpktsz_a)/ (linkrate - class_a_idle)));
+	tqavhc1 = 0x80000000 + (class_b_idle * ((1522 + tpktsz_a) /
+				(linkrate - class_a_idle)));
 
 	/* implicitly enable the Qav shaper */
 	tqavctrl |= E1000_TQAVCTRL_TX_ARB;
@@ -1533,22 +2185,23 @@ igb_set_class_bandwidth2(device_t *dev,
 	E1000_WRITE_REG(hw, E1000_TQAVCC(1), tqavcc1);
 	E1000_WRITE_REG(hw, E1000_TQAVCTRL, tqavctrl);
 
- unlock:
-	if( sem_post( adapter->memlock ) != 0 ) {
+unlock:
+	if (sem_post(adapter->memlock) != 0)
 		error = errno;
-	}
 
 	return error;
 }
 
 int igb_get_mac_addr(device_t *dev, u_int8_t mac_addr[ETH_ADDR_LEN])
 {
-	struct adapter	*adapter;
+	struct adapter *adapter;
 	struct e1000_hw *hw;
 
-	if (NULL == dev) return EINVAL;
+	if (dev == NULL)
+		return -EINVAL;
 	adapter = (struct adapter *)dev->private_data;
-	if (NULL == adapter) return ENXIO;
+	if (adapter == NULL)
+		return -ENXIO;
 
 	hw = &adapter->hw;
 
@@ -1556,3 +2209,120 @@ int igb_get_mac_addr(device_t *dev, u_int8_t mac_addr[ETH_ADDR_LEN])
 	return 0;
 }
 
+int igb_setup_flex_filter(device_t *dev, unsigned int queue_id,
+			  unsigned int filter_id, unsigned int filter_len,
+			  u_int8_t *filter, u_int8_t *mask)
+{
+	struct adapter *adapter;
+	struct e1000_hw *hw;
+	u32 i = 0, j, k;
+	u32 fhft, wufc;
+
+	if (dev == NULL)
+		return -EINVAL;
+
+	adapter = (struct adapter *)dev->private_data;
+	if (adapter == NULL)
+		return -ENXIO;
+
+	if (filter_id > 7)
+		return -EINVAL;
+
+	if (queue_id > 1)
+		return -EINVAL;
+
+	if (filter_len > 128)
+		return -EINVAL;
+
+	hw = &adapter->hw;
+
+	/*
+	 * example pattern to set to match on the following in a Magic Packet
+	 * 0x00: xx xx xx xx xx xx xx xx  xx xx xx xx 08 00 45 00
+	 * 0x10: xx xx xx xx xx xx xx 11  xx xx xx xx xx xx xx xx
+	 * 0x20: xx xx xx xx 00 07 00 86  xx xx ff ff ff ff ff ff
+	 * 0x30: m0 m1 m2 m3 m4 m5 xx xx  xx xx xx xx xx xx xx xx
+	 *
+	 * Where m0-m5 are the 6 bytes of the mac address in network order
+	 *
+	 * example code follows
+	 *
+	 * ethertype should be IP which is 0x0800
+	 * filter[0x0C] = 0x08;
+	 * filter[0x0D] = 0x00;
+
+	 * verify IPv4 and header length 20
+	 * filter[0x0E] = 0x45;
+	 * filter[0x0F] = 0x00;
+	 * mask[1] = 0xF0;
+
+	 * verify L3 protocol is UDP
+	 * filter[0x17] = 0x11;
+	 * mask[2] = 0x80;
+
+	 * verify source and destination port numbers
+	 * filter[0x24] = 0x00;
+	 * filter[0x25] = 0x07;
+	 * filter[0x26] = 0x00;
+	 * filter[0x27] = 0x86;
+	 * mask[4] = 0xF0;
+
+* add start filter of 6 bytes all 0xFF
+	 * memset(&filter[0x2a], 0xff, 6);
+	 * mask[5] = 0xFC;
+
+	 * add mac address
+	 * memcpy(&filter[0x30], hw->mac.addr, 6);
+	 * mask[6] |= 0x3F;
+	 */
+
+	while (i < filter_len) {
+		for (j = 0; j < 8; j += 4) {
+			fhft = 0;
+			for (k = 0; k < 4; k++)
+				fhft |= ((u32)(filter[i + j + k])) << (k * 8);
+			E1000_WRITE_REG_ARRAY(hw, E1000_FHFT(filter_id),
+					(i/2) + (j/4), fhft);
+		}
+		E1000_WRITE_REG_ARRAY(hw, E1000_FHFT(filter_id),
+				(i/2) + 2, mask[i/8]);
+		i += 8;
+	}
+
+	E1000_WRITE_REG_ARRAY(hw, E1000_FHFT(filter_id),
+			63, (queue_id << 8) | filter_len);
+
+	E1000_WRITE_REG(hw, E1000_WUC, 0x21); /* XXX is this right ? */
+
+	wufc = E1000_READ_REG(hw, E1000_WUFC);
+	wufc |= (E1000_WUFC_FLX0 << filter_id) | E1000_WUFC_FLEX_HQ;
+	E1000_WRITE_REG(hw, E1000_WUFC, wufc);
+
+	return 0;
+}
+
+int igb_clear_flex_filter(device_t *dev, unsigned int filter_id)
+{
+	struct adapter *adapter;
+	struct e1000_hw *hw;
+	u32 wufc;
+
+	if (dev == NULL)
+		return -EINVAL;
+
+	adapter = (struct adapter *)dev->private_data;
+	if (adapter == NULL)
+		return -ENXIO;
+
+	if (filter_id > 7)
+		return -EINVAL;
+
+
+	hw = &adapter->hw;
+
+	wufc = E1000_READ_REG(hw, E1000_WUFC);
+	wufc &= ~(E1000_WUFC_FLX0 << filter_id);
+	E1000_WRITE_REG(hw, E1000_WUFC, wufc);
+
+	return 0;
+}

--- a/lib/igb/igb.h
+++ b/lib/igb/igb.h
@@ -1,6 +1,6 @@
 /******************************************************************************
 
-  Copyright (c) 2001-2012, Intel Corporation
+  Copyright (c) 2001-2016, Intel Corporation
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -38,8 +38,8 @@
 #include <sys/types.h>
 
 struct resource {
-        u_int64_t       paddr;
-	u_int32_t	mmap_size;
+	u_int64_t paddr;
+	u_int32_t mmap_size;
 };
 
 /* datastructure used to transmit a timed packet */
@@ -47,24 +47,24 @@ struct resource {
 #define IGB_PACKET_LATCHTIME	2	/* grab a timestamp of transmission */
 
 struct igb_packet {
-        struct resource map;            /* bus_dma map for packet */
-	unsigned int	offset;		/* offset into physical page */
-	void		*vaddr;
-	u_int32_t 	len;
-	u_int32_t 	flags;
-	u_int64_t	attime;		/* launchtime */
-	u_int64_t	dmatime;	/* when dma tx desc wb*/
+	struct resource map;	/* bus_dma map for packet */
+	unsigned int offset;	/* offset into physical page */
+	void *vaddr;
+	u_int32_t len;
+	u_int32_t flags;
+	u_int64_t attime;	/* launchtime */
+	u_int64_t dmatime;	/* when dma tx desc wb*/
 	struct igb_packet *next;	/* used in the clean routine */
 };
 
 typedef struct _device_t {
-	void	*private_data;
+	void *private_data;
 	u_int16_t pci_vendor_id;
 	u_int16_t pci_device_id;
 	u_int16_t domain;
-	u_int8_t	bus;
-	u_int8_t	dev;
-	u_int8_t	func;
+	u_int8_t bus;
+	u_int8_t dev;
+	u_int8_t func;
 } device_t;
 
 /*
@@ -72,36 +72,47 @@ typedef struct _device_t {
  * e1000_dma_malloc_page and e1000_dma_free_page.
  */
 struct igb_dma_alloc {
-        u_int64_t               dma_paddr;
-        void                    *dma_vaddr;
-        unsigned int    	mmap_size;
+	u_int64_t dma_paddr;
+	void *dma_vaddr;
+	unsigned int mmap_size;
 };
 
-int	igb_probe( device_t *dev );
-int	igb_attach(char *dev_path, device_t *pdev);
-int igb_attach_tx( device_t *pdev );
-int	igb_detach(device_t *dev);
-int	igb_suspend(device_t *dev);
-int	igb_resume(device_t *dev);
-int	igb_init(device_t *dev);
-int	igb_dma_malloc_page(device_t *dev, struct igb_dma_alloc *page);
-void	igb_dma_free_page(device_t *dev, struct igb_dma_alloc *page);
-int	igb_xmit(device_t *dev, unsigned int queue_index, struct igb_packet *packet);
-void	igb_clean(device_t *dev, struct igb_packet **cleaned_packets);
-int	igb_get_wallclock(device_t *dev, u_int64_t	*curtime, u_int64_t *rdtsc);
-int igb_gettime(device_t *dev, clockid_t clk_id, u_int64_t *curtime, struct timespec *system_time );
-int	igb_set_class_bandwidth(device_t *dev, u_int32_t class_a, u_int32_t class_b, u_int32_t tpktsz_a, u_int32_t tpktsz_b);
-int	igb_set_class_bandwidth2(device_t *dev, u_int32_t class_a_bytes_per_second, u_int32_t class_b_bytes_per_second);
+int igb_probe(device_t *dev);
+int igb_attach(char *dev_path, device_t *pdev);
+int igb_attach_rx(device_t *pdev);
+int igb_attach_tx(device_t *pdev);
+int igb_detach(device_t *dev);
+int igb_suspend(device_t *dev);
+int igb_resume(device_t *dev);
+int igb_init(device_t *dev);
+int igb_dma_malloc_page(device_t *dev, struct igb_dma_alloc *page);
+void igb_dma_free_page(device_t *dev, struct igb_dma_alloc *page);
+int igb_xmit(device_t *dev, unsigned int queue_index,
+	     struct igb_packet *packet);
+int igb_refresh_buffers(device_t *dev, u_int32_t idx,
+			 struct igb_packet **rxbuf_packets,
+			 u_int32_t num_bufs);
+int igb_receive(device_t *dev, unsigned int queue_index, 
+	     struct igb_packet **received_packets, u_int32_t *count);
+void igb_clean(device_t *dev, struct igb_packet **cleaned_packets);
+int igb_get_wallclock(device_t *dev, u_int64_t *curtime, u_int64_t *rdtsc);
+int igb_gettime(device_t *dev, clockid_t clk_id, u_int64_t *curtime,
+		struct timespec *system_time);
+int igb_set_class_bandwidth(device_t *dev, u_int32_t class_a, u_int32_t class_b,
+			    u_int32_t tpktsz_a, u_int32_t tpktsz_b);
+int igb_set_class_bandwidth2(device_t *dev, u_int32_t class_a_bytes_per_second,
+			     u_int32_t class_b_bytes_per_second);
+int igb_setup_flex_filter(device_t *dev, unsigned int queue_id,
+			  unsigned int filter_id, unsigned int filter_len,
+			  u_int8_t *filter, u_int8_t *mask);
+int igb_clear_flex_filter(device_t *dev, unsigned int filter_id);
+void igb_trigger(device_t *dev, u_int32_t data);
+void igb_readreg(device_t *dev, u_int32_t reg, u_int32_t *data);
+void igb_writereg(device_t *dev, u_int32_t reg, u_int32_t data);
 
-void	igb_trigger(device_t *dev, u_int32_t data);
-void	igb_readreg(device_t *dev, u_int32_t reg, u_int32_t *data);
-void	igb_writereg(device_t *dev, u_int32_t reg, u_int32_t data);
-
-int igb_lock( device_t *dev );
-int igb_unlock( device_t *dev );
+int igb_lock(device_t *dev);
+int igb_unlock(device_t *dev);
 
 int igb_get_mac_addr(device_t *dev, u_int8_t mac_addr[6]);
 
 #endif /* _IGB_H_DEFINED_ */
-
-


### PR DESCRIPTION
This patch set adds support for direct packet receiving from the I210 device. The simple_rx application demonstrates how to use the new receive APIs. It was created based on simple_listener and it has the same usage. 

Signed-off-by: Toshiki Nishioka <toshiki.nishioka@intel.com>