### PR TITLE
igb_avb: move userpage list to private data of task.

### DIFF
--- a/kmod/igb/igb.h
+++ b/kmod/igb/igb.h
@@ -575,7 +575,6 @@ struct igb_adapter {
 	/* OS defined structs */
 	struct pci_dev *pdev;
 	/* user-dma specific variables */
-	struct igb_user_page	*userpages;
 	u32	uring_tx_init;
 	u32	uring_rx_init;
 #ifndef HAVE_NETDEV_STATS_IN_NETDEV
@@ -893,6 +892,15 @@ struct igb_link_cmd {
 	u32		up;
 	u32		speed;
 	u32		duplex;
+};
+
+struct igb_private_data {
+	struct igb_adapter *adapter;
+	/* user-dma specific variable for buffer */
+	struct igb_user_page *userpages;
+	/* user-dma specific variable for TX and RX */
+	u32	uring_tx_init;
+	u32	uring_rx_init;
 };
 
 #endif /* _IGB_H_ */

--- a/kmod/igb/igb_main.c
+++ b/kmod/igb/igb_main.c
@@ -2686,7 +2686,6 @@ static int igb_probe(struct pci_dev *pdev,
 	adapter->msg_enable = (1 << debug) - 1;
 
 	/* AVB specific */
-	adapter->userpages = NULL;
 	adapter->uring_tx_init = 0;
 	adapter->uring_rx_init = 0;
 	mutex_init(&adapter->lock);
@@ -10137,6 +10136,7 @@ static struct igb_adapter *igb_lookup(char *id)
 
 static int igb_bind(struct file *file, void __user *argp)
 {
+	struct igb_private_data *igb_priv = file->private_data;
 	struct igb_adapter *adapter;
 	struct igb_bind_cmd req;
 	int err = 0;
@@ -10146,13 +10146,18 @@ static int igb_bind(struct file *file, void __user *argp)
 
 	printk("bind to iface %s\n", req.iface);
 
+	if (igb_priv == NULL) {
+		printk("cannot find private data!\n");
+		return -ENOENT;
+	}
+
 	adapter = igb_lookup(req.iface);
 	if (adapter == NULL) {
 		printk("lookup failed to iface %s\n", req.iface);
 		return -ENOENT;
 	}
 
-	file->private_data = adapter;
+	igb_priv->adapter = adapter;
 
 	req.mmap_size = 0;
 	req.mmap_size = pci_resource_len(adapter->pdev, 0);
@@ -10166,30 +10171,41 @@ static int igb_bind(struct file *file, void __user *argp)
 	return 0;
 
 failed:
-	file->private_data = NULL;
+	igb_priv->adapter = NULL;
 	return err;
 }
 
 static int igb_unbind(struct file *file)
 {
 	struct igb_adapter *adapter;
+	struct igb_private_data *igb_priv = file->private_data;
 
-	adapter = file->private_data;
+	if (igb_priv == NULL) {
+		printk("cannot find private data!\n");
+		return -ENOENT;
+	}
 
+	adapter = igb_priv->adapter;
 	if (adapter == NULL)
 		return -EBADFD;
 
-	file->private_data = NULL;
+	igb_priv->adapter = NULL;
 	return 0;
 }
 
 static long igb_getspeed(struct file *file, void __user *arg)
 {
+	struct igb_private_data *igb_priv = file->private_data;
 	struct igb_adapter *adapter;
 	struct igb_link_cmd req;
 	u32	link;
 
-	adapter = file->private_data;
+	if (igb_priv == NULL) {
+		printk("cannot find private data!\n");
+		return -ENOENT;
+	}
+
+	adapter = igb_priv->adapter;
 	if (adapter == NULL) {
 		printk("map to unbound device!\n");
 		return -ENOENT;
@@ -10213,16 +10229,118 @@ static long igb_getspeed(struct file *file, void __user *arg)
 	return 0;
 }
 
-static long igb_mapbuf(struct file *file, void __user *arg, int ring)
+static long igb_mapbuf_user(struct file *file, void __user *arg, int ring)
 {
+	struct igb_private_data *igb_priv = file->private_data;
 	struct igb_adapter *adapter;
 	struct igb_buf_cmd req;
 	int err = 0;
+	struct page *page;
+	dma_addr_t page_dma;
+	struct igb_user_page *userpage;
+
+	if (igb_priv == NULL) {
+		printk("cannot find private data!\n");
+		return -ENOENT;
+	}
+
+	adapter = igb_priv->adapter;
+	if (adapter == NULL) {
+		printk("map to unbound device!\n");
+		return -ENOENT;
+	}
 
 	if (copy_from_user(&req, arg, sizeof(req)))
 		return -EFAULT;
 
-	adapter = file->private_data;
+	userpage = vzalloc(sizeof(struct igb_user_page));
+	if (unlikely(!userpage)) {
+		err = -ENOMEM;
+		goto failed;
+	}
+
+	mutex_lock(&adapter->lock);
+	if (igb_priv->userpages == NULL) {
+		igb_priv->userpages = userpage;
+	} else {
+		userpage->next = igb_priv->userpages;
+		igb_priv->userpages->prev = userpage;
+		igb_priv->userpages = userpage;
+	}
+
+#if defined(CONFIG_IGB_SUPPORT_32BIT_IOCTL)
+#if defined(CONFIG_ZONE_DMA32)
+	page = alloc_page(GFP_ATOMIC | __GFP_COLD | GFP_DMA32);
+#else /* defined(CONFIG_ZONE_DMA32) */
+	page = alloc_page(GFP_ATOMIC | __GFP_COLD | GFP_DMA);
+#endif /* defined(CONFIG_ZONE_DMA32) */
+#else /* defined(CONFIG_IGB_SUPPORT_32BIT_IOCTL) */
+	page = alloc_page(GFP_ATOMIC | __GFP_COLD);
+#endif /* defined(CONFIG_IGB_SUPPORT_32BIT_IOCTL) */
+	if (unlikely(!page)) {
+		err = -ENOMEM;
+		goto page_failed;
+	}
+
+	page_dma = dma_map_page(pci_dev_to_dev(adapter->pdev), page,
+			0, PAGE_SIZE, DMA_FROM_DEVICE);
+
+	if (dma_mapping_error(pci_dev_to_dev(adapter->pdev), page_dma)) {
+		err = -ENOMEM;
+		goto map_failed;
+	}
+
+	igb_priv->userpages->page = page;
+	igb_priv->userpages->page_dma = page_dma;
+
+	req.physaddr = page_dma;
+	req.mmap_size = PAGE_SIZE;
+	mutex_unlock(&adapter->lock);
+
+	if (copy_to_user(arg, &req, sizeof(req))) {
+		printk("copyout to user failed\n");
+		err = -EFAULT;
+		mutex_lock(&adapter->lock);
+		goto copy_failed;
+	}
+
+	return 0;
+
+copy_failed:
+	dma_unmap_page(pci_dev_to_dev(adapter->pdev),
+			userpage->page_dma, PAGE_SIZE,
+			DMA_FROM_DEVICE);
+map_failed:
+	put_page(userpage->page);
+page_failed:
+	if (userpage->prev)
+		userpage->prev->next = userpage->next;
+	if (userpage->next)
+		userpage->next->prev = userpage->prev;
+	if (userpage == igb_priv->userpages)
+		igb_priv->userpages = userpage->next;
+	vfree(userpage);
+	mutex_unlock(&adapter->lock);
+failed:
+	return err;
+}
+
+static long igb_mapbuf(struct file *file, void __user *arg, int ring)
+{
+	struct igb_private_data *igb_priv = file->private_data;
+	struct igb_adapter *adapter;
+	struct igb_buf_cmd req;
+	int err = 0;
+
+	if (igb_priv == NULL) {
+		printk("cannot find private data!\n");
+		return -ENOENT;
+	}
+
+	if (copy_from_user(&req, arg, sizeof(req)))
+		return -EFAULT;
+
+	adapter = igb_priv->adapter;
 	if (adapter == NULL) {
 		printk("map to unbound device!\n");
 		return -ENOENT;
@@ -10235,15 +10353,19 @@ static long igb_mapbuf(struct file *file, void __user *arg, int ring)
 			return -EINVAL;
 		}
 
+		mutex_lock(&adapter->lock);
 		if (adapter->uring_tx_init & (1 << req.queue)) {
+			mutex_unlock(&adapter->lock);
 			printk("mapring:queue in use (%d)\n", req.queue);
 			return -EBUSY;
 		}
 
 		adapter->uring_tx_init |= (1 << req.queue);
+		igb_priv->uring_tx_init |= (1 << req.queue);
 
 		req.physaddr = adapter->tx_ring[req.queue]->dma;
 		req.mmap_size = adapter->tx_ring[req.queue]->size;
+		mutex_unlock(&adapter->lock);
 	} else if (ring == IGB_MAP_RX_RING) {
 		if (req.queue >= 3) {
 			printk("mapring:invalid queue specified(%d)\n",
@@ -10251,66 +10373,22 @@ static long igb_mapbuf(struct file *file, void __user *arg, int ring)
 			return -EINVAL;
 		}
 
+		mutex_lock(&adapter->lock);
 		if (adapter->uring_rx_init & (1 << req.queue)) {
+			mutex_unlock(&adapter->lock);
 			printk("mapring:queue in use (%d)\n", req.queue);
 			return -EBUSY;
 		}
 
 		adapter->uring_rx_init |= (1 << req.queue);
+		igb_priv->uring_rx_init |= (1 << req.queue);
 
 		req.physaddr = adapter->rx_ring[req.queue]->dma;
 		req.mmap_size = adapter->rx_ring[req.queue]->size;
-	} else {
-		struct page *page;
-		dma_addr_t page_dma;
-		struct igb_user_page *userpage;
-
-		userpage = vzalloc(sizeof(struct igb_user_page));
-		if (unlikely(!userpage)) {
-			err = -ENOMEM;
-			goto failed;
-		}
-
-		mutex_lock(&adapter->lock);
-		if (adapter->userpages == NULL) {
-			adapter->userpages = userpage;
-		} else {
-			userpage->next = adapter->userpages;
-			adapter->userpages->prev = userpage;
-			adapter->userpages = userpage;
-		}
-
-#if defined(CONFIG_IGB_SUPPORT_32BIT_IOCTL)
-#if defined(CONFIG_ZONE_DMA32)
-		page = alloc_page(GFP_ATOMIC | __GFP_COLD | GFP_DMA32);
-#else /* defined(CONFIG_ZONE_DMA32) */
-		page = alloc_page(GFP_ATOMIC | __GFP_COLD | GFP_DMA);
-#endif /* defined(CONFIG_ZONE_DMA32) */
-#else /* defined(CONFIG_IGB_SUPPORT_32BIT_IOCTL) */
-		page = alloc_page(GFP_ATOMIC | __GFP_COLD);
-#endif /* defined(CONFIG_IGB_SUPPORT_32BIT_IOCTL) */
-		if (unlikely(!page)) {
-			err = -ENOMEM;
-			mutex_unlock(&adapter->lock);
-			goto failed;
-		}
-
-		page_dma = dma_map_page(pci_dev_to_dev(adapter->pdev), page,
-					0, PAGE_SIZE, DMA_FROM_DEVICE);
-
-		if (dma_mapping_error(pci_dev_to_dev(adapter->pdev), page_dma)) {
-			put_page(page);
-			err = -ENOMEM;
-			mutex_unlock(&adapter->lock);
-			goto failed;;
-		}
-
-		adapter->userpages->page = page;
-		adapter->userpages->page_dma = page_dma;
-
-		req.physaddr = page_dma;
-		req.mmap_size = PAGE_SIZE;
 		mutex_unlock(&adapter->lock);
+	} else {
+		printk("mapring: invalid ioctl %d\n", _IOC_NR(ring));
+		return -EINVAL;
 	}
 
 	if (copy_to_user(arg, &req, sizeof(req))) {
@@ -10328,13 +10406,19 @@ failed:
 static long igb_unmapbuf(struct file *file, void __user *arg, int ring)
 {
 	int err = 0;
+	struct igb_private_data *igb_priv = file->private_data;
 	struct igb_adapter *adapter;
 	struct igb_buf_cmd req;
+
+	if (igb_priv == NULL) {
+		printk("cannot find private data!\n");
+		return -ENOENT;
+	}
 
 	if (copy_from_user(&req, arg, sizeof(req)))
 		return -EFAULT;
 
-	adapter = file->private_data;
+	adapter = igb_priv->adapter;
 	if (adapter == NULL) {
 		printk("map to unbound device!\n");
 		return -ENOENT;
@@ -10345,25 +10429,43 @@ static long igb_unmapbuf(struct file *file, void __user *arg, int ring)
 		if (req.queue >= 3)
 			return -EINVAL;
 
-		if (0 == (adapter->uring_tx_init & (1 << req.queue)))
+		mutex_lock(&adapter->lock);
+		if (0 == (igb_priv->uring_tx_init & (1 << req.queue))) {
+			mutex_unlock(&adapter->lock);
 			return -EINVAL;
+		} else {
+			if (0 == (adapter->uring_tx_init & (1 << req.queue))) {
+				printk("Warning: invalid tx ring buffer state!\n");
+			}
+		}
 
 		adapter->uring_tx_init &= ~(1 << req.queue);
+		igb_priv->uring_tx_init &= ~(1 << req.queue);
+		mutex_unlock(&adapter->lock);
 	} else if (ring == IGB_UNMAP_RX_RING) {
 		/* its easy to figure out what to free on the rings ... */
 		if (req.queue >= 3)
 			return -EINVAL;
 
-		if (0 == (adapter->uring_rx_init & (1 << req.queue)))
+		mutex_lock(&adapter->lock);
+		if (0 == (igb_priv->uring_rx_init & (1 << req.queue))) {
+			mutex_unlock(&adapter->lock);
 			return -EINVAL;
+		} else {
+			if (0 == (adapter->uring_rx_init & (1 << req.queue))) {
+				printk("Warning: invalid rx ring buffer state!\n");
+			}
+		}
 
 		adapter->uring_rx_init &= ~(1 << req.queue);
+		igb_priv->uring_rx_init &= ~(1 << req.queue);
+		mutex_unlock(&adapter->lock);
 	} else {
 		/* have to find the corresponding page to free */
-		struct igb_user_page *userpage; 
+		struct igb_user_page *userpage;
 
 		mutex_lock(&adapter->lock);
-		userpage = adapter->userpages;
+		userpage = igb_priv->userpages;
 
 		while (userpage != NULL) {
 			if (req.physaddr == userpage->page_dma)
@@ -10390,8 +10492,8 @@ static long igb_unmapbuf(struct file *file, void __user *arg, int ring)
 		if (userpage->next)
 			userpage->next->prev = userpage->prev;
 
-		if (userpage == adapter->userpages)
-			adapter->userpages = userpage->next;
+		if (userpage == igb_priv->userpages)
+			igb_priv->userpages = userpage->next;
 
 		vfree(userpage);
 		mutex_unlock(&adapter->lock);
@@ -10414,8 +10516,10 @@ static long igb_ioctl_file(struct file *file, unsigned int cmd,
 		break;
 	case IGB_MAP_TX_RING:
 	case IGB_MAP_RX_RING:
-	case IGB_MAPBUF:
 		err = igb_mapbuf(file, argp, cmd);
+		break;
+	case IGB_MAPBUF:
+		err = igb_mapbuf_user(file, argp, cmd);
 		break;
 	case IGB_UNMAP_TX_RING:
 	case IGB_UNMAP_RX_RING:
@@ -10435,37 +10539,67 @@ static long igb_ioctl_file(struct file *file, unsigned int cmd,
 
 static int igb_open_file(struct inode *inode, struct file *file)
 {
-	file->private_data = NULL;
-	return 0;
+       struct igb_private_data *igb_priv = NULL;
+       int ret = 0;
+
+       igb_priv = kzalloc(sizeof(struct igb_private_data *), GFP_KERNEL);
+       if (igb_priv == NULL) {
+               ret = -ENOMEM;
+               goto out;
+       }
+       igb_priv->uring_tx_init = 0;
+       igb_priv->uring_rx_init = 0;
+       igb_priv->userpages = NULL;
+       igb_priv->adapter = NULL;
+out:
+       file->private_data = igb_priv;
+       return ret;
 }
 
 static int igb_close_file(struct inode *inode, struct file *file)
 {
-	struct igb_adapter *adapter = file->private_data;
-	int err;
+	struct igb_private_data *igb_priv = file->private_data;
+	struct igb_adapter *adapter = NULL;
+	int err = 0;
 	int i;
 	struct igb_user_page *userpage;
 
+	if (igb_priv == NULL) {
+		printk("cannot find private data!\n");
+		return -ENOENT;
+	}
+
+	adapter = igb_priv->adapter;
 	if (adapter == NULL)
-		return 0;
-
-	/* free up any rings and user-mapped pages */
-	for (i = 0; i < 3; i++) {
-		if (adapter->uring_tx_init & (1 << i)) {
-			igb_free_tx_resources(adapter->tx_ring[i]);
-			adapter->uring_tx_init &= ~(1 << i);
-		}
-	}
-
-	for (i = 0; i < 3; i++) {
-		if (adapter->uring_rx_init & (1 << i)) {
-			igb_free_rx_resources(adapter->rx_ring[i]);
-			adapter->uring_rx_init &= ~(1 << i);
-		}
-	}
+		goto out;
 
 	mutex_lock(&adapter->lock);
-	userpage = adapter->userpages;
+	/* free up any rings and user-mapped pages */
+	for (i = 0; i < 3; i++) {
+		if (igb_priv->uring_tx_init & (1 << i)) {
+			if (adapter->uring_tx_init & (1 << i)) {
+				igb_free_tx_resources(adapter->tx_ring[i]);
+			} else {
+				printk("Warning: invalid tx ring buffer state!\n");
+			}
+			adapter->uring_tx_init &= ~(1 << i);
+			igb_priv->uring_tx_init &= ~(1 << i);
+		}
+	}
+
+	for (i = 0; i < 3; i++) {
+		if (igb_priv->uring_rx_init & (1 << i)) {
+			if (adapter->uring_rx_init & (1 << i)) {
+				igb_free_rx_resources(adapter->rx_ring[i]);
+			} else {
+				printk("Warning: invalid rx ring buffer state!\n");
+			}
+			adapter->uring_rx_init &= ~(1 << i);
+			igb_priv->uring_rx_init &= ~(1 << i);
+		}
+	}
+
+	userpage = igb_priv->userpages;
 
 	while (userpage != NULL) {
 		dma_unmap_page(pci_dev_to_dev(adapter->pdev),
@@ -10482,15 +10616,18 @@ static int igb_close_file(struct inode *inode, struct file *file)
 		if (userpage->next)
 			userpage->next->prev = userpage->prev;
 
-		if (userpage == adapter->userpages)
-			adapter->userpages = userpage->next;
+		if (userpage == igb_priv->userpages)
+			igb_priv->userpages = userpage->next;
 
 		vfree(userpage);
-		userpage = adapter->userpages;
+		userpage = igb_priv->userpages;
 	}
 	mutex_unlock(&adapter->lock);
 
 	err = igb_unbind(file);
+out:
+	file->private_data = NULL;
+	kfree(igb_priv);
 	return err;
 }
 
@@ -10509,11 +10646,18 @@ static int igb_vm_fault(struct vm_area_struct *area, struct vm_fault *fdata)
 
 static int igb_mmap(struct file *file, struct vm_area_struct *vma)
 {
-	struct igb_adapter *adapter = file->private_data;
+	struct igb_private_data *igb_priv = file->private_data;
+	struct igb_adapter *adapter = NULL;
 	unsigned long size  = vma->vm_end - vma->vm_start;
 	dma_addr_t pgoff = vma->vm_pgoff;
 	dma_addr_t physaddr;
 
+	if (igb_priv == NULL) {
+		printk("cannot find private data!\n");
+		return -ENOENT;
+	}
+
+	adapter = igb_priv->adapter;
 	if (adapter == NULL)
 		return -ENODEV;
 


### PR DESCRIPTION
Buffers must be released by task that requested mapbuf ioctl.
It prevents kernel oops due to incorrect memory free.

- add igb_private_data struct.
- move userpage list from igb_adapter to igb_private_data struct.
- separate igb_mapbuf_user from igb_mapbuf due to error cover code.


kernel oops is occurred in below case.
This patch prevents kernel oops for this problem.
1.process A
call igb_attach()
--> bind success
call igb_attach_tx()
--> TX ring buffer allocation success.
call igb_dma_malloc_page() seven times.
--> userpages allocation success.
waiting..

2.process B
call igb_attach()
call igb_attach_tx()
--> Error because TX ring buffer was already allocated by "process A".
call igb_deatch()
--> igb_close_file() function will be called by close() operation.
--> Problem is all buffers that was allocated by "process A" will be freed.

So, kernel oops will be occured if memory operation is occured from the "process A".

[ 130.487749] BUG: unable to handle kernel paging request at 003c0010
[ 130.487759] IP: [] put_compound_page+0x2e/0x10b
[ 130.487763] *pdpt = 000000002ab2c001 *pde = 0000000000000000 
[ 130.487766] Oops: 0000 [#1] PREEMPT SMP 
~~ snip ~~
[ 130.487836] Call Trace: 
[ 130.487841] [] ? release_pages+0x52/0x164
[ 130.487846] [] ? tlb_flush_mmu+0x53/0x6b
[ 130.487850] [] ? unmap_single_vma+0x460/0x4e7
[ 130.487854] [] ? unmap_vmas+0x2d/0x42
[ 130.487858] [] ? unmap_region+0x64/0x9a
[ 130.487862] [] ? do_munmap+0x1da/0x246
[ 130.487866] [] ? vm_munmap+0x37/0x48
[ 130.487871] [] ? sysenter_do_call+0x12/0x26
~~ snip ~~
[ 130.487907] EIP: [] put_compound_page+0x2e/0x10b SS:ESP 0068:ed085e10
[ 130.487908] CR2: 00000000003c0010
[ 130.487911] ---[ end trace 853d980d1ce158f7 ]---
[ 130.487913] Kernel panic - not syncing: Fatal exception