### PR TITLE
igb: Fix alloc size for igb_private_data

### DIFF
--- a/kmod/igb/igb_main.c
+++ b/kmod/igb/igb_main.c
@@ -10542,7 +10542,7 @@ static int igb_open_file(struct inode *inode, struct file *file)
        struct igb_private_data *igb_priv = NULL;
        int ret = 0;
 
-       igb_priv = kzalloc(sizeof(struct igb_private_data *), GFP_KERNEL);
+       igb_priv = kzalloc(sizeof(struct igb_private_data), GFP_KERNEL);
        if (igb_priv == NULL) {
                ret = -ENOMEM;
                goto out;


### PR DESCRIPTION
Previous allocation was for the size of a pointer, not the structure.
This caused kernel memory corruption when the igb_avb driver was used
for streaming.

This should fix issue #474 