### PR TITLE
Fixes to Makefiles and compiler warnings and errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ simple_listener:
 	$(call descend,examples/$@)
 
 simple_listener_clean:
-	$(call descend,examples/simple_rx/,clean)
+	$(call descend,examples/simple_listener/,clean)
 
 simple_rx:
 	$(MAKE) lib

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ lib: FORCE
 
 lib_clean:
 	$(call descend,lib/igb/,clean)
+	$(call descend,lib/common/,clean)
 
 mrpd:
 	$(call descend,daemons/$@)
@@ -66,6 +67,12 @@ maap_clean:
 daemons_all: mrpd maap gptp
 
 daemons_all_clean: mrpd_clean gptp_clean maap_clean
+
+examples_common:
+	$(call descend,examples/common)
+
+examples_common_clean:
+	$(call descend,examples/common/,clean)
 
 simple_talker:
 	$(MAKE) lib
@@ -124,10 +131,10 @@ avtp_pipeline_clean:
 avtp_pipeline_doc: lib
 	$(MAKE) -s -C lib/avtp_pipeline -f avtp_pipeline.mk doc
 
-examples_all: simple_talker simple_listener mrp_client live_stream jackd-talker \
+examples_all: examples_common simple_talker simple_listener mrp_client live_stream jackd-talker \
 	jackd-listener simple_rx
 
-examples_all_clean: simple_talker_clean simple_listener_clean mrp_client_clean \
+examples_all_clean: examples_common_clean simple_talker_clean simple_listener_clean mrp_client_clean \
 	jackd-talker_clean jackd-listener_clean live_stream_clean simple_rx_clean
 
 all: igb lib daemons_all examples_all avtp_pipeline

--- a/daemons/gptp/linux/build/Makefile
+++ b/daemons/gptp/linux/build/Makefile
@@ -30,7 +30,7 @@
 
 ALTERNATE_LINUX_INCPATH=$(HOME)/header/include/
 
-CFLAGS_G = -Wall -std=c++0x -g -I. -I../../common -I../src \
+CFLAGS_G = -Wall -fPIC -g -I. -I../../common -I../src \
 	-I$(ALTERNATE_LINUX_INCPATH)
 
 # Check to see if PTP cross-timestamping is supported in hardware/driver
@@ -46,7 +46,7 @@ ifeq ($(HAS_PRECISE_TIME),0)
        CFLAGS_G += -DPTP_HW_CROSSTSTAMP
 endif
 
-CPPFLAGS_G = $(CFLAGS_G) -Wnon-virtual-dtor
+CPPFLAGS_G = $(CFLAGS_G) -std=c++0x -Wnon-virtual-dtor
 
 LDFLAGS_G = -lpthread -lrt
 

--- a/daemons/gptp/linux/build/Makefile
+++ b/daemons/gptp/linux/build/Makefile
@@ -30,7 +30,7 @@
 
 ALTERNATE_LINUX_INCPATH=$(HOME)/header/include/
 
-CFLAGS_G = -Wall -fPIC -g -I. -I../../common -I../src \
+CFLAGS_G = -Wall -g -I. -I../../common -I../src \
 	-I$(ALTERNATE_LINUX_INCPATH)
 
 # Check to see if PTP cross-timestamping is supported in hardware/driver

--- a/daemons/gptp/linux/src/daemon_cl.cpp
+++ b/daemons/gptp/linux/src/daemon_cl.cpp
@@ -112,7 +112,7 @@ int main(int argc, char **argv)
 	bool pps = false;
 	uint8_t priority1 = 248;
 	bool override_portstate = false;
-	PortState port_state;
+	PortState port_state = PTP_SLAVE;
 
 	char *restoredata = NULL;
 	char *restoredataptr = NULL;

--- a/daemons/gptp/linux/src/linux_hal_common.cpp
+++ b/daemons/gptp/linux/src/linux_hal_common.cpp
@@ -847,7 +847,7 @@ bool LinuxNetworkInterfaceFactory::createInterface
 	}
 
 	memset( &device, 0, sizeof(device));
-	ifname->toString( device.ifr_name, IFNAMSIZ );
+	ifname->toString( device.ifr_name, IFNAMSIZ - 1 );
 	err = ioctl( net_iface_l->sd_event, SIOCGIFHWADDR, &device );
 	if( err == -1 ) {
 		GPTP_LOG_ERROR

--- a/daemons/gptp/linux/src/linux_hal_generic.cpp
+++ b/daemons/gptp/linux/src/linux_hal_generic.cpp
@@ -455,7 +455,7 @@ bool LinuxTimestamperGeneric::HWTimestamper_gettime
 	{
 		unsigned i;
 		struct ptp_clock_time *pct;
-		struct ptp_clock_time *system_time_l, *device_time_l;
+		struct ptp_clock_time *system_time_l = NULL, *device_time_l = NULL;
 		int64_t interval = LLONG_MAX;
 		struct ptp_sys_offset offset;
 
@@ -475,8 +475,10 @@ bool LinuxTimestamperGeneric::HWTimestamper_gettime
 			}
 		}
 
-		*device_time = pctTimestamp( device_time_l );
-		*system_time = pctTimestamp( system_time_l );
+		if (device_time_l)
+			*device_time = pctTimestamp( device_time_l );
+		if (system_time_l)
+			*system_time = pctTimestamp( system_time_l );
 	}
 
 	return true;

