### PR TITLE
Add support for "new" PTP cross-timestamp mechanism added in kernel version 4.6

### DIFF
--- a/daemons/gptp/linux/build/Makefile
+++ b/daemons/gptp/linux/build/Makefile
@@ -30,8 +30,18 @@
 
 ALTERNATE_LINUX_INCPATH=$(HOME)/header/include/
 
+# Check to see if PTP cross-timestamping is supported in hardware
+PRECISE_TIME_TEST = "\#include <linux/ptp_clock.h>\\n\
+	\#ifdef PTP_SYS_OFFSET_PRECISE\\nint main(){return 0;}\\n\#endif"
+HAS_PRECISE_TIME = $(shell echo $(PRECISE_TIME_TEST) | gcc -xc - \
+	-I$(ALTERNATE_LINUX_INCPATH) -o /dev/null > /dev/null 2>&1 ; echo $$?)
+
 CFLAGS_G = -Wall -std=c++0x -g -I. -I../../common -I../src \
 	-I$(ALTERNATE_LINUX_INCPATH)
+
+ifeq ($(HAS_PRECISE_TIME),0)
+	CFLAGS_G += -DPTP_HW_CROSSTSTAMP
+endif
 
 CPPFLAGS_G := $(CFLAGS_G) -Wnon-virtual-dtor
 

--- a/daemons/gptp/linux/src/daemon_cl.cpp
+++ b/daemons/gptp/linux/src/daemon_cl.cpp
@@ -363,10 +363,6 @@ int main(int argc, char **argv)
 	portInit.lock_factory = lock_factory;
 
 	pPort = new IEEE1588Port(&portInit);
-	if (!pPort->init_port(phy_delay)) {
-		printf("failed to initialize port \n");
-		return -1;
-	}
 
 	if(use_config_file)
 	{
@@ -406,6 +402,11 @@ int main(int argc, char **argv)
 			}
 		}
 
+	}
+
+	if (!pPort->init_port(phy_delay)) {
+		printf("failed to initialize port \n");
+		return -1;
 	}
 
 	if( restoredataptr != NULL ) {

--- a/daemons/gptp/linux/src/linux_hal_generic.cpp
+++ b/daemons/gptp/linux/src/linux_hal_generic.cpp
@@ -435,7 +435,8 @@ bool LinuxTimestamperGeneric::HWTimestamper_gettime
 
 		memset( &offset, 0, sizeof(offset));
 		offset.n_samples = PTP_MAX_SAMPLES;
-		ioctl( phc_fd, PTP_SYS_OFFSET, &offset );
+		if( ioctl( phc_fd, PTP_SYS_OFFSET, &offset ) == -1 )
+			return false;
 
 		pct = &offset.ts[0];
 		for( i = 0; i < offset.n_samples; ++i ) {

--- a/daemons/gptp/linux/src/linux_hal_generic.hpp
+++ b/daemons/gptp/linux/src/linux_hal_generic.hpp
@@ -62,7 +62,9 @@ private:
 	bool cross_stamp_good;
 	std::list<Timestamp> rxTimestampList;
 	LinuxNetworkInterfaceList iface_list;
+#ifdef PTP_HW_CROSSTSTAMP
 	bool precise_timestamp_enabled;
+#endif
 
 	TicketingLock *net_lock;
 

--- a/daemons/gptp/linux/src/linux_hal_generic.hpp
+++ b/daemons/gptp/linux/src/linux_hal_generic.hpp
@@ -62,6 +62,7 @@ private:
 	bool cross_stamp_good;
 	std::list<Timestamp> rxTimestampList;
 	LinuxNetworkInterfaceList iface_list;
+	bool precise_timestamp_enabled;
 
 	TicketingLock *net_lock;
 


### PR DESCRIPTION
Add support for HW timestamping & fix issue where link delay adjustments from .ini file are not applied correctly