### PR TITLE
Fixes to gPTP signaling message TLV values

### DIFF
--- a/daemons/gptp/common/avbts_message.hpp
+++ b/daemons/gptp/common/avbts_message.hpp
@@ -1059,16 +1059,16 @@ class SignallingTLV {
 	 */
 	SignallingTLV() {
 		tlvType = PLAT_htons(0x3);
-		lengthField = PLAT_htons(28);
+		lengthField = PLAT_htons(12);
 		organizationId[0] = '\x00';
 		organizationId[1] = '\x80';
 		organizationId[2] = '\xC2';
 		organizationSubType_ms = 0;
-		organizationSubType_ls = PLAT_htons(1);
+		organizationSubType_ls = PLAT_htons(2);
 		linkDelayInterval = 0;
 		timeSyncInterval = 0;
 		announceInterval = 0;
-		flags = 0;
+		flags = 3;
 		reserved = PLAT_htons(0);
 	}
 

--- a/daemons/gptp/common/ieee1588port.cpp
+++ b/daemons/gptp/common/ieee1588port.cpp
@@ -582,7 +582,7 @@ void IEEE1588Port::processEvent(Event e)
 				// Send an initial signalling message
 				PTPMessageSignalling *sigMsg = new PTPMessageSignalling(this);
 				if (sigMsg) {
-					sigMsg->setintervals(log_min_mean_pdelay_req_interval, log_mean_sync_interval, PTPMessageSignalling::sigMsgInterval_NoSend);
+					sigMsg->setintervals(PTPMessageSignalling::sigMsgInterval_NoSend, log_mean_sync_interval, PTPMessageSignalling::sigMsgInterval_NoSend);
 					sigMsg->sendPort(this, NULL);
 					delete sigMsg;
 				}
@@ -732,7 +732,7 @@ void IEEE1588Port::processEvent(Event e)
 				// Send an initial signaling message
 				PTPMessageSignalling *sigMsg = new PTPMessageSignalling(this);
 				if (sigMsg) {
-					sigMsg->setintervals(log_min_mean_pdelay_req_interval, log_mean_sync_interval, PTPMessageSignalling::sigMsgInterval_NoSend);
+					sigMsg->setintervals(PTPMessageSignalling::sigMsgInterval_NoSend, log_mean_sync_interval, PTPMessageSignalling::sigMsgInterval_NoSend);
 					sigMsg->sendPort(this, NULL);
 					delete sigMsg;
 				}
@@ -1202,7 +1202,10 @@ void IEEE1588Port::processEvent(Event e)
 				// Send operational signalling message
 					PTPMessageSignalling *sigMsg = new PTPMessageSignalling(this);
 					if (sigMsg) {
-						sigMsg->setintervals(log_min_mean_pdelay_req_interval, log_mean_sync_interval, PTPMessageSignalling::sigMsgInterval_NoChange);
+						if (automotive_profile)
+							sigMsg->setintervals(PTPMessageSignalling::sigMsgInterval_NoChange, log_mean_sync_interval, PTPMessageSignalling::sigMsgInterval_NoChange);
+						else 
+							sigMsg->setintervals(log_min_mean_pdelay_req_interval, log_mean_sync_interval, PTPMessageSignalling::sigMsgInterval_NoChange);
 						sigMsg->sendPort(this, NULL);
 						delete sigMsg;
 					}


### PR DESCRIPTION
Starting with Wireshark 2.0.5 the signaling message in gPTP is reported as Malformed due to an incorrect value for the LengthField.

As defined in 802.1AS 2011 section 10.5.4.3.3 LengthField the length value shall be 12.
Currently gPTP is sending an incorrect value of 28.

Additionally for the signaling message TLV: 
Organization Subtype is 0x1 in the packet but it should be 0x2
LinkDelayInterval is 0x0 but for the Automotive Profile should be 127
Flags field is 0x0 in the packet but should be 0x3