### PR TITLE
Add -lrt to simple_rx build for Travis

### DIFF
--- a/examples/simple_rx/Makefile
+++ b/examples/simple_rx/Makefile
@@ -3,7 +3,8 @@ OPT = -O2 -g
 CFLAGS = $(OPT) -Wall -Wextra -Wno-parentheses
 IGBDIR = ../../lib/igb
 INCFLAGS = -I../../daemons/mrpd -I../common -I../../daemons/common -I$(IGBDIR)
-LDLIBS = -lpcap -lsndfile -pthread -lpci
+# GLIBC versions starting with 2.17 don't need -lrt anymore
+LDLIBS = -lpcap -lsndfile -pthread -lpci -lrt
 
 all: simple_rx
 


### PR DESCRIPTION
Travis is still running ancient Ubuntu systems as their default build image. In pre-2.17 versions of GLIBC, -lrt is required to use `clock_gettime`, and it doesn't seem to cause a problem in post-2.17 versions.