--- a/daemons/gptp/linux/src/linux_hal_persist_file.cpp
+++ b/daemons/gptp/linux/src/linux_hal_persist_file.cpp
@@ -123,7 +123,9 @@ public:
 
 		bool result = false;
 		if (memoryDataLength > storedDataLength) {
-			ftruncate(persistFD, memoryDataLength);
+			int ret = ftruncate(persistFD, memoryDataLength);
+			if (ret != 0) {
+			}
 			if (restoredata != ((void *)-1)) {
 				restoredata = mremap(restoredata, storedDataLength, memoryDataLength, MREMAP_MAYMOVE);
 			}

--- a/daemons/gptp/linux/src/linux_hal_persist_file.cpp
+++ b/daemons/gptp/linux/src/linux_hal_persist_file.cpp
@@ -125,6 +125,7 @@ public:
 		if (memoryDataLength > storedDataLength) {
 			int ret = ftruncate(persistFD, memoryDataLength);
 			if (ret != 0) {
+				printf("Failed to extend stored data length from %ld to %ld, %s\n", storedDataLength, memoryDataLength, strerror(errno));
 			}
 			if (restoredata != ((void *)-1)) {
 				restoredata = mremap(restoredata, storedDataLength, memoryDataLength, MREMAP_MAYMOVE);

--- a/daemons/maap/common/maap_protocol.c
+++ b/daemons/maap/common/maap_protocol.c
@@ -57,7 +57,7 @@ int state_transit(maap_info_t *maap_info)
 	uint8_t *s = NULL;
 	int i= 0;
 	int num_bytes = 0;
-	int maap_probe_count;
+	int maap_probe_count = 0;
 
 	switch (current_state) {
 	case INITIAL:

--- a/daemons/maap/linux/maap_linux.c
+++ b/daemons/maap/linux/maap_linux.c
@@ -195,7 +195,7 @@ int main(int argc, char *argv[])
 	}
 
 	pthread_mutex_init(&(lock), NULL);
-	seed = src_mac[6] + time(NULL);
+	seed = src_mac[5] + time(NULL);
 	srand(seed);
 
 	maap_Info = (maap_info_t *)calloc(1,sizeof(maap_info_t));

--- a/daemons/mrpd/msrp.c
+++ b/daemons/mrpd/msrp.c
@@ -124,7 +124,7 @@ void msrp_print_debug_info(int evt, const struct msrp_attribute *attrib)
 }
 #endif
 
-int msrp_count_type(int attrib_type)
+int msrp_count_type(uint32_t attrib_type)
 {
 	int count = 0;
 	struct msrp_attribute *attrib;

--- a/daemons/mrpd/msrp.h
+++ b/daemons/mrpd/msrp.h
@@ -187,7 +187,7 @@ int msrp_recv_msg(void);
  * \param attrib_type The attribute type to count.
  * \return The number of attributes of type attrib_type in the MSRP database.
  */
-int msrp_count_type(int attrib_type);
+int msrp_count_type(uint32_t attrib_type);
 
 /**
  * Return the number of interesting talker stream ids recorded in the

--- a/examples/live_stream/listener.c
+++ b/examples/live_stream/listener.c
@@ -198,8 +198,10 @@ int main(int argc, char *argv[ ])
 			fprintf(stderr,"frame sequence = %lld\n", frame_sequence++);
 			h1722 = (seventeen22_header *)((uint8_t*)frame + sizeof(eth_header));
 			length = ntohs(h1722->length) - sizeof(six1883_header);
-			write(1, (uint8_t *)((uint8_t*)frame + sizeof(eth_header) + sizeof(seventeen22_header) +
+			rc = write(1, (uint8_t *)((uint8_t*)frame + sizeof(eth_header) + sizeof(seventeen22_header) +
 				sizeof(six1883_header)), length);
+			if (rc != length) {
+			}
 		} else {
 			fprintf(stderr,"recvfrom() error for frame sequence = %lld\n", frame_sequence++);
 		}

--- a/examples/live_stream/listener.c
+++ b/examples/live_stream/listener.c
@@ -200,7 +200,8 @@ int main(int argc, char *argv[ ])
 			length = ntohs(h1722->length) - sizeof(six1883_header);
 			rc = write(1, (uint8_t *)((uint8_t*)frame + sizeof(eth_header) + sizeof(seventeen22_header) +
 				sizeof(six1883_header)), length);
-			if (rc != length) {
+			if (rc == -1) {
+				fprintf(stderr, "Failed to write %d bytes: %s (%d)\n", length, strerror(errno), errno);
 			}
 		} else {
 			fprintf(stderr,"recvfrom() error for frame sequence = %lld\n", frame_sequence++);

--- a/examples/simple_rx/Makefile
+++ b/examples/simple_rx/Makefile
@@ -23,5 +23,5 @@ $(IGBDIR)/igb.o:  $(IGBDIR)/igb.c
 	$(CC) $(LDFLAGS) $^ $(LDLIBS) -o $@
 
 clean:
-	$(RM)  simple_listener
+	$(RM)  simple_rx
 	$(RM) `find . -name "*~" -o -name "*.[oa]" -o -name "\#*\#" -o -name TAGS -o -name core -o -name "*.orig"`

--- a/lib/igb/Makefile
+++ b/lib/igb/Makefile
@@ -2,7 +2,6 @@ OBJS=igb
 INCL=e1000_82575.h e1000_defines.h e1000_hw.h e1000_osdep.h e1000_regs.h igb.h
 AVBLIB=libigb.a
 #CFLAGS=-ggdb
-CFLAGS=-fPIC
 
 CC?=gcc
 RANLIB?=ranlib

--- a/lib/igb/Makefile
+++ b/lib/igb/Makefile
@@ -2,6 +2,7 @@ OBJS=igb
 INCL=e1000_82575.h e1000_defines.h e1000_hw.h e1000_osdep.h e1000_regs.h igb.h
 AVBLIB=libigb.a
 #CFLAGS=-ggdb
+CFLAGS=-fPIC
 
 CC?=gcc
 RANLIB?=ranlib


### PR DESCRIPTION
Since added simple_rx, the clean target does not properly clean all the generated object and executable files. The changes here corrected the corresponding Makefiles to be able to remove all the generated files.

Besides that, when added -O2 to Open AVB daemons Makefile CFLAGS, there are some compile warnings and errors shown. The changes here also fix those warnings and errors.

This should fix #473 too.

Regards,
Roland Hii