### PR TITLE
gPTP: IEEE1588Port::processEvent(), start and stop pDelay on LINKUP/D…

### DIFF
--- a/daemons/gptp/common/ieee1588port.cpp
+++ b/daemons/gptp/common/ieee1588port.cpp
@@ -712,6 +712,8 @@ void IEEE1588Port::processEvent(Event e)
 		break;
 
 	case LINKUP:
+		haltPdelay(false);
+		startPDelay();
 		if (automotive_profile) {
 			GPTP_LOG_EXCEPTION("LINKUP");
 		}
@@ -771,6 +773,8 @@ void IEEE1588Port::processEvent(Event e)
 		break;
 
 	case LINKDOWN:
+		setAsCapable(false);
+		stopPDelay();
 		if (automotive_profile) {
 			GPTP_LOG_EXCEPTION("LINK DOWN");
 		}

--- a/daemons/gptp/common/ieee1588port.cpp
+++ b/daemons/gptp/common/ieee1588port.cpp
@@ -773,12 +773,12 @@ void IEEE1588Port::processEvent(Event e)
 		break;
 
 	case LINKDOWN:
-		setAsCapable(false);
 		stopPDelay();
 		if (automotive_profile) {
 			GPTP_LOG_EXCEPTION("LINK DOWN");
 		}
 		else {
+			setAsCapable(false);
 			GPTP_LOG_STATUS("LINK DOWN");
 		}
 		if (testMode) {


### PR DESCRIPTION
…OWN events

Without stopping pDelay timers, continuous log output is generated when
the network cable is disconnected.