### PR TITLE
MRP: BUGFIX - memory leak in MSRP when checking for interesting streams

### DIFF
--- a/daemons/mrpd/msrp.c
+++ b/daemons/mrpd/msrp.c
@@ -628,6 +628,9 @@ int msrp_event(int event, struct msrp_attribute *rattrib)
 #if LOG_MSRP
 			msrp_print_debug_info(event, attrib);
 #endif
+		} else {
+			/* free this attrib if we are not interested */
+			free(rattrib);
 		}
 
 		break;


### PR DESCRIPTION
Note: This memory leak only occurs if TalkerAdv stream pruning is active
(cmdline option -p). Attributes that were selected to be pruned during
event processing were not being free'd.