### PR TITLE
gptp: fix wrong Follow_up Correction Field value in GPTP_LOG_VERBOSE

### DIFF
--- a/daemons/gptp/common/ptp_message.cpp
+++ b/daemons/gptp/common/ptp_message.cpp
@@ -1006,7 +1006,7 @@ void PTPMessageFollowUp::processMessage(IEEE1588Port * port)
 	scalar_offset -= TIMESTAMP_TO_NS( preciseOriginTimestamp );
 
 	GPTP_LOG_VERBOSE
-		("Followup Correction Field: %Ld,%lu", correctionField >> 16,
+		("Followup Correction Field: %Ld, Link Delay: %lu", correctionField,
 		 delay);
 	GPTP_LOG_VERBOSE
 		("FollowUp Scalar = %lld", scalar_offset);


### PR DESCRIPTION
correctionField doesn't need to be shifted again when logging as
it's done a few lines above.