### PR TITLE
gPTP: remove accelerated SYNC send on startup. See discussion in #465.

### DIFF
--- a/daemons/gptp/common/avbts_port.hpp
+++ b/daemons/gptp/common/avbts_port.hpp
@@ -219,9 +219,6 @@ typedef struct {
 	/* forceSlave Forces port to be slave  */
 	bool forceSlave;
 
-	/* accelerated_sync_count If non-zero, then start 16ms sync timer */
-	int accelerated_sync_count;
-
 	/* timestamper Hardware timestamper instance */
 	HWTimestamper * timestamper;
 
@@ -319,7 +316,6 @@ class IEEE1588Port {
 	char log_min_mean_delay_req_interval;
 	char log_min_mean_pdelay_req_interval;
 	bool burst_enabled;
-	int _accelerated_sync_count;
 	static const int64_t ONE_WAY_DELAY_DEFAULT = 3600000000000;
 	static const int64_t INVALID_LINKDELAY = 3600000000000;
 	static const int64_t NEIGHBOR_PROP_DELAY_THRESH = 800;
@@ -620,7 +616,6 @@ class IEEE1588Port {
 	 * @param  clock IEEE1588Clock instance
 	 * @param  index Interface index
 	 * @param  forceSlave Forces port to be slave
-	 * @param  accelerated_sync_count If non-zero, then start 16ms sync timer
 	 * @param  timestamper Hardware timestamper instance
 	 * @param  offset  Initial clock offset
 	 * @param  net_label Network label
@@ -631,7 +626,7 @@ class IEEE1588Port {
 	 */
 	IEEE1588Port
 	(IEEE1588Clock * clock, uint16_t index,
-	 bool forceSlave, int accelerated_sync_count,
+	 bool forceSlave,
 	 HWTimestamper * timestamper,
 	 int32_t offset, InterfaceLabel * net_label,
 	 OSConditionFactory * condition_factory,

--- a/daemons/gptp/linux/src/daemon_cl.cpp
+++ b/daemons/gptp/linux/src/daemon_cl.cpp
@@ -65,7 +65,7 @@ void gPTPPersistWriteCB(char *bufPtr, uint32_t bufSize);
 void print_usage( char *arg0 ) {
 	fprintf( stderr,
 			"%s <network interface> [-S] [-P] [-M <filename>] "
-			"[-A <count>] [-G <group>] [-R <priority 1>] "
+			"[-G <group>] [-R <priority 1>] "
 			"[-D <gb_tx_delay,gb_rx_delay,mb_tx_delay,mb_rx_delay>] "
 			"[-T] [-L] [-E] [-GM] [-INITSYNC <value>] [-OPERSYNC <value>] "
 			"[-INITPDELAY <value>] [-OPERPDELAY <value>] "
@@ -77,7 +77,6 @@ void print_usage( char *arg0 ) {
 		  "\t-S start syntonization\n"
 		  "\t-P pulse per second\n"
 		  "\t-M <filename> save/restore state\n"
-		  "\t-A <count> initial accelerated sync count\n"
 		  "\t-G <group> group id for shared memory\n"
 		  "\t-R <priority 1> priority 1 value\n"
 		  "\t-D Phy Delay <gb_tx_delay,gb_rx_delay,mb_tx_delay,mb_rx_delay>\n"
@@ -120,7 +119,6 @@ int main(int argc, char **argv)
 	off_t restoredatacount = 0;
 	bool restorefailed = false;
 	LinuxIPCArg *ipc_arg = NULL;
-	int accelerated_sync_count = 0;
 	bool use_config_file = false;
 	char config_file_path[512];
 	memset(config_file_path, 0, 512);
@@ -130,7 +128,6 @@ int main(int argc, char **argv)
 	portInit.clock = NULL;
 	portInit.index = 0;
 	portInit.forceSlave = false;
-	portInit.accelerated_sync_count = 0;
 	portInit.timestamper = NULL;
 	portInit.offset = 0;
 	portInit.net_label = NULL;
@@ -205,14 +202,6 @@ int main(int argc, char **argv)
 				else {
 					printf( "Restore file must be specified on "
 							"command line\n" );
-				}
-			}
-			else if( strcmp(argv[i] + 1,  "A" ) == 0 ) {
-				if( i+1 < argc ) {
-					accelerated_sync_count = atoi( argv[++i] );
-				} else {
-					printf( "Accelerated sync count must be specified on the "
-							"command line with A option\n" );
 				}
 			}
 			else if( strcmp(argv[i] + 1,  "G") == 0 ) {
@@ -353,7 +342,6 @@ int main(int argc, char **argv)
 	portInit.clock = pClock;
 	portInit.index = 1;
 	portInit.forceSlave = false;
-	portInit.accelerated_sync_count = accelerated_sync_count;
 	portInit.timestamper = timestamper;
 	portInit.offset = 0;
 	portInit.net_label = ifname;

--- a/daemons/gptp/windows/daemon_cl/daemon_cl.cpp
+++ b/daemons/gptp/windows/daemon_cl/daemon_cl.cpp
@@ -84,7 +84,6 @@ int _tmain(int argc, _TCHAR* argv[])
 	portInit.clock = NULL;
 	portInit.index = 1;
 	portInit.forceSlave = false;
-	portInit.accelerated_sync_count = 0;
 	portInit.timestamper = NULL;
 	portInit.offset = 0;
 	portInit.net_label = NULL;


### PR DESCRIPTION
Completely remove accelerated sync on gPTP daemon startup. I think I have covered everything - comments welcomed.