### PR TITLE
gPTP: use message type in combination with sequence ID to uniquely id…

### DIFF
--- a/daemons/gptp/common/avbts_message.hpp
+++ b/daemons/gptp/common/avbts_message.hpp
@@ -165,6 +165,44 @@ enum MulticastType {
 	MCAST_OTHER
 };
 
+class PTPMessageId {
+	MessageType _messageType;
+	uint16_t _sequenceId;
+public:
+	PTPMessageId() { };
+	PTPMessageId(MessageType messageType, uint16_t sequenceId) :
+		_messageType(messageType),_sequenceId(sequenceId) { }
+	PTPMessageId(const PTPMessageId& a) {
+		_messageType = a._messageType;
+		_sequenceId = a._sequenceId;
+	}
+
+	MessageType getMessageType(void) {
+		return _messageType;
+	}
+	void setMessageType(MessageType messageType) {
+		_messageType = messageType;
+	}
+
+	uint16_t getSequenceId(void) {
+		return _sequenceId;
+	}
+	void setSequenceId(uint16_t sequenceId) {
+		_sequenceId = sequenceId;
+	}
+
+	bool operator!=(const PTPMessageId & cmp) const {
+		return
+			this->_sequenceId != cmp._sequenceId ||
+			this->_messageType != cmp._messageType ? true : false;
+	}
+	bool operator==(const PTPMessageId & cmp)const {
+		return
+			this->_sequenceId == cmp._sequenceId &&
+			this->_messageType == cmp._messageType ? true : false;
+	}
+};
+
 /**
  * @brief Provides the PTPMessage common interface used during building of
  * PTP messages.
@@ -237,6 +275,13 @@ protected:
 		return messageType;
 	}
 
+	/**
+	 * @brief  Gets the MessageID of the PTP message.
+	 * @return MessageId
+	 */
+	PTPMessageId getMessageId(void) {
+		return PTPMessageId(messageType, sequenceId);
+	}
 	/**
 	 * @brief  Gets the correctionField value in a Little-Endian format.
 	 * @return correctionField

--- a/daemons/gptp/common/avbts_port.hpp
+++ b/daemons/gptp/common/avbts_port.hpp
@@ -1149,7 +1149,7 @@ class IEEE1588Port {
 	 * @return GPTP_EC_SUCCESS if no error, GPTP_EC_FAILURE if error and GPTP_EC_EAGAIN to try again.
 	 */
 	int getRxTimestamp
-	(PortIdentity * sourcePortIdentity, uint16_t sequenceId,
+	(PortIdentity * sourcePortIdentity, PTPMessageId messageId,
 	 Timestamp & timestamp, unsigned &counter_value, bool last);
 
 	/**
@@ -1162,7 +1162,7 @@ class IEEE1588Port {
 	 * @return GPTP_EC_SUCCESS if no error, GPTP_EC_FAILURE if error and GPTP_EC_EAGAIN to try again.
 	 */
 	int getTxTimestamp
-	(PortIdentity * sourcePortIdentity, uint16_t sequenceId,
+	(PortIdentity * sourcePortIdentity, PTPMessageId messageId,
 	 Timestamp & timestamp, unsigned &counter_value, bool last);
 
 	/**

--- a/daemons/gptp/common/ieee1588.hpp
+++ b/daemons/gptp/common/ieee1588.hpp
@@ -65,6 +65,7 @@
 class LinkLayerAddress;
 struct ClockQuality;
 class PortIdentity;
+class PTPMessageId;
 class PTPMessageCommon;
 class PTPMessageSync;
 class PTPMessageAnnounce;
@@ -528,14 +529,14 @@ public:
 	/**
 	 * @brief  Gets the tx timestamp from hardware
 	 * @param  identity PTP port identity
-	 * @param  sequenceId Sequence ID
+	 * @param  PTPMessageId Message ID
 	 * @param  timestamp [out] Timestamp value
 	 * @param  clock_value [out] Clock value
 	 * @param  last Signalizes that it is the last timestamp to get. When TRUE, releases the lock when its done.
 	 * @return GPTP_EC_SUCCESS if no error, GPTP_EC_FAILURE if error and GPTP_EC_EAGAIN to try again.
 	 */
 	virtual int HWTimestamper_txtimestamp(PortIdentity * identity,
-			uint16_t sequenceId,
+			PTPMessageId messageId,
 			Timestamp & timestamp,
 			unsigned &clock_value,
 			bool last) = 0;
@@ -543,14 +544,14 @@ public:
 	/**
 	 * @brief  Get rx timestamp
 	 * @param  identity PTP port identity
-	 * @param  sequenceId Sequence ID
+	 * @param  messageId Message ID
 	 * @param  timestamp [out] Timestamp value
 	 * @param  clock_value [out] Clock value
 	 * @param  last Signalizes that it is the last timestamp to get. When TRUE, releases the lock when its done.
 	 * @return GPTP_EC_SUCCESS if no error, GPTP_EC_FAILURE if error and GPTP_EC_EAGAIN to try again.
 	 */
 	virtual int HWTimestamper_rxtimestamp(PortIdentity * identity,
-			uint16_t sequenceId,
+			PTPMessageId messageId,
 			Timestamp & timestamp,
 			unsigned &clock_value,
 			bool last) = 0;

--- a/daemons/gptp/common/ieee1588port.cpp
+++ b/daemons/gptp/common/ieee1588port.cpp
@@ -1343,7 +1343,7 @@ int IEEE1588Port::getTxTimestamp
 	PortIdentity identity;
 	msg->getPortIdentity(&identity);
 	return getTxTimestamp
-		(&identity, msg->getSequenceId(), timestamp, counter_value, last);
+		(&identity, msg->getMessageId(), timestamp, counter_value, last);
 }
 
 int IEEE1588Port::getRxTimestamp(PTPMessageCommon * msg, Timestamp & timestamp,
@@ -1352,16 +1352,16 @@ int IEEE1588Port::getRxTimestamp(PTPMessageCommon * msg, Timestamp & timestamp,
 	PortIdentity identity;
 	msg->getPortIdentity(&identity);
 	return getRxTimestamp
-		(&identity, msg->getSequenceId(), timestamp, counter_value, last);
+		(&identity, msg->getMessageId(), timestamp, counter_value, last);
 }
 
 int IEEE1588Port::getTxTimestamp(PortIdentity * sourcePortIdentity,
-				 uint16_t sequenceId, Timestamp & timestamp,
+				 PTPMessageId messageId, Timestamp & timestamp,
 				 unsigned &counter_value, bool last)
 {
 	if (_hw_timestamper) {
 		return _hw_timestamper->HWTimestamper_txtimestamp
-		    (sourcePortIdentity, sequenceId, timestamp, counter_value,
+			(sourcePortIdentity, messageId, timestamp, counter_value,
 		     last);
 	}
 	timestamp = clock->getSystemTime();
@@ -1369,12 +1369,12 @@ int IEEE1588Port::getTxTimestamp(PortIdentity * sourcePortIdentity,
 }
 
 int IEEE1588Port::getRxTimestamp(PortIdentity * sourcePortIdentity,
-				 uint16_t sequenceId, Timestamp & timestamp,
+				 PTPMessageId messageId, Timestamp & timestamp,
 				 unsigned &counter_value, bool last)
 {
 	if (_hw_timestamper) {
 		return _hw_timestamper->HWTimestamper_rxtimestamp
-		    (sourcePortIdentity, sequenceId, timestamp, counter_value,
+		    (sourcePortIdentity, messageId, timestamp, counter_value,
 		     last);
 	}
 	timestamp = clock->getSystemTime();

--- a/daemons/gptp/common/ptp_message.cpp
+++ b/daemons/gptp/common/ptp_message.cpp
@@ -69,6 +69,7 @@ PTPMessageCommon *buildPTPMessage
 {
 	OSTimer *timer = port->getTimerFactory()->createTimer();
 	PTPMessageCommon *msg = NULL;
+	PTPMessageId messageId;
 	MessageType messageType;
 	unsigned char tspec_msg_t = 0;
 	unsigned char transportSpecific = 0;
@@ -113,13 +114,16 @@ PTPMessageCommon *buildPTPMessage
 	sequenceId = PLAT_ntohs(sequenceId);
 
 	GPTP_LOG_VERBOSE("Captured Sequence Id: %u", sequenceId);
+	messageId.setMessageType(messageType);
+	messageId.setSequenceId(sequenceId);
+
 
 	if (!(messageType >> 3)) {
 		int iter = 5;
 		long req = 4000;	// = 1 ms
 		int ts_good =
 		    port->getRxTimestamp
-			(sourcePortIdentity, sequenceId, timestamp, counter_value, false);
+			(sourcePortIdentity, messageId, timestamp, counter_value, false);
 		while (ts_good != GPTP_EC_SUCCESS && iter-- != 0) {
 			// Waits at least 1 time slice regardless of size of 'req'
 			timer->sleep(req);
@@ -128,7 +132,7 @@ PTPMessageCommon *buildPTPMessage
 					"Error (RX) timestamping RX event packet (Retrying), error=%d",
 					  ts_good );
 			ts_good =
-			    port->getRxTimestamp(sourcePortIdentity, sequenceId,
+			    port->getRxTimestamp(sourcePortIdentity, messageId,
 						 timestamp, counter_value,
 						 iter == 0);
 			req *= 2;

--- a/daemons/gptp/linux/src/linux_hal_generic.cpp
+++ b/daemons/gptp/linux/src/linux_hal_generic.cpp
@@ -277,7 +277,7 @@ void LinuxTimestamperGeneric::HWTimestamper_reset()
 }
 
 int LinuxTimestamperGeneric::HWTimestamper_txtimestamp
-( PortIdentity *identity, uint16_t sequenceId, Timestamp &timestamp,
+( PortIdentity *identity, PTPMessageId messageId, Timestamp &timestamp,
   unsigned &clock_value, bool last ) {
 	int err;
 	int ret = GPTP_EC_EAGAIN;

--- a/daemons/gptp/linux/src/linux_hal_generic.hpp
+++ b/daemons/gptp/linux/src/linux_hal_generic.hpp
@@ -143,28 +143,28 @@ public:
 	/**
 	 * @brief  Gets the TX timestamp from hardware interface
 	 * @param  identity PTP port identity
-	 * @param  sequenceId Sequence ID
+	 * @param  PTPMessageId Message ID
 	 * @param  timestamp [out] Timestamp value
 	 * @param  clock_value [out] Clock value
 	 * @param  last Signalizes that it is the last timestamp to get. When TRUE, releases the lock when its done.
 	 * @return GPTP_EC_SUCCESS if no error, GPTP_EC_FAILURE if error and GPTP_EC_EAGAIN to try again.
 	 */
 	virtual int HWTimestamper_txtimestamp
-	( PortIdentity *identity, uint16_t sequenceId, Timestamp &timestamp,
+	( PortIdentity *identity, PTPMessageId messageId, Timestamp &timestamp,
 	  unsigned &clock_value, bool last );
 
 	/**
 	 * @brief  Gets the RX timestamp from the hardware interface. This
 	 * Currently the RX timestamp is retrieved at LinuxNetworkInterface::nrecv method.
 	 * @param  identity PTP port identity
-	 * @param  sequenceId Sequence ID
+	 * @param  PTPMessageId Message ID
 	 * @param  timestamp [out] Timestamp value
 	 * @param  clock_value [out] Clock value
 	 * @param  last Signalizes that it is the last timestamp to get. When TRUE, releases the lock when its done.
      * @return GPTP_EC_SUCCESS if no error, GPTP_EC_FAILURE if error and GPTP_EC_EAGAIN to try again.
 	 */
 	virtual int HWTimestamper_rxtimestamp
-	( PortIdentity *identity, uint16_t sequenceId, Timestamp &timestamp,
+	( PortIdentity *identity, PTPMessageId messageId, Timestamp &timestamp,
 	  unsigned &clock_value, bool last ) {
 		/* This shouldn't happen. Ever. */
 		if( rxTimestampList.empty() ) return GPTP_EC_EAGAIN;

--- a/daemons/gptp/linux/src/linux_hal_intelce.cpp
+++ b/daemons/gptp/linux/src/linux_hal_intelce.cpp
@@ -121,17 +121,17 @@ int LinuxTimestamperIntelCE::ce_timestamp_common
 }
 
 int LinuxTimestamperIntelCE::HWTimestamper_txtimestamp
-( PortIdentity *identity, uint16_t sequenceId, Timestamp &timestamp,
+( PortIdentity *identity, PTPMessageId messageId, Timestamp &timestamp,
   unsigned &clock_value, bool last ) {
 	return ce_timestamp_common
-		( identity, sequenceId, timestamp, clock_value, true );
+		( identity, messageId.getSequenceId(), timestamp, clock_value, true );
 }
 
 int LinuxTimestamperIntelCE::HWTimestamper_rxtimestamp
-( PortIdentity *identity, uint16_t sequenceId, Timestamp &timestamp,
+( PortIdentity *identity, PTPMessageId messageId, Timestamp &timestamp,
   unsigned &clock_value, bool last ) {
 	return ce_timestamp_common
-		( identity, sequenceId, timestamp, clock_value, false );
+		( identity, messageId.getSequenceId(), timestamp, clock_value, false );
 }
 
 bool LinuxTimestamperIntelCE::post_init( int ifindex, int sd, TicketingLock *lock ) {

--- a/daemons/gptp/linux/src/linux_hal_intelce.hpp
+++ b/daemons/gptp/linux/src/linux_hal_intelce.hpp
@@ -64,7 +64,7 @@ public:
 	/**
 	 * @brief  Gets the TX hardware timestamp value
 	 * @param  identity Clock Identity
-	 * @param  sequenceId Sequence ID
+	 * @param  PTPMessageId Message ID
 	 * @param  timestamp [out] Reference to the TX timestamps
 	 * @param  clock_value [out] 64 bit timestamp value
 	 * @param  last Not used
@@ -72,13 +72,13 @@ public:
 	 * is no data available. -1 in case of error when reading data from hardware interface.
 	 */
 	virtual int HWTimestamper_txtimestamp
-	( PortIdentity *identity, uint16_t sequenceId, Timestamp &timestamp,
+	( PortIdentity *identity, PTPMessageId messageId, Timestamp &timestamp,
 	  unsigned &clock_value, bool last );
 
 	/**
 	 * @brief  Gets the RX hardware timestamp value
 	 * @param  identity Clock identity
-	 * @param  sequenceId Sequence ID
+	 * @param  PTPMessageId Message ID
 	 * @param  timestamp [out] Reference to the RX timestamps
 	 * @param  clock_value [out] 64 bit timestamp value
 	 * @param  last Not used
@@ -86,7 +86,7 @@ public:
 	 * is no data available. -1 in case of error when reading data from hardware interface.
 	 */
 	virtual int HWTimestamper_rxtimestamp
-	( PortIdentity *identity, uint16_t sequenceId, Timestamp &timestamp,
+	( PortIdentity *identity, PTPMessageId messageId, Timestamp &timestamp,
 	  unsigned &clock_value, bool last );
 
 	/**

--- a/daemons/gptp/windows/daemon_cl/daemon_cl.cpp
+++ b/daemons/gptp/windows/daemon_cl/daemon_cl.cpp
@@ -38,6 +38,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "avbts_osnet.hpp"
 #include "avbts_oslock.hpp"
 #include "windows_hal.hpp"
+#include "avbts_message.hpp"
 #include <tchar.h>
 
 #define MACSTR_LENGTH 17

--- a/daemons/gptp/windows/daemon_cl/windows_hal.hpp
+++ b/daemons/gptp/windows/daemon_cl/windows_hal.hpp
@@ -711,13 +711,13 @@ public:
 	/**
 	 * @brief  Gets the TX timestamp
 	 * @param  identity [in] PortIdentity interface
-	 * @param  sequenceId Sequence ID
+	 * @param  PTPMessageId Message ID
 	 * @param  timestamp [out] TX hardware timestamp
 	 * @param  clock_value Not used
 	 * @param  last Not used
 	 * @return GPTP_EC_SUCCESS if no error, GPTP_EC_FAILURE if error and GPTP_EC_EAGAIN to try again.
 	 */
-	virtual int HWTimestamper_txtimestamp( PortIdentity *identity, uint16_t sequenceId, Timestamp &timestamp, unsigned &clock_value, bool last )
+	virtual int HWTimestamper_txtimestamp(PortIdentity *identity, PTPMessageId messageId, Timestamp &timestamp, unsigned &clock_value, bool last)
 	{
 		DWORD buf[4], buf_tmp[4];
 		DWORD returned = 0;
@@ -747,13 +747,13 @@ public:
 	/**
 	 * @brief  Gets the RX timestamp
 	 * @param  identity PortIdentity interface
-	 * @param  sequenceId  Sequence ID
+	 * @param  PTPMessageId Message ID
 	 * @param  timestamp [out] RX hardware timestamp
 	 * @param  clock_value [out] Not used
 	 * @param  last Not used
 	 * @return GPTP_EC_SUCCESS if no error, GPTP_EC_FAILURE if error and GPTP_EC_EAGAIN to try again.
 	 */
-	virtual int HWTimestamper_rxtimestamp( PortIdentity *identity, uint16_t sequenceId, Timestamp &timestamp, unsigned &clock_value, bool last )
+	virtual int HWTimestamper_rxtimestamp(PortIdentity *identity, PTPMessageId messageId, Timestamp &timestamp, unsigned &clock_value, bool last)
 	{
 		DWORD buf[4], buf_tmp[4];
 		DWORD returned;
@@ -771,7 +771,7 @@ public:
 		if( result != ERROR_GEN_FAILURE ) return GPTP_EC_FAILURE;
 		if( returned != sizeof(buf_tmp) ) return GPTP_EC_EAGAIN;
 		packet_sequence_id = *((uint32_t *) buf+3) >> 16;
-		if( PLAT_ntohs( packet_sequence_id ) != sequenceId ) return GPTP_EC_EAGAIN;
+		if (PLAT_ntohs(packet_sequence_id) != messageId.getSequenceId()) return GPTP_EC_EAGAIN;
 		rx_r = (((uint64_t)buf[1]) << 32) | buf[0];
 		rx_s = scaleNativeClockToNanoseconds( rx_r );
 		timestamp = nanoseconds64ToTimestamp( rx_s ) - latency;


### PR DESCRIPTION
This pull request is for discussion.....

The following assertions motivate this commit
- gPTP packet Tx timestamps are collected sometime after the packet goes out on the wire
- slave and master sequenceIDs can in fact be the same breifly
- pDelay timer callback and packet receive processing occurs in different threads
- Path_Delay_Req_Message and Path_Delay_Resp_Message both require Tx timestamps

The idea here is to make available BOTH the message type and the sequence ID to the HAL timestamping layer. If the HAL layer can support message matching by both type and ID, then it can use them both. If it can only use the sequence ID, then it can stick with that.

Comments?
