### PR TITLE
Change link up handling of hardware timestamper

### DIFF
--- a/daemons/gptp/common/avbts_port.hpp
+++ b/daemons/gptp/common/avbts_port.hpp
@@ -1139,6 +1139,12 @@ class IEEE1588Port {
 	void timestamper_init(void);
 
 	/**
+	 * @brief Resets the hwtimestamper
+	 */
+	void timestamper_reset(void);
+
+
+	/**
 	 * @brief  Gets RX timestamp based on port identity
 	 * @param  sourcePortIdentity [in] Source port identity
 	 * @param  sequenceId Sequence ID

--- a/daemons/gptp/common/ieee1588.hpp
+++ b/daemons/gptp/common/ieee1588.hpp
@@ -478,6 +478,13 @@ public:
 		{ return true; }
 
 	/**
+	 * @brief Reset the hardware timestamp unit
+	 * @return void
+	 */
+	virtual void HWTimestamper_reset(void) {
+	}
+
+	/**
 	 * @brief  This method is called before the object is de-allocated.
 	 * @return void
 	 */

--- a/daemons/gptp/common/ieee1588port.cpp
+++ b/daemons/gptp/common/ieee1588port.cpp
@@ -207,6 +207,13 @@ void IEEE1588Port::timestamper_init(void)
 	}
 }
 
+void IEEE1588Port::timestamper_reset(void)
+{
+	if( _hw_timestamper != NULL ) {
+		_hw_timestamper->init_phy_delay(this->link_delay);
+	}
+}
+
 bool IEEE1588Port::init_port(int delay[4])
 {
 	if (!OSNetworkInterfaceFactory::buildInterface
@@ -764,7 +771,7 @@ void IEEE1588Port::processEvent(Event e)
 				linkUpCount++;
 			}
 		}
-		this->timestamper_init();
+		this->timestamper_reset();
 		break;
 
 	case LINKDOWN:

--- a/daemons/gptp/common/ieee1588port.cpp
+++ b/daemons/gptp/common/ieee1588port.cpp
@@ -211,6 +211,7 @@ void IEEE1588Port::timestamper_reset(void)
 {
 	if( _hw_timestamper != NULL ) {
 		_hw_timestamper->init_phy_delay(this->link_delay);
+		_hw_timestamper->HWTimestamper_reset();
 	}
 }
 

--- a/daemons/gptp/linux/src/linux_hal_generic.cpp
+++ b/daemons/gptp/linux/src/linux_hal_generic.cpp
@@ -269,6 +269,13 @@ bool LinuxTimestamperGeneric::HWTimestamper_init
 	return true;
 }
 
+void LinuxTimestamperGeneric::HWTimestamper_reset()
+{
+	if( !resetFrequencyAdjustment() ) {
+		GPTP_LOG_ERROR( "Failed to reset (zero) frequency adjustment" );
+	}
+}
+
 int LinuxTimestamperGeneric::HWTimestamper_txtimestamp
 ( PortIdentity *identity, uint16_t sequenceId, Timestamp &timestamp,
   unsigned &clock_value, bool last ) {

--- a/daemons/gptp/linux/src/linux_hal_generic.hpp
+++ b/daemons/gptp/linux/src/linux_hal_generic.hpp
@@ -103,6 +103,12 @@ public:
 	( InterfaceLabel *iface_label, OSNetworkInterface *iface );
 
 	/**
+	 * @brief  Reset the Hardware timestamp interface
+	 * @return void
+	 */
+	virtual void HWTimestamper_reset();
+
+	/**
 	 * @brief  Inserts a new timestamp to the beginning of the
 	 * RX timestamp list.
 	 * @param tstamp [in] RX timestamp


### PR DESCRIPTION
As per issue #436 there are some problems with the way we were calling `timestamper_init` when we received link up events. That function is only designed to be called once, and causes resource leaks when called multiple times.

These patches create a 'reset' interface to the timestamper and call that instead on link up events. For the moment, it only resets the frequency adjustment, but if there are other useful things that need to happen when the link is restored we'll have a safe place to add them.