### PR TITLE
Fix gPTP link up/down detection. Check only the interface used by port

### DIFF
--- a/daemons/gptp/linux/src/linux_hal_common.cpp
+++ b/daemons/gptp/linux/src/linux_hal_common.cpp
@@ -169,7 +169,7 @@ void LinuxNetworkInterface::clear_reenable_rx_queue() {
 	}
 }
 
-static void x_readEvent(int sockint, IEEE1588Port *pPort)
+static void x_readEvent(int sockint, IEEE1588Port *pPort, int ifindex)
 {
 	int status;
 	char buf[4096];
@@ -204,11 +204,13 @@ static void x_readEvent(int sockint, IEEE1588Port *pPort)
 
 		if (msgHdr->nlmsg_type == RTM_NEWLINK) {
 			ifi = (struct ifinfomsg *)NLMSG_DATA(msgHdr);
-			if ((ifi->ifi_flags & IFF_RUNNING)) {
-				pPort->processEvent(LINKUP);
-			}
-			else {
-				pPort->processEvent(LINKDOWN);
+			if (ifi->ifi_index == ifindex) {
+				if ((ifi->ifi_flags & IFF_RUNNING)) {
+					pPort->processEvent(LINKUP);
+				}
+				else {
+					pPort->processEvent(LINKDOWN);
+				}
 			}
 		}
 	}
@@ -249,7 +251,7 @@ void LinuxNetworkInterface::watchNetLink(IEEE1588Port *pPort)
 		if (retval == -1)
 			; // Error on select. We will ignore and keep going
 		else if (retval) {
-			x_readEvent(netLinkSocket, pPort);
+			x_readEvent(netLinkSocket, pPort, ifindex);
 		}
 		else {
 			; // Would be timeout but Won't happen because we wait forever


### PR DESCRIPTION
This pull request fixes an issue that the link up and down detection in gPTP was not checking if the interface with the link event was the interface in use by gPTP. This would result in gPTP acting on incorrect link events on systems with multiple network interfaces. This issue was in Linux specific code.

Requesting expedited review of this pull request due to it blocking a customer release.