### PR TITLE
Bug fixes for gPTP daemon

### DIFF
--- a/daemons/gptp/common/ptp_message.cpp
+++ b/daemons/gptp/common/ptp_message.cpp
@@ -408,6 +408,9 @@ PTPMessageCommon *buildPTPMessage
 		}
 		break;
 	case ANNOUNCE_MESSAGE:
+
+		XPTPD_INFO("*** Received Announce message");
+
 		{
 			PTPMessageAnnounce *annc = new PTPMessageAnnounce();
 			annc->messageType = messageType;
@@ -906,7 +909,7 @@ void PTPMessageFollowUp::processMessage(IEEE1588Port * port)
 	FrequencyRatio local_clock_adjustment;
 	FrequencyRatio local_system_freq_offset;
 	FrequencyRatio master_local_freq_offset;
-	int correction;
+	int64_t correction;
 	int32_t scaledLastGmFreqChange = 0;
 	scaledNs scaledLastGmPhaseChange;
 
@@ -959,9 +962,8 @@ void PTPMessageFollowUp::processMessage(IEEE1588Port * port)
 	master_local_freq_offset += 1.0;
 	master_local_freq_offset /= port->getPeerRateOffset();
 
-	correctionField = (uint64_t)
-		((correctionField >> 16)/master_local_freq_offset);
-	correction = (int) (delay + correctionField);
+	correctionField = (correctionField >> 16);
+	correction = (int64_t)((delay * master_local_freq_offset) + correctionField );
 
 	if( correction > 0 )
 	  TIMESTAMP_ADD_NS( preciseOriginTimestamp, correction );
@@ -1007,10 +1009,10 @@ void PTPMessageFollowUp::processMessage(IEEE1588Port * port)
 	port->getClock()->getFUPStatus()->setScaledLastGmPhaseChange( scaledLastGmPhaseChange );
 
 	if( port->getPortState() == PTP_SLAVE )
-   {
-      /* The sync_count counts the number of sync messages received
-         that influence the time on the device. Since adjustments are only
-         made in the PTP_SLAVE state, increment it here */
+	{
+		/* The sync_count counts the number of sync messages received
+		   that influence the time on the device. Since adjustments are only
+		   made in the PTP_SLAVE state, increment it here */
 		port->incSyncCount();
 
 		/* Do not call calcLocalSystemClockRateDifference it updates state

--- a/daemons/gptp/common/ptp_message.cpp
+++ b/daemons/gptp/common/ptp_message.cpp
@@ -1006,8 +1006,13 @@ void PTPMessageFollowUp::processMessage(IEEE1588Port * port)
 	port->getClock()->getFUPStatus()->setScaledLastGmFreqChange( scaledLastGmFreqChange );
 	port->getClock()->getFUPStatus()->setScaledLastGmPhaseChange( scaledLastGmPhaseChange );
 
-	if( port->getPortState() != PTP_MASTER ) {
+	if( port->getPortState() == PTP_SLAVE )
+   {
+      /* The sync_count counts the number of sync messages received
+         that influence the time on the device. Since adjustments are only
+         made in the PTP_SLAVE state, increment it here */
 		port->incSyncCount();
+
 		/* Do not call calcLocalSystemClockRateDifference it updates state
 		   global to the clock object and if we are master then the network
 		   is transitioning to us not being master but the master process

--- a/daemons/gptp/common/ptp_message.cpp
+++ b/daemons/gptp/common/ptp_message.cpp
@@ -958,7 +958,7 @@ void PTPMessageFollowUp::processMessage(IEEE1588Port * port)
 	}
 
 	master_local_freq_offset  =  tlv.getRateOffset();
-	master_local_freq_offset /= 2ULL << 41;
+	master_local_freq_offset /= 1ULL << 41;
 	master_local_freq_offset += 1.0;
 	master_local_freq_offset /= port->getPeerRateOffset();
 


### PR DESCRIPTION
This pull request includes two bug fixes to the gPTP daemon. Following is a detailed explanation for the bugs observed and their fixes:

**0d1173c: gPTP: Fix end node adjusting time in PTP_INITIALIZING state**

This issue was observed when two devices (A and B) running the gPTP daemon are directly connected. However, this issue also affects a scenario where multiple devices are connected to a grandmaster on a time-aware 802.1AS network. 
 
When the gPTP daemon is started, both the devices set asCapable as enabled and device A is chosen as the grandmaster by the BMC algorithm. If device A goes offline when device B is adjusting its freq, device B goes into the PTP_MASTER state and sets asCapable as disabled but retains the current freq adjustment. When device A comes back online, both devices set asCapable as enabled and device A goes into PTP_INITIALIZING state. Since device B is currently the GM, device A receives Sync and FollowUp messages from B and starts adjusting its clock to device B's frequency. On the next ANNOUNCE_TIMEOUT event, device A is chosen as the new GM by the BMC algorithm but its clock is running at an incorrect frequency. Since it is a GM, it never updates/resets its clock frequency. Therefore, device B starts driving its clock based on this incorrect frequency. 
 
Depending on the magnitude of error in the grandmaster's frequency, it is possible that the target frequency the slave should achieve in order to synchronize to the grandmaster might lie outside the slave's adjustment range, making it impossible to stay synchronized to the grandmaster.

To fix this issue, the code has been changed so that the end nodes adjust their clocks only in the PTP_SLAVE state. 


**318c3f4: gPTP: Fix correction applied to preciseOriginTimestamp**

This issue was observed when two devices running the gPTP daemon are connected through a switch with the syntonize option enabled (-S). The phase offset on the slave device oscillates in the range of tens of microseconds and never converged. 
During the investigation, it was found that when processing a FollowUp message, the correction to the preciseOriginTimestamp is being calculated incorrectly. The correctionField is converted into the local time base using the rate ratio and added to the path delay to calculate the correction value (in the local time base). This correction is then applied to the preciseOriginTimestamp (which is in the grandmaster time base). This preciseOriginTimestamp is then used in computing the phase offset (in ptp_message.cpp:972) and rate ratio (in ieee1588clock.cpp:309), thus resulting in incorrect values. The rate ratio is also subsequently used when processing the next FollowUp message, thus compounding the incorrect value.

To fix the issue, the correction value is computed by expressing the correctionField and path delay in the grandmaster time base as per the IEEE 802.1AS-2011 standard (clause 11.1.3). This correction field is applied to the preciseOriginTimestamp, which is then used to calculate the correct phase offset and rate ratio.
