### PR TITLE
Fixing issue #390 - gPTP daemon build failure with ARCH set to I210

### DIFF
--- a/daemons/gptp/linux/build/Makefile
+++ b/daemons/gptp/linux/build/Makefile
@@ -33,7 +33,7 @@ ALTERNATE_LINUX_INCPATH=$(HOME)/header/include/
 CFLAGS_G = -Wall -std=c++0x -g -I. -I../../common -I../src \
 	-I$(ALTERNATE_LINUX_INCPATH)
 
-CPPFLAGS_G := $(CFLAGS_G) -Wnon-virtual-dtor
+CPPFLAGS_G = $(CFLAGS_G) -Wnon-virtual-dtor
 
 LDFLAGS_G = -lpthread -lrt
 


### PR DESCRIPTION
Change in daemon/gptp/linux/build/Makefile which prevents the gPTP daemon build from failing (no more "igb.h undefined" error due to proper CPPFLAGS setting, ARCH=I210 make daemons_all ends with a success) - resolution to issues #390 and #385 