### PR TITLE
Open avb next - issue #460

### DIFF
--- a/daemons/gptp/common/avbts_message.hpp
+++ b/daemons/gptp/common/avbts_message.hpp
@@ -616,12 +616,19 @@ class scaledNs {
 	/**
 	 * @brief  Gets scaledNs in a byte string format
 	 * @param  byte_str [out] scaledNs value
-	 * @return void
+	 * @return 0 in case of success, -1 if an error occurs(invalid size)
 	 */
-	void toByteString(uint8_t * byte_str, size_t sizeof_byte_str_array) {
+	int toByteString(uint8_t * byte_str, size_t sizeof_byte_str_array) {
 
 		if(sizeof_byte_str_array >= sizeof(*this))
+		{
 			memcpy(byte_str, this, sizeof(*this));
+			return 0;
+		} else
+		{
+			/*the size is invalid, method returns an error*/
+			return -1;
+		}
 	}
 
 	/**
@@ -692,11 +699,19 @@ class FollowUpTLV {
 	/**
 	 * @brief  Gets FollowUpTLV information in a byte string format
 	 * @param  byte_str [out] FollowUpTLV values
+	 * @return 0 in case of success, -1 if an error occurs(invalid size)
 	 */
-	void toByteString(uint8_t * byte_str, size_t sizeof_byte_str_array) {
+	int toByteString(uint8_t * byte_str, size_t sizeof_byte_str_array) {
 
 		if(sizeof_byte_str_array >= sizeof(*this))
+		{
 			memcpy(byte_str, this, sizeof(*this));
+			return 0;
+		} else
+		{
+			/*the size is invalid, method returns an error*/
+			return -1;
+		}
 	}
 
 	/**
@@ -1080,11 +1095,19 @@ class SignallingTLV {
 	 * @brief  Gets Msg Interval Request TLV information in a byte
 	 *         string format
 	 * @param  byte_str [out] Msg Interval Request TLV values
+	 * @return 0 in case of success, -1 if an error occurs(invalid size)
 	 */
-	void toByteString(uint8_t * byte_str, size_t sizeof_byte_str_array) {
+	int toByteString(uint8_t * byte_str, size_t sizeof_byte_str_array) {
 
 		if(sizeof_byte_str_array >= sizeof(*this))
+		{
 			memcpy(byte_str, this, sizeof(*this));
+			return 0;
+		} else
+		{
+			/*the size is invalid, method returns an error*/
+			return -1;
+		}
 	}
 
 	/**

--- a/daemons/gptp/common/avbts_message.hpp
+++ b/daemons/gptp/common/avbts_message.hpp
@@ -618,8 +618,10 @@ class scaledNs {
 	 * @param  byte_str [out] scaledNs value
 	 * @return void
 	 */
-	void toByteString(uint8_t * byte_str) {
-		memcpy(byte_str, this, sizeof(*this));
+	void toByteString(uint8_t * byte_str, size_t sizeof_byte_str_array) {
+
+		if(sizeof_byte_str_array >= sizeof(*this))
+			memcpy(byte_str, this, sizeof(*this));
 	}
 
 	/**
@@ -691,8 +693,10 @@ class FollowUpTLV {
 	 * @brief  Gets FollowUpTLV information in a byte string format
 	 * @param  byte_str [out] FollowUpTLV values
 	 */
-	void toByteString(uint8_t * byte_str) {
-		memcpy(byte_str, this, sizeof(*this));
+	void toByteString(uint8_t * byte_str, size_t sizeof_byte_str_array) {
+
+		if(sizeof_byte_str_array >= sizeof(*this))
+			memcpy(byte_str, this, sizeof(*this));
 	}
 
 	/**
@@ -1077,8 +1081,10 @@ class SignallingTLV {
 	 *         string format
 	 * @param  byte_str [out] Msg Interval Request TLV values
 	 */
-	void toByteString(uint8_t * byte_str) {
-		memcpy(byte_str, this, sizeof(*this));
+	void toByteString(uint8_t * byte_str, size_t sizeof_byte_str_array) {
+
+		if(sizeof_byte_str_array >= sizeof(*this))
+			memcpy(byte_str, this, sizeof(*this));
 	}
 
 	/**

--- a/daemons/gptp/common/ptp_message.cpp
+++ b/daemons/gptp/common/ptp_message.cpp
@@ -899,8 +899,11 @@ void PTPMessageFollowUp::sendPort(IEEE1588Port * port,
 	tlv.setGMTimeBaseIndicator(tbi_NO);
 
 	size_t available_size = sizeof(buf_t) - (PTP_COMMON_HDR_LENGTH + PTP_FOLLOWUP_LENGTH
-						+port->getPayloadOffset());
-	tlv.toByteString(buf_ptr + PTP_COMMON_HDR_LENGTH + PTP_FOLLOWUP_LENGTH, available_size);
+						+ port->getPayloadOffset());
+	int result = tlv.toByteString(buf_ptr + PTP_COMMON_HDR_LENGTH + PTP_FOLLOWUP_LENGTH,
+						 available_size);
+	if(result != 0)
+		GPTP_LOG_ERROR("toByteString returned an error - invalid size passed");
 
 	GPTP_LOG_VERBOSE
 		("Follow-Up Time: %u seconds(hi)", preciseOriginTimestamp.seconds_ms);
@@ -1767,7 +1770,10 @@ void PTPMessageSignalling::sendPort(IEEE1588Port * port, PortIdentity * destIden
 
 	size_t available_size = sizeof(buf_t) - (PTP_COMMON_HDR_LENGTH + PTP_SIGNALLING_LENGTH
 						+ port->getPayloadOffset());
-	tlv.toByteString(buf_ptr + PTP_COMMON_HDR_LENGTH + PTP_SIGNALLING_LENGTH, available_size);
+	int result = tlv.toByteString(buf_ptr + PTP_COMMON_HDR_LENGTH + PTP_SIGNALLING_LENGTH,
+						 available_size);
+	if(result != 0)
+		GPTP_LOG_ERROR("toByteString returned an error - invalid size passed");
 
 	port->sendGeneralPort(PTP_ETHERTYPE, buf_t, messageLength, MCAST_OTHER, destIdentity);
 }

--- a/daemons/gptp/common/ptp_message.cpp
+++ b/daemons/gptp/common/ptp_message.cpp
@@ -774,8 +774,8 @@ void PTPMessageAnnounce::sendPort(IEEE1588Port * port,
 	       &stepsRemoved_l, sizeof(stepsRemoved));
 	memcpy(buf_ptr + PTP_ANNOUNCE_TIME_SOURCE(PTP_ANNOUNCE_OFFSET),
 	       &timeSource, sizeof(timeSource));
+	
 	tlv.toByteString(buf_ptr + PTP_COMMON_HDR_LENGTH + PTP_ANNOUNCE_LENGTH);
-
 	port->sendGeneralPort(PTP_ETHERTYPE, buf_t, messageLength, MCAST_OTHER, destIdentity);
 	port->incCounter_ieee8021AsPortStatTxAnnounce();
 
@@ -897,7 +897,10 @@ void PTPMessageFollowUp::sendPort(IEEE1588Port * port,
 	/*Change time base indicator to Network Order before sending it*/
 	uint16_t tbi_NO = PLAT_htonl(tlv.getGMTimeBaseIndicator());
 	tlv.setGMTimeBaseIndicator(tbi_NO);
-	tlv.toByteString(buf_ptr + PTP_COMMON_HDR_LENGTH + PTP_FOLLOWUP_LENGTH);
+
+	size_t available_size = sizeof(buf_t) - (PTP_COMMON_HDR_LENGTH + PTP_FOLLOWUP_LENGTH
+						+port->getPayloadOffset());
+	tlv.toByteString(buf_ptr + PTP_COMMON_HDR_LENGTH + PTP_FOLLOWUP_LENGTH, available_size);
 
 	GPTP_LOG_VERBOSE
 		("Follow-Up Time: %u seconds(hi)", preciseOriginTimestamp.seconds_ms);
@@ -1762,7 +1765,9 @@ void PTPMessageSignalling::sendPort(IEEE1588Port * port, PortIdentity * destIden
 	memcpy(buf_ptr + PTP_SIGNALLING_TARGET_PORT_IDENTITY(PTP_SIGNALLING_OFFSET),
 	       &targetPortIdentify, sizeof(targetPortIdentify));
 
-	tlv.toByteString(buf_ptr + PTP_COMMON_HDR_LENGTH + PTP_SIGNALLING_LENGTH);
+	size_t available_size = sizeof(buf_t) - (PTP_COMMON_HDR_LENGTH + PTP_SIGNALLING_LENGTH
+						+ port->getPayloadOffset());
+	tlv.toByteString(buf_ptr + PTP_COMMON_HDR_LENGTH + PTP_SIGNALLING_LENGTH, available_size);
 
 	port->sendGeneralPort(PTP_ETHERTYPE, buf_t, messageLength, MCAST_OTHER, destIdentity);
 }


### PR DESCRIPTION
This is a proposed solution for Andrew Elder's suggestion: changes made to "toByteString()" methods in gptp/common/avbts_message.hpp and gptp/common/ptp_message.cpp:

a) Added a sizeof_byte_str_array parameter to all three "toByteString" methods (SignallingTLV and FollowupTLV are used, scaledNS has been altered for future reference and consistency purposes)

b) A separate "available_size" variable is being created before each of the method invocation . It is being initialized with space left available in the buffer (buf_t) to which the data is being copied further on 
