### PR TITLE
Enable C++11 support in CppUTest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,17 @@ git:
 before_install:
   - sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
   - git submodule update --init --recursive
+  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
   - sudo apt-get update -qq
-  - sudo apt-get install doxygen graphviz
+  - sudo apt-get install doxygen graphviz gcc-4.8 g++-4.8
+  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.6 10
+  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 20
+  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.6 10
+  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 20
+  - sudo update-alternatives --install /usr/bin/cc cc /usr/bin/gcc 30
+  - sudo update-alternatives --set cc /usr/bin/gcc
+  - sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++ 30
+  - sudo update-alternatives --set c++ /usr/bin/g++
 compiler:
   - gcc
 env: BUILD_KERNEL=3.13.0-36-generic

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required (VERSION 2.8) 
 project (open-avb)
 enable_testing()
+
+set(C++11 ON CACHE BOOL "Compile with C++11 support" FORCE)
 add_subdirectory("thirdparty/cpputest")
 add_subdirectory("daemons/common/tests")
 add_subdirectory("daemons/mrpd")

--- a/daemons/mrpd/tests/simple/parse_tests.cpp
+++ b/daemons/mrpd/tests/simple/parse_tests.cpp
@@ -70,7 +70,7 @@ TEST(ParseTestGroup, TestParse_null)
 	int err_index;
 	int status;
 	struct parse_param specs[] = {
-		{ "C" PARSE_ASSIGN, parse_null, &value },
+		{ (char*)"C" PARSE_ASSIGN, parse_null, &value },
 		{ 0, parse_null, 0 }};
 	const char strz[] = "C=1234";
 
@@ -96,7 +96,7 @@ TEST(ParseTestGroup, TestParse_u8)
 	int err_index;
 	int status;
 	struct parse_param specs[] = {
-		{ "C" PARSE_ASSIGN, parse_u8, &value },
+		{ (char*)"C" PARSE_ASSIGN, parse_u8, &value },
 		{ 0, parse_null, 0 } };
 	char strz[64];
 	int i;
@@ -147,7 +147,7 @@ TEST(ParseTestGroup, TestParse_u16)
 	int err_index;
 	int status;
 	struct parse_param specs[] = {
-		{ "C" PARSE_ASSIGN, parse_u16, &value },
+		{ (char*)"C" PARSE_ASSIGN, parse_u16, &value },
 		{ 0, parse_null, 0 } };
 	char strz[64];
 	int i;
@@ -197,7 +197,7 @@ TEST(ParseTestGroup, TestParse_u16_04x)
 	int err_index;
 	int status;
 	struct parse_param specs[] = {
-		{ "C" PARSE_ASSIGN, parse_u16_04x, &value },
+		{ (char*)"C" PARSE_ASSIGN, parse_u16_04x, &value },
 		{ 0, parse_null, 0 } };
 	char strz[64];
 	int i;
@@ -247,7 +247,7 @@ TEST(ParseTestGroup, TestParse_u32)
 	int err_index;
 	int status;
 	struct parse_param specs[] = {
-		{ "C" PARSE_ASSIGN, parse_u32, &value },
+		{ (char*)"C" PARSE_ASSIGN, parse_u32, &value },
 		{ 0, parse_null, 0 } };
 	char strz[64];
 	int i;
@@ -298,13 +298,13 @@ TEST(ParseTestGroup, TestParse_u64)
 	int err_index;
 	int status;
 	struct parse_param specsu[] = {
-		{ "C" PARSE_ASSIGN, parse_u64, &value },
+		{ (char*)"C" PARSE_ASSIGN, parse_u64, &value },
 		{ 0, parse_null, 0 } };
 	struct parse_param specsx[] = {
-		{ "C" PARSE_ASSIGN, parse_h64, &value },
+		{ (char*)"C" PARSE_ASSIGN, parse_h64, &value },
 		{ 0, parse_null, 0 } };
 	struct parse_param specsc[] = {
-		{ "C" PARSE_ASSIGN, parse_c64, &stream_id },
+		{ (char*)"C" PARSE_ASSIGN, parse_c64, &stream_id },
 		{ 0, parse_null, 0 } };
 	char strz[64];
 	int i, j;


### PR DESCRIPTION
This is a fix for #448 

It enables C++11 support in the CppUTest build via a change to the top-level CMakeLists.txt file, and also fixes some warnings from our MRPD unit tests that showed up as a result of the change